### PR TITLE
Modify the prompt to show the currently running container.

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -811,7 +811,7 @@ enter()
             capsh --caps="" -- -c 'cd "$1"; export PS1="$2"; shift 2; exec "$@"' \
                     /bin/sh \
                     "$PWD" \
-                    "$toolbox_prompt" \
+                    "$toolbox_container$toolbox_prompt" \
                     "$shell_to_exec" -l 2>&3
 )
 


### PR DESCRIPTION
This modifies the prompt to show the currently running container, making it easy to identify which container instance you are working with in the case where you might have many. This would be one way to resolve #117.

This prefixes the diamond character with the container name to
very clearly distinguish the name from the rest of your prompt.

Where previously a bash prompt might read
🔹[zerotri@toolbox toolbox]$

for the container `sysutils` it would now read

sysutils🔹[zerotri@toolbox toolbox]$

EDIT: This would also potentially help resolve the problem defined in #98.