### PR TITLE
Install iproute package in toolbox images

### DIFF
--- a/images/fedora/f33/extra-packages
+++ b/images/fedora/f33/extra-packages
@@ -11,6 +11,7 @@ gnupg
 gnupg2-smime
 gvfs-client
 hostname
+iproute
 iputils
 jwhois
 keyutils

--- a/images/fedora/f34/extra-packages
+++ b/images/fedora/f34/extra-packages
@@ -11,6 +11,7 @@ gnupg
 gnupg2-smime
 gvfs-client
 hostname
+iproute
 iputils
 jwhois
 keyutils

--- a/images/fedora/f35/extra-packages
+++ b/images/fedora/f35/extra-packages
@@ -11,6 +11,7 @@ gnupg
 gnupg2-smime
 gvfs-client
 hostname
+iproute
 iputils
 jwhois
 keyutils


### PR DESCRIPTION
While toolbox containers are started without network namespace isolation, in the current release of `fedora-toolbox` images there is no way to inspect and interact with network interfaces of the system (or even look up the ip address without exiting the container) - neither `ip` command, nor `ifconfig` commands are present.

This PR adds `iproute` to `extra-packages` list for all Fedora versions. This adds only *2.9 MB* extra size and results in installation of the following packages (for `f31` toolbox):
1. `iproute`
2. `libmnl`
3. `linux-atm-libs`
4. `iproute-tc`