### PR TITLE
Try to migrate to a supported OCI runtime if 'podman start' suggests so

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -245,6 +245,19 @@ container_name_is_valid()
 )
 
 
+container_start()
+(
+    container="$1"
+
+    if ! podman start "$container" >/dev/null 2>&3; then
+        echo "$base_toolbox_command: failed to start container $container" >&2
+        return 1
+    fi
+
+    return 0
+)
+
+
 copy_etc_profile_d_toolbox_to_container()
 (
     container="$1"
@@ -1336,8 +1349,7 @@ run()
     if is_etc_profile_d_toolbox_a_bind_mount "$toolbox_container"; then
         echo "$base_toolbox_command: /etc/profile.d/toolbox.sh already mounted in container $toolbox_container" >&3
 
-        if ! podman start "$toolbox_container" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
+        if ! container_start "$toolbox_container"; then
             exit 1
         fi
     else
@@ -1347,8 +1359,7 @@ run()
             exit 1
         fi
 
-        if ! podman start "$toolbox_container" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: failed to start container $toolbox_container" >&2
+        if ! container_start "$toolbox_container"; then
             exit 1
         fi
 

--- a/toolbox
+++ b/toolbox
@@ -1597,7 +1597,7 @@ migrate()
 
     if [ -f "$migrate_stamp" ] 2>&3; then
         if grep "$version" "$migrate_stamp" >/dev/null 2>&3; then
-            echo "$base_toolbox_command: migration not needed: $version is unchanged" >&3
+            echo "$base_toolbox_command: migration not needed: Podman version $version is unchanged" >&3
             return 0
         fi
 
@@ -1610,7 +1610,7 @@ migrate()
         fi
 
         if [ "$version" = "$version_old" ] 2>&3; then
-            echo "$base_toolbox_command: migration not needed: $version is old" >&3
+            echo "$base_toolbox_command: migration not needed: Podman version $version is old" >&3
             return 0
         fi
     fi

--- a/toolbox
+++ b/toolbox
@@ -1576,6 +1576,8 @@ migrate()
         return 1
     fi
 
+    echo "$base_toolbox_command: current Podman version is $version" >&3
+
     if ! mkdir --parents "$configuration_directory" 2>&3; then
         echo "$base_toolbox_command: unable to migrate containers: configuration directory not created" >&2
         return 1

--- a/toolbox
+++ b/toolbox
@@ -249,9 +249,44 @@ container_start()
 (
     container="$1"
 
-    if ! podman start "$container" >/dev/null 2>&3; then
-        echo "$base_toolbox_command: failed to start container $container" >&2
-        return 1
+    error_message=$( (podman start "$container" >/dev/null) 2>&1)
+    ret_val="$?"
+    [ "$error_message" != "" ] 2>&3 && echo "$error_message" >&3
+
+    if [ "$ret_val" -ne 0 ] 2>&3; then
+        if echo "$error_message" | grep "use system migrate to mitigate" >/dev/null 2>&3; then
+            echo "$base_toolbox_command: checking if 'podman system migrate' supports --new-runtime" >&3
+
+            if ! (podman system migrate --help 2>&3 | grep "new-runtime" >/dev/null 2>&3); then
+                echo "$base_toolbox_command: container $container doesn't support cgroups v$cgroups_version" >&2
+                echo "Update Podman to version 1.6.2 or newer." >&2
+                return 1
+            else
+                echo "$base_toolbox_command: 'podman system migrate' supports --new-runtime" >&3
+
+                oci_runtime_required="runc"
+                [ "$cgroups_version" -eq 2 ] 2>&3 && oci_runtime_required="crun"
+
+                echo "$base_toolbox_command: migrating containers to OCI runtime $oci_runtime_required" >&3
+
+                if ! podman system migrate --new-runtime "$oci_runtime_required" >/dev/null 2>&3; then
+                    echo "$base_toolbox_command: failed to migrate containers to OCI runtime $oci_runtime_required" >&2
+                    echo "Factory reset with: toolbox reset" >&2
+                    echo "Try '$base_toolbox_command --help' for more information." >&2
+                    return 1
+                fi
+
+                if ! podman start "$container" >/dev/null 2>&3; then
+                    echo "$base_toolbox_command: container $container doesn't support cgroups v$cgroups_version" >&2
+                    echo "Factory reset with: toolbox reset" >&2
+                    echo "Try '$base_toolbox_command --help' for more information." >&2
+                    return 1
+                fi
+            fi
+        else
+            echo "$base_toolbox_command: failed to start container $container" >&2
+            return 1
+        fi
     fi
 
     return 0

--- a/toolbox
+++ b/toolbox
@@ -22,6 +22,7 @@ arguments=""
 assume_yes=false
 base_toolbox_command=$(basename "$0" 2>&3)
 base_toolbox_image=""
+cgroups_version=""
 
 # Based on the nameRegex value in:
 # https://github.com/containers/libpod/blob/master/libpod/options.go
@@ -439,6 +440,24 @@ enter_print_container_not_found()
     echo "$base_toolbox_command: container $container not found" >&2
     echo "Use the 'create' command to create a toolbox." >&2
     echo "Try '$base_toolbox_command --help' for more information." >&2
+)
+
+
+get_cgroups_version()
+(
+    version=1
+
+    if ! mounts=$(mount 2>&3); then
+        echo "$base_toolbox_command: failed to detect cgroups version: couldn't list mount points" >&2
+        return 1
+    fi
+
+    if ! (echo "$mounts" | grep "^cgroup " >/dev/null 2>&3) && (echo "$mounts" | grep "^cgroup2 " >/dev/null 2>&3); then
+        version=2
+    fi
+
+    echo "$version"
+    return 0
 )
 
 
@@ -2163,6 +2182,12 @@ if [ -f /run/.containerenv ] 2>&3; then
            ;;
     esac
 fi
+
+if ! cgroups_version=$(get_cgroups_version); then
+    exit 1
+fi
+
+echo "$base_toolbox_command: running on a cgroups v$cgroups_version host" >&3
 
 if [ "$op" != "reset" ] 2>&3; then
     if ! migrate; then


### PR DESCRIPTION
Toolbox containers using runc as their runtime don't work on host
operating systems using cgroups v2. They need to be migrated to crun.
'podman start' throws a specific error for such containers:
  ERRO[0000]: oci runtime "runc" does not support CGroups V2: use
    system migrate to mitigate
  Error: unable to start container "fedora-toolbox-30": this version
    of runc doesn't work on cgroups v2: OCI runtime error

This error is identified by the phrase "use system migrate to mitigate"
to avoid encoding any assumptions about updating from cgroups v1 to v2
or downgrading in the other direction.

If the migration fails, 'toolbox reset' is suggested as the last hope.