### PR TITLE
Update the label for tagging to reflect the project's new home

### DIFF
--- a/images/fedora/f29/Dockerfile
+++ b/images/fedora/f29/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:29
 
 ENV NAME=fedora-toolbox VERSION=29
-LABEL com.github.debarshiray.toolbox="true" \
+LABEL com.github.containers.toolbox="true" \
+      com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \

--- a/images/fedora/f30/Dockerfile
+++ b/images/fedora/f30/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:30
 
 ENV NAME=fedora-toolbox VERSION=30
-LABEL com.github.debarshiray.toolbox="true" \
+LABEL com.github.containers.toolbox="true" \
+      com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \

--- a/images/fedora/f31/Dockerfile
+++ b/images/fedora/f31/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:31
 
 ENV NAME=fedora-toolbox VERSION=31
-LABEL com.github.debarshiray.toolbox="true" \
+LABEL com.github.containers.toolbox="true" \
+      com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \

--- a/images/fedora/f32/Dockerfile
+++ b/images/fedora/f32/Dockerfile
@@ -1,7 +1,8 @@
 FROM registry.fedoraproject.org/fedora:32
 
 ENV NAME=fedora-toolbox VERSION=32
-LABEL com.github.debarshiray.toolbox="true" \
+LABEL com.github.containers.toolbox="true" \
+      com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$FGC/$NAME" \
       version="$VERSION" \

--- a/toolbox
+++ b/toolbox
@@ -862,6 +862,7 @@ create()
             --group-add "$group_for_sudo" \
             --hostname toolbox \
             --ipc host \
+            --label "com.github.containers.toolbox=true" \
             --label "com.github.debarshiray.toolbox=true" \
             --name $toolbox_container \
             --network host \


### PR DESCRIPTION
The older com.github.debarshiray.toolbox label is still used in most
places as an alias for the new name for the sake of simplicity and
compatibility; except in 'create', where the new label is explicitly
specified in addition to the older one to help popularize it via newly
created toolbox containers.

The older com.github.debarshiray.toolbox label should eventually be
dropped, but before that, the even older use of com.redhat.component
for tagging needs to be phased out. The com.github.debarshiray.toolbox
label was introduced in commit 0ab6eb7401fb3964, as part of Toolbox
0.0.8, right before the release of Fedora 30 [1]. Therefore,
com.redhat.component needs to stay at least until Fedora 29 is
supported.

[1] https://fedoraproject.org/wiki/Releases/30/Schedule