### PR TITLE
Try to enter the same directory inside the toolbox

### DIFF
--- a/fedora-toolbox
+++ b/fedora-toolbox
@@ -190,7 +190,6 @@ enter()
             --env DESKTOP_SESSION=$DESKTOP_SESSION \
             --env DISPLAY=$DISPLAY \
             --env LANG=$LANG \
-            --env PS1="$toolbox_prompt" \
             --env SHELL=$SHELL \
             --env SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
             --env TERM=$TERM \
@@ -207,7 +206,11 @@ enter()
             --interactive \
             --tty \
             $toolbox_container \
-            $shell_to_exec -l 2>&42
+            /bin/sh -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
+                    /bin/sh \
+                    "$PWD" \
+                    "$toolbox_prompt" \
+                    $shell_to_exec -l 2>&42
 )
 
 


### PR DESCRIPTION
The intermediate /bin/sh process will reset the values of PS1 and PWD.
Therefore, it's necessary to pass those as arguments to the script.

https://github.com/debarshiray/fedora-toolbox/issues/20