### PR TITLE
Make 'podman exec' wait for container init

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -753,7 +753,7 @@ unshare_userns_rm()
     unshare --user sh -c "flock $unshare_directory/map rm --force --recursive $path" 2>&3 &
     unshare_pid="$!"
 
-    echo "$base_toolbox_command: setting UID map of user namespace" >&3
+    echo "$base_toolbox_command: setting GID and UID map of user namespace" >&3
 
     if ! newgidmap "$unshare_pid" 0 "$user_id_real" 1 1 "$userns_gid_start" "$userns_gid_len" 2>&3; then
         echo "$base_toolbox_command: failed to set GID mapping of user namespace" >&2

--- a/toolbox
+++ b/toolbox
@@ -1043,6 +1043,17 @@ init_container()
     init_container_uid="$5"
     init_container_user="$6"
 
+    if [ "$XDG_RUNTIME_DIR" = "" ] 2>&3; then
+        echo "$base_toolbox_command: XDG_RUNTIME_DIR is unset" >&3
+
+        XDG_RUNTIME_DIR=/run/user/"$init_container_uid"
+        echo "$base_toolbox_command: XDG_RUNTIME_DIR set to $XDG_RUNTIME_DIR" >&3
+
+        toolbox_runtime_directory="$XDG_RUNTIME_DIR"/toolbox
+    fi
+
+    init_container_initialized_stamp="$toolbox_runtime_directory"/container-initialized-"$$"
+
     echo "$base_toolbox_command: creating /run/.toolboxenv" >&3
 
     if ! touch /run/.toolboxenv 2>&3; then
@@ -1187,6 +1198,13 @@ EOF
         fi
     fi
 
+    echo "$base_toolbox_command: finished initializing container" >&3
+
+    if ! touch "$init_container_initialized_stamp" 2>&3; then
+        echo "$base_toolbox_command: failed to create initialization stamp" >&2
+        return 1
+    fi
+
     echo "$base_toolbox_command: going to sleep" >&3
 
     exec sleep +Inf
@@ -1318,6 +1336,48 @@ run()
         if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
             exit 1
         fi
+    fi
+
+    echo "$base_toolbox_command: inspecting entry point of container $toolbox_container" >&3
+
+    if ! entry_point=$(podman inspect --format "{{index .Config.Cmd 0}}" --type container "$toolbox_container" 2>&3); then
+        echo "$base_toolbox_command: failed to inspect entry point of container $toolbox_container" >&2
+        exit 1
+    fi
+
+    echo "$base_toolbox_command: entry point of container $toolbox_container is $entry_point" >&3
+
+    if [ "$entry_point" = "toolbox" ] 2>&3; then
+        echo "$base_toolbox_command: waiting for container $toolbox_container to finish initializing" >&3
+
+        if ! entry_point_pid=$(podman inspect --format "{{.State.Pid}}" --type container "$toolbox_container" 2>&3); then
+            echo "$base_toolbox_command: failed to inspect entry point PID of container $toolbox_container" >&2
+            exit 1
+        fi
+
+        if ! is_integer "$entry_point_pid"; then
+            echo "$base_toolbox_command: failed to parse entry point PID of container $toolbox_container" >&2
+            exit 1
+        fi
+
+        if [ "$entry_point_pid" -le 0 ] 2>&3; then
+            echo "$base_toolbox_command: invalid entry point PID of container $toolbox_container" >&2
+            exit 1
+        fi
+
+        container_initialized_stamp="$toolbox_runtime_directory/container-initialized-$entry_point_pid"
+        container_initialized_timeout=25 #s
+
+        i=0
+        while ! [ -f "$container_initialized_stamp" ] 2>&3; do
+            sleep 1 2>&3
+
+            i=$((i + 1))
+            if [ "$i" -eq "$container_initialized_timeout" ] 2>&3; then
+                echo "$base_toolbox_command: failed to initialize container $toolbox_container" >&2
+                exit 1
+            fi
+        done
     fi
 
     if ! podman exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then

--- a/toolbox
+++ b/toolbox
@@ -767,6 +767,9 @@ unshare_userns_rm()
         return 1
     fi
 
+    echo "$base_toolbox_command: GID map of user namespace:" >&3
+    cat /proc/"$unshare_pid"/gid_map 1>&3 2>&3
+
     echo "$base_toolbox_command: UID map of user namespace:" >&3
     cat /proc/$unshare_pid/uid_map 1>&3 2>&3
 

--- a/toolbox
+++ b/toolbox
@@ -92,7 +92,7 @@ has_prefix()
             ;;
     esac
 
-    return $ret_val
+    return "$ret_val"
 )
 
 
@@ -112,14 +112,14 @@ has_substring()
             ;;
     esac
 
-    return $ret_val
+    return "$ret_val"
 )
 
 
 is_integer()
 {
     [ "$1" != "" ] && [ "$1" -eq "$1" ] 2>&3
-    return $?
+    return "$?"
 }
 
 
@@ -240,7 +240,7 @@ container_name_is_valid()
     name="$1"
 
     echo "$name" | grep "^$container_name_regexp$" >/dev/null 2>&3
-    return $?
+    return "$?"
 )
 
 
@@ -487,7 +487,7 @@ image_reference_can_be_id()
     image="$1"
 
     echo "$image" | grep "^[a-f0-9]\{6,64\}$" >/dev/null 2>&3
-    return $?
+    return "$?"
 )
 
 
@@ -771,7 +771,7 @@ unshare_userns_rm()
     cat /proc/"$unshare_pid"/gid_map 1>&3 2>&3
 
     echo "$base_toolbox_command: UID map of user namespace:" >&3
-    cat /proc/$unshare_pid/uid_map 1>&3 2>&3
+    cat /proc/"$unshare_pid"/uid_map 1>&3 2>&3
 
     if ! flock --unlock 4 2>&3; then
         echo "$base_toolbox_command: failed to remove $path: lock couldn't be unlocked" >&2

--- a/toolbox
+++ b/toolbox
@@ -704,8 +704,8 @@ unshare_userns_rm()
         return 1
     fi
 
-    exec 6>"$unshare_directory/map"
-    if ! flock 6 2>&3; then
+    exec 4>"$unshare_directory/map"
+    if ! flock 4 2>&3; then
         echo "$base_toolbox_command: failed to enter user namespace: lock couldn't be acquired" >&2
         return 1
     fi
@@ -770,7 +770,7 @@ unshare_userns_rm()
     echo "$base_toolbox_command: UID map of user namespace:" >&3
     cat /proc/$unshare_pid/uid_map 1>&3 2>&3
 
-    if ! flock --unlock 6 2>&3; then
+    if ! flock --unlock 4 2>&3; then
         echo "$base_toolbox_command: failed to remove $path: lock couldn't be unlocked" >&2
         kill -9 "$unshare_pid" 2>&3
         return 1


### PR DESCRIPTION
In the 'run' script are two main Podman commands. 'podman start' and
'podman exec'. 'podman start' is used for container initalization using
the 'init_container' function. But because this function is executed in
a subshell the next call doesn't wait for it to finish. Such an issue
isn't very common but it may happen.

This solves the potential issue by using a dirty hack. A simple while
loop that'll block the function until a 'block file' is deleted by the
preceeding process.