### PR TITLE
rm/rmi: give more specific error messages when image/container does not exist/cannot be removed

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -973,7 +973,12 @@ remove_containers()
             ret_val=$(echo "$ids" \
                       | (
                             while read -r id; do
-                                if ! $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3; then
+                                $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3
+                                ret_code=$?
+                                if [ $ret_code = 2 ]; then
+                                    echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
+                                    ret_val=1
+                                elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove container $id" >&2
                                     ret_val=1
                                 fi
@@ -988,10 +993,17 @@ remove_containers()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            if ! labels=$($prefix_sudo podman inspect \
+                            labels=$($prefix_sudo podman inspect \
                                                   --format "{{.Config.Labels}}" \
                                                   --type container \
-                                                  "$id" 2>&3); then
+                                                  "$id" 2>&3)
+
+                            ret_code=$?
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find container $id" >&2
+                                ret_val=1
+                                continue
+                            elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to inspect $id" >&2
                                 ret_val=1
                                 continue
@@ -1004,7 +1016,12 @@ remove_containers()
                                 continue
                             fi
 
-                            if ! $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3; then
+                            $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3
+                            ret_code=$?
+                            if [ $ret_code = 2 ]; then
+                                echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
+                                ret_val=1
+                            elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove container $id" >&2
                                 ret_val=1
                             fi
@@ -1050,7 +1067,12 @@ remove_images()
             ret_val=$(echo "$ids" \
                       | (
                             while read -r id; do
-                                if ! $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3; then
+                                $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3
+                                ret_code=$?
+                                if [ $ret_code = 2 ]; then
+                                    echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
+                                    ret_val=1
+                                elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove image $id" >&2
                                     ret_val=1
                                 fi
@@ -1065,10 +1087,16 @@ remove_images()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            if ! labels=$($prefix_sudo podman inspect \
+                            labels=$($prefix_sudo podman inspect \
                                                   --format "{{.Labels}}" \
                                                   --type image \
-                                                  "$id" 2>&3); then
+                                                  "$id" 2>&3)
+                            ret_code=$?
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find image $id" >&2
+                                ret_val=1
+                                continue
+                            elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to inspect $id" >&2
                                 ret_val=1
                                 continue
@@ -1081,7 +1109,12 @@ remove_images()
                                 continue
                             fi
 
-                            if ! $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3; then
+                            $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3
+                            ret_code=$?
+                            if [ $ret_code = 2 ]; then
+                                echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
+                                ret_val=1
+                            elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove image $id" >&2
                                 ret_val=1
                             fi

--- a/toolbox
+++ b/toolbox
@@ -977,11 +977,11 @@ remove_containers()
                                 ret_code=$?
                                 if [ $ret_code = 1 ]; then
                                     echo "$base_toolbox_command: unable to find container $id" >&2
-                                    echo "Try '$base_toolbox_command list -c' to list existing containers"
+                                    echo "Try '$base_toolbox_command list -c' to list existing containers" >&2
                                     ret_val=1
                                 elif [ $ret_code = 2 ]; then
                                     echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
-                                    echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal"
+                                    echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal" >&2
                                     ret_val=1
                                 elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove container $id" >&2
@@ -998,18 +998,20 @@ remove_containers()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
+                            $prefix_sudo podman container exists $id #2>&3
+                            ret_code=$?
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find container $id" >&2
+                                echo "Try '$base_toolbox_command list -c' to list existing containers" >&2
+                                ret_val=1
+                                continue
+                            fi
                             labels=$($prefix_sudo podman inspect \
                                                   --format "{{.Config.Labels}}" \
                                                   --type container \
                                                   "$id" 2>&3)
-
                             ret_code=$?
-                            if [ $ret_code = 1 ]; then
-                                echo "$base_toolbox_command: unable to find container $id" >&2
-                                echo "Try '$base_toolbox_command list -c' to list existing containers"
-                                ret_val=1
-                                continue
-                            elif [ $ret_code != 0 ]; then
+                            if [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to inspect $id" >&2
                                 ret_val=1
                                 continue
@@ -1026,11 +1028,11 @@ remove_containers()
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find container $id" >&2
-                                echo "Try '$base_toolbox_command list -c' to list existing containers"
+                                echo "Try '$base_toolbox_command list -c' to list existing containers" >&2
                                 ret_val=1
                             elif [ $ret_code = 2 ]; then
                                 echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
-                                echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal"
+                                echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal" >&2
                                 ret_val=1
                             elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove container $id" >&2
@@ -1082,11 +1084,11 @@ remove_images()
                                 ret_code=$?
                                 if [ $ret_code = 1 ]; then
                                     echo "$base_toolbox_command: unable to find image $id" >&2
-                                    echo "Try '$base_toolbox_command list -i' to list existing images"
+                                    echo "Try '$base_toolbox_command list -i' to list existing images" >&2
                                     ret_val=1
                                 elif [ $ret_code = 2 ]; then
                                     echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
-                                    echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image"
+                                    echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image" >&2
                                     ret_val=1
                                 elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove image $id" >&2
@@ -1103,17 +1105,20 @@ remove_images()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
+                            $prefix_sudo podman image exists $id #2>&3
+                            ret_code=$?
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find container $id" >&2
+                                echo "Try '$base_toolbox_command list -c' to list existing containers" >&2
+                                ret_val=1
+                                continue
+                            fi
                             labels=$($prefix_sudo podman inspect \
                                                   --format "{{.Labels}}" \
                                                   --type image \
                                                   "$id" 2>&3)
                             ret_code=$?
-                            if [ $ret_code = 1 ]; then
-                                echo "$base_toolbox_command: unable to find image $id" >&2
-                                echo "Try '$base_toolbox_command list -i' to list existing images"
-                                ret_val=1
-                                continue
-                            elif [ $ret_code != 0 ]; then
+                            if [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to inspect $id" >&2
                                 ret_val=1
                                 continue
@@ -1130,11 +1135,11 @@ remove_images()
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find image $id" >&2
-                                echo "Try '$base_toolbox_command list -i' to list existing images"
+                                echo "Try '$base_toolbox_command list -i' to list existing images" >&2
                                 ret_val=1
                             elif [ $ret_code = 2 ]; then
                                 echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
-                                echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image"
+                                echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image" >&2
                                 ret_val=1
                             elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove image $id" >&2

--- a/toolbox
+++ b/toolbox
@@ -975,8 +975,13 @@ remove_containers()
                             while read -r id; do
                                 $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3
                                 ret_code=$?
-                                if [ $ret_code = 2 ]; then
+                                if [ $ret_code = 1 ]; then
+                                    echo "$base_toolbox_command: unable to find container $id" >&2
+                                    echo "Try '$base_toolbox_command list -c' to list existing containers"
+                                    ret_val=1
+                                elif [ $ret_code = 2 ]; then
                                     echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
+                                    echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal"
                                     ret_val=1
                                 elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove container $id" >&2
@@ -1001,6 +1006,7 @@ remove_containers()
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find container $id" >&2
+                                echo "Try '$base_toolbox_command list -c' to list existing containers"
                                 ret_val=1
                                 continue
                             elif [ $ret_code != 0 ]; then
@@ -1018,8 +1024,13 @@ remove_containers()
 
                             $prefix_sudo podman rm $force_option "$id" >/dev/null 2>&3
                             ret_code=$?
-                            if [ $ret_code = 2 ]; then
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find container $id" >&2
+                                echo "Try '$base_toolbox_command list -c' to list existing containers"
+                                ret_val=1
+                            elif [ $ret_code = 2 ]; then
                                 echo "$base_toolbox_command: cannot remove running or paused container $id" >&2
+                                echo "Try 'podman stop $id' to stop the container or '$base_toolbox_command rm -f $id' for force removal"
                                 ret_val=1
                             elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove container $id" >&2
@@ -1069,8 +1080,13 @@ remove_images()
                             while read -r id; do
                                 $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3
                                 ret_code=$?
-                                if [ $ret_code = 2 ]; then
+                                if [ $ret_code = 1 ]; then
+                                    echo "$base_toolbox_command: unable to find image $id" >&2
+                                    echo "Try '$base_toolbox_command list -i' to list existing images"
+                                    ret_val=1
+                                elif [ $ret_code = 2 ]; then
                                     echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
+                                    echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image"
                                     ret_val=1
                                 elif [ $ret_code != 0 ]; then
                                     echo "$base_toolbox_command: failed to remove image $id" >&2
@@ -1094,6 +1110,7 @@ remove_images()
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find image $id" >&2
+                                echo "Try '$base_toolbox_command list -i' to list existing images"
                                 ret_val=1
                                 continue
                             elif [ $ret_code != 0 ]; then
@@ -1111,8 +1128,13 @@ remove_images()
 
                             $prefix_sudo podman rmi $force_option "$id" >/dev/null 2>&3
                             ret_code=$?
-                            if [ $ret_code = 2 ]; then
+                            if [ $ret_code = 1 ]; then
+                                echo "$base_toolbox_command: unable to find image $id" >&2
+                                echo "Try '$base_toolbox_command list -i' to list existing images"
+                                ret_val=1
+                            elif [ $ret_code = 2 ]; then
                                 echo "$base_toolbox_command: image $id has dependent child images or is being used by a container" >&2
+                                echo "Try '$base_toolbox_command rmi -f $id' for force removal of the image"
                                 ret_val=1
                             elif [ $ret_code != 0 ]; then
                                 echo "$base_toolbox_command: failed to remove image $id" >&2

--- a/toolbox
+++ b/toolbox
@@ -998,7 +998,7 @@ remove_containers()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            $prefix_sudo podman container exists $id #2>&3
+                            $prefix_sudo podman container exists $id 2>&3
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find container $id" >&2
@@ -1105,7 +1105,7 @@ remove_images()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            $prefix_sudo podman image exists $id #2>&3
+                            $prefix_sudo podman image exists $id 2>&3
                             ret_code=$?
                             if [ $ret_code = 1 ]; then
                                 echo "$base_toolbox_command: unable to find container $id" >&2


### PR DESCRIPTION
Currently, we give a generic error message when the image/container specified by the user cannot be removed. This usually happens for one of the following reasons:

1. the user specifies an image or a container that does not exist
2. the image has a child image or is being used by a container
3. the container is paused or running

This PR addresses these three cases and gives more specific message so that the user understands what happened. In order for this to work, the [libpod#2945](https://github.com/containers/libpod/pull/2945) PR needs to be merged.