### PR TITLE
Add a '--very-verbose | -vv' option

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -28,12 +28,12 @@ __toolbox() {
   _init_completion -s || return
 
   if [ "${COMP_CWORD}" -eq 1 ]; then
-    mapfile -t COMPREPLY < <(compgen -W "--assumeyes --help --verbose $commands" -- "$2")
+    mapfile -t COMPREPLY < <(compgen -W "--assumeyes --help --verbose --very-verbose $commands" -- "$2")
     return 0
   fi
 
   case "$prev" in
-    --verbose | -v)
+    --verbose | -v | --very-verbose | -vv)
       mapfile -t COMPREPLY < <(compgen -W "$commands" -- "$2")
       return 0
       ;;
@@ -52,7 +52,7 @@ __toolbox() {
   esac
 
   local command
-  if [ "${COMP_WORDS[1]}" = --verbose ]; then
+  if [ "${COMP_WORDS[1]}" = --verbose ] || [ "${COMP_WORDS[1]}" = --very-verbose ]; then
     command=${COMP_WORDS[2]}
   else
     command=${COMP_WORDS[1]}

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -43,6 +43,7 @@ Print a synopsis of this manual and exit.
 **--verbose, -v**
 
 Print debug information including standard error stream of internal commands.
+Use `-vv` for more detail.
 
 ## COMMANDS
 

--- a/toolbox
+++ b/toolbox
@@ -54,6 +54,7 @@ environment_variables="COLORTERM \
         XDG_VTNR"
 fgc=""
 
+podman_command="podman"
 registry="registry.fedoraproject.org"
 registry_candidate="candidate-registry.fedoraproject.org"
 release=""
@@ -249,7 +250,7 @@ container_start()
 (
     container="$1"
 
-    error_message=$( (podman start "$container" >/dev/null) 2>&1)
+    error_message=$( ($podman_command start "$container" >/dev/null) 2>&1)
     ret_val="$?"
     [ "$error_message" != "" ] 2>&3 && echo "$error_message" >&3
 
@@ -257,7 +258,7 @@ container_start()
         if echo "$error_message" | grep "use system migrate to mitigate" >/dev/null 2>&3; then
             echo "$base_toolbox_command: checking if 'podman system migrate' supports --new-runtime" >&3
 
-            if ! (podman system migrate --help 2>&3 | grep "new-runtime" >/dev/null 2>&3); then
+            if ! ($podman_command system migrate --help 2>&3 | grep "new-runtime" >/dev/null 2>&3); then
                 echo "$base_toolbox_command: container $container doesn't support cgroups v$cgroups_version" >&2
                 echo "Update Podman to version 1.6.2 or newer." >&2
                 return 1
@@ -269,14 +270,14 @@ container_start()
 
                 echo "$base_toolbox_command: migrating containers to OCI runtime $oci_runtime_required" >&3
 
-                if ! podman system migrate --new-runtime "$oci_runtime_required" >/dev/null 2>&3; then
+                if ! $podman_command system migrate --new-runtime "$oci_runtime_required" >/dev/null 2>&3; then
                     echo "$base_toolbox_command: failed to migrate containers to OCI runtime $oci_runtime_required" >&2
                     echo "Factory reset with: toolbox reset" >&2
                     echo "Try '$base_toolbox_command --help' for more information." >&2
                     return 1
                 fi
 
-                if ! podman start "$container" >/dev/null 2>&3; then
+                if ! $podman_command start "$container" >/dev/null 2>&3; then
                     echo "$base_toolbox_command: container $container doesn't support cgroups v$cgroups_version" >&2
                     echo "Factory reset with: toolbox reset" >&2
                     echo "Try '$base_toolbox_command --help' for more information." >&2
@@ -318,7 +319,7 @@ copy_etc_profile_d_toolbox_to_container()
 
     echo "$base_toolbox_command: copying $toolbox_runtime_directory/toolbox.sh to container $container" >&3
 
-    if ! podman exec \
+    if ! $podman_command exec \
                  --user root:root \
                  "$container" \
                  sh -c "cp $toolbox_runtime_directory/toolbox.sh /etc/profile.d" sh 2>&3; then
@@ -454,7 +455,7 @@ create_toolbox_image_name()
     # https://github.com/containers/buildah/blob/master/util/util.go
 
     if image_reference_can_be_id "$base_toolbox_image"; then
-        if base_toolbox_image_id=$(podman inspect \
+        if base_toolbox_image_id=$($podman_command inspect \
                                            --format "{{.Id}}" \
                                            --type image \
                                            "$base_toolbox_image" 2>&3); then
@@ -622,7 +623,7 @@ images_get_details()
     if ! echo "$images" | while read -r image; do
             [ "$image" = "" ] 2>&3 && continue
 
-            if ! podman images \
+            if ! $podman_command images \
                          --format "{{.ID}} {{.Repository}}:{{.Tag}} {{.Created}}" \
                          --noheading \
                          "$image" 2>&3; then
@@ -642,7 +643,7 @@ is_etc_profile_d_toolbox_a_bind_mount()
 {
     container="$1"
 
-    podman inspect --format "[{{range .Mounts}}{{.Dst}} {{end}}]" --type container "$container" 2>&3 \
+    $podman_command inspect --format "[{{range .Mounts}}{{.Dst}} {{end}}]" --type container "$container" 2>&3 \
     | grep /etc/profile.d/toolbox.sh >/dev/null 2>/dev/null 2>&3
 
     return "$?"
@@ -651,7 +652,7 @@ is_etc_profile_d_toolbox_a_bind_mount()
 
 list_container_names()
 (
-    if ! containers_old=$(podman ps \
+    if ! containers_old=$($podman_command ps \
                                   --all \
                                   --filter "label=com.redhat.component=fedora-toolbox" \
                                   --format "{{.Names}}" 2>&3); then
@@ -659,7 +660,7 @@ list_container_names()
         return 1
     fi
 
-    if ! containers=$(podman ps \
+    if ! containers=$($podman_command ps \
                               --all \
                               --filter "label=com.github.debarshiray.toolbox=true" \
                               --format "{{.Names}}" 2>&3); then
@@ -715,7 +716,7 @@ pull_base_toolbox_image()
     if image_reference_can_be_id "$base_toolbox_image"; then
         echo "$base_toolbox_command: looking for image $base_toolbox_image" >&3
 
-        if podman image exists "$base_toolbox_image" >/dev/null 2>&3; then
+        if $podman_command image exists "$base_toolbox_image" >/dev/null 2>&3; then
             return 0
         fi
     fi
@@ -725,7 +726,7 @@ pull_base_toolbox_image()
     if ! $has_domain; then
         echo "$base_toolbox_command: looking for image localhost/$base_toolbox_image" >&3
 
-        if podman image exists localhost/$base_toolbox_image >/dev/null 2>&3; then
+        if $podman_command image exists localhost/$base_toolbox_image >/dev/null 2>&3; then
             return 0
         fi
     fi
@@ -738,7 +739,7 @@ pull_base_toolbox_image()
 
     echo "$base_toolbox_command: looking for image $base_toolbox_image_full" >&3
 
-    if podman image exists "$base_toolbox_image_full" >/dev/null 2>&3; then
+    if $podman_command image exists "$base_toolbox_image_full" >/dev/null 2>&3; then
         return 0
     fi
 
@@ -775,7 +776,7 @@ pull_base_toolbox_image()
         spinner_directory=""
     fi
 
-    podman pull $base_toolbox_image_full >/dev/null 2>&3
+    $podman_command pull $base_toolbox_image_full >/dev/null 2>&3
     ret_val=$?
 
     if [ "$spinner_directory" != "" ]; then
@@ -956,7 +957,7 @@ create()
     if image_reference_has_domain "$base_toolbox_image"; then
         base_toolbox_image_full="$base_toolbox_image"
     else
-        if ! base_toolbox_image_full=$(podman inspect \
+        if ! base_toolbox_image_full=$($podman_command inspect \
                                                --format "{{index .RepoTags 0}}" \
                                                --type image \
                                                "$base_toolbox_image" 2>&3); then
@@ -970,7 +971,7 @@ create()
     echo "$base_toolbox_command: checking if container $toolbox_container already exists" >&3
 
     enter_command=$(create_enter_command "$toolbox_container")
-    if podman container exists $toolbox_container >/dev/null 2>&3; then
+    if $podman_command container exists $toolbox_container >/dev/null 2>&3; then
         echo "$base_toolbox_command: container $toolbox_container already exists" >&2
         echo "Enter with: $enter_command" >&2
         echo "Try '$base_toolbox_command --help' for more information." >&2
@@ -1046,7 +1047,7 @@ create()
     fi
 
     # shellcheck disable=SC2086
-    podman create \
+    $podman_command create \
             --dns none \
             --env TOOLBOX_PATH="$TOOLBOX_PATH" \
             --group-add "$group_for_sudo" \
@@ -1333,15 +1334,15 @@ run()
 
     echo "$base_toolbox_command: checking if container $toolbox_container exists" >&3
 
-    if ! podman container exists "$toolbox_container" 2>&3; then
+    if ! $podman_command container exists "$toolbox_container" 2>&3; then
         echo "$base_toolbox_command: container $toolbox_container not found" >&3
 
-        if podman container exists "$toolbox_container_old_v1" 2>&3; then
+        if $podman_command container exists "$toolbox_container_old_v1" 2>&3; then
             echo "$base_toolbox_command: container $toolbox_container_old_v1 found" >&3
 
             # shellcheck disable=SC2030
             toolbox_container="$toolbox_container_old_v1"
-        elif podman container exists "$toolbox_container_old_v2" 2>&3; then
+        elif $podman_command container exists "$toolbox_container_old_v2" 2>&3; then
             echo "$base_toolbox_command: container $toolbox_container_old_v2 found" >&3
 
             # shellcheck disable=SC2030
@@ -1447,7 +1448,7 @@ run()
 
     echo "$base_toolbox_command: inspecting entry point of container $toolbox_container" >&3
 
-    if ! entry_point=$(podman inspect --format "{{index .Config.Cmd 0}}" --type container "$toolbox_container" 2>&3); then
+    if ! entry_point=$($podman_command inspect --format "{{index .Config.Cmd 0}}" --type container "$toolbox_container" 2>&3); then
         echo "$base_toolbox_command: failed to inspect entry point of container $toolbox_container" >&2
         exit 1
     fi
@@ -1457,7 +1458,7 @@ run()
     if [ "$entry_point" = "toolbox" ] 2>&3; then
         echo "$base_toolbox_command: waiting for container $toolbox_container to finish initializing" >&3
 
-        if ! entry_point_pid=$(podman inspect --format "{{.State.Pid}}" --type container "$toolbox_container" 2>&3); then
+        if ! entry_point_pid=$($podman_command inspect --format "{{.State.Pid}}" --type container "$toolbox_container" 2>&3); then
             echo "$base_toolbox_command: failed to inspect entry point PID of container $toolbox_container" >&2
             exit 1
         fi
@@ -1487,7 +1488,7 @@ run()
         done
     fi
 
-    if ! podman exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then
+    if ! $podman_command exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then
         echo "$base_toolbox_command: failed to create /run/.toolboxenv in container $toolbox_container" >&2
         exit 1
     fi
@@ -1497,7 +1498,7 @@ run()
     echo "$base_toolbox_command: looking for $program in container $toolbox_container" >&3
 
     # shellcheck disable=SC2016
-    if ! podman exec \
+    if ! $podman_command exec \
                  --user "$USER" \
                  "$toolbox_container" \
                  sh -c 'command -v "$1"' sh "$program" >/dev/null 2>&3; then
@@ -1521,7 +1522,7 @@ run()
     # shellcheck disable=SC2016
     # for the command passed to capsh
     # shellcheck disable=SC2086
-    podman exec \
+    $podman_command exec \
             --interactive \
             --tty \
             --user "$USER" \
@@ -1553,14 +1554,14 @@ list_images()
 (
     output=""
 
-    if ! images_old=$(podman images \
+    if ! images_old=$($podman_command images \
                               --filter "label=com.redhat.component=fedora-toolbox" \
                               --format "{{.Repository}}:{{.Tag}}" 2>&3); then
         echo "$base_toolbox_command: failed to list images with com.redhat.component=fedora-toolbox" >&2
         return 1
     fi
 
-    if ! images=$(podman images \
+    if ! images=$($podman_command images \
                           --filter "label=com.github.debarshiray.toolbox=true" \
                           --format "{{.Repository}}:{{.Tag}}" 2>&3); then
         echo "$base_toolbox_command: failed to list images with com.github.debarshiray.toolbox=true" >&2
@@ -1595,7 +1596,7 @@ containers_get_details()
     if ! echo "$containers" | while read -r container; do
             [ "$container" = "" ] 2>&3 && continue
 
-            if ! podman ps --all \
+            if ! $podman_command ps --all \
                          --filter "name=$container" \
                          --format "{{.ID}}  {{.Names}}  {{.Created}}  {{.Status}}  {{.Image}}" 2>&3; then
                 echo "$base_toolbox_command: failed to get details for container $container" >&2
@@ -1637,7 +1638,7 @@ list_containers()
             | (
                   while read -r container; do
                       id=$(echo "$container" | cut --delimiter " " --fields 1 2>&3)
-                      is_running=$(podman inspect "$id" --format "{{.State.Running}}" 2>&3)
+                      is_running=$($podman_command inspect "$id" --format "{{.State.Running}}" 2>&3)
                       if $is_running; then
                           # shellcheck disable=SC2059
                           printf "${LGC}$container${NC}\n"
@@ -1659,7 +1660,7 @@ migrate()
 
     migrate_lock="$toolbox_runtime_directory"/migrate.lock
 
-    if ! version=$(podman version --format "{{.Version}}" 2>&3); then
+    if ! version=$($podman_command version --format "{{.Version}}" 2>&3); then
         echo "$base_toolbox_command: unable to migrate containers: Podman version couldn't be read" >&2
         return 1
     fi
@@ -1703,7 +1704,7 @@ migrate()
         fi
     fi
 
-    if ! podman system migrate >/dev/null 2>&3; then
+    if ! $podman_command system migrate >/dev/null 2>&3; then
         echo "$base_toolbox_command: unable to migrate containers" >&2
         return 1
     fi
@@ -1724,7 +1725,7 @@ remove_containers()
     $force && force_option="--force"
 
     if $all; then
-        if ! ids_old=$(podman ps \
+        if ! ids_old=$($podman_command ps \
                                --all \
                                --filter "label=com.redhat.component=fedora-toolbox" \
                                --format "{{.ID}}" 2>&3); then
@@ -1732,7 +1733,7 @@ remove_containers()
             return 1
         fi
 
-        if ! ids=$(podman ps \
+        if ! ids=$($podman_command ps \
                            --all \
                            --filter "label=com.github.debarshiray.toolbox=true" \
                            --format "{{.ID}}" 2>&3); then
@@ -1745,7 +1746,7 @@ remove_containers()
             ret_val=$(echo "$ids" \
                       | (
                             while read -r id; do
-                                if ! podman rm $force_option "$id" >/dev/null 2>&3; then
+                                if ! $podman_command rm $force_option "$id" >/dev/null 2>&3; then
                                     echo "$base_toolbox_command: failed to remove container $id" >&2
                                     ret_val=1
                                 fi
@@ -1760,7 +1761,7 @@ remove_containers()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            if ! labels=$(podman inspect \
+                            if ! labels=$($podman_command inspect \
                                                   --format "{{.Config.Labels}}" \
                                                   --type container \
                                                   "$id" 2>&3); then
@@ -1776,7 +1777,7 @@ remove_containers()
                                 continue
                             fi
 
-                            if ! podman rm $force_option "$id" >/dev/null 2>&3; then
+                            if ! $podman_command rm $force_option "$id" >/dev/null 2>&3; then
                                 echo "$base_toolbox_command: failed to remove container $id" >&2
                                 ret_val=1
                             fi
@@ -1802,14 +1803,14 @@ remove_images()
     $force && force_option="--force"
 
     if $all; then
-        if ! ids_old=$(podman images \
+        if ! ids_old=$($podman_command images \
                                --filter "label=com.redhat.component=fedora-toolbox" \
                                --format "{{.ID}}" 2>&3); then
             echo "$0: failed to list images with com.redhat.component=fedora-toolbox" >&2
             return 1
         fi
 
-        if ! ids=$(podman images \
+        if ! ids=$($podman_command images \
                            --all \
                            --filter "label=com.github.debarshiray.toolbox=true" \
                            --format "{{.ID}}" 2>&3); then
@@ -1822,7 +1823,7 @@ remove_images()
             ret_val=$(echo "$ids" \
                       | (
                             while read -r id; do
-                                if ! podman rmi $force_option "$id" >/dev/null 2>&3; then
+                                if ! $podman_command rmi $force_option "$id" >/dev/null 2>&3; then
                                     echo "$base_toolbox_command: failed to remove image $id" >&2
                                     ret_val=1
                                 fi
@@ -1837,7 +1838,7 @@ remove_images()
                   | sed "s/ \+/\n/g" 2>&3 \
                   | (
                         while read -r id; do
-                            if ! labels=$(podman inspect \
+                            if ! labels=$($podman_command inspect \
                                                   --format "{{.Labels}}" \
                                                   --type image \
                                                   "$id" 2>&3); then
@@ -1853,7 +1854,7 @@ remove_images()
                                 continue
                             fi
 
-                            if ! podman rmi $force_option "$id" >/dev/null 2>&3; then
+                            if ! $podman_command rmi $force_option "$id" >/dev/null 2>&3; then
                                 echo "$base_toolbox_command: failed to remove image $id" >&2
                                 ret_val=1
                             fi
@@ -2142,6 +2143,11 @@ while has_prefix "$1" -; do
             ;;
         -v | --verbose )
             exec 3>&2
+            verbose=true
+            ;;
+        -vv | --very-verbose )
+            exec 3>&2
+            podman_command="podman --log-level debug"
             verbose=true
             ;;
         * )


### PR DESCRIPTION
Toolbox only offers a --verbose | -v option that shows debug information
only of Toolbox itself. We have no way of getting debug info right from
Podman without altering the code or running the commands themselves.

This just adds a new variable 'podman' that translates to a string
depending on the presence of '--very-verbose | -v' option. If this
option is used, every Podman command in the code is ran with '--log-level
debug' option. Use wisely, it can be 'very verbose'.