### PR TITLE
Make the hostname of the container into a command line option

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -17,7 +17,7 @@ __toolbox() {
   local commands="$verbose_commands rm rmi"
 
   declare -A options
-  local options=([create]="--candidate-registry --container --image --release" \
+  local options=([create]="--candidate-registry --container --hostname --image --release" \
                  [enter]="--container --release" \
                  [help]="$commands" \
                  [init-container]="--home --home-link --monitor-host --shell --uid --user" \

--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -46,6 +46,12 @@ customized containers from custom-built base images.
 Change the NAME of the base image used to create the toolbox container. This
 is useful for creating containers from custom-built base images.
 
+**--hostname** HOSTNAME
+
+Change the hostname of the toolbox container. This is the name displayed at the
+terminal prompt, so changing this can be useful to differentiate containers
+once they are open.
+
 **--release** RELEASE, **-r** RELEASE
 
 Create a toolbox container for a different operating system RELEASE than the
@@ -75,6 +81,11 @@ $ toolbox create --container foo --image bar
 
 ```
 $ toolbox create --candidate-registry
+```
+
+### Create a toolbox with the default container name but a hostname of devserver
+```
+$ toolbox create --hostname devserver
 ```
 
 ## SEE ALSO

--- a/toolbox
+++ b/toolbox
@@ -860,7 +860,7 @@ create()
             --dns none \
             --env TOOLBOX_PATH="$TOOLBOX_PATH" \
             --group-add "$group_for_sudo" \
-            --hostname toolbox \
+            --hostname $toolbox_hostname \
             --ipc host \
             --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \
@@ -1921,6 +1921,7 @@ fi
 
 case $op in
     create )
+        toolbox_hostname="toolbox"
         while has_prefix "$1" -; do
             case $1 in
                 --candidate-registry )
@@ -1953,6 +1954,10 @@ case $op in
                     arg=$(echo "$1" | sed "s/^F\|^f//" 2>&3)
                     exit_if_non_positive_argument --release "$arg"
                     release=$arg
+                    ;;
+                --hostname )
+                    shift
+                    toolbox_hostname=$1
                     ;;
                 * )
                     exit_if_unrecognized_option "$1"


### PR DESCRIPTION
This creates a new command line option `-h` or `--hostname` for the `toolbox create` command that allows the user to specify the hostname of the container. If none is specified, it defaults to `toolbox`.

This would allow the user to specify the name, so it would fix #98 by allowing them to manually assign the name.