### PR TITLE
Bind mount some locations at runtime and enable the systemd journal

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -896,7 +896,6 @@ create()
 
     dbus_system_bus_address="unix:path=/var/run/dbus/system_bus_socket"
     home_link=""
-    flatpak_system_directory_bind=""
     kcm_socket=""
     kcm_socket_bind=""
     libvirt_system_directory_bind=""
@@ -911,10 +910,6 @@ create()
     fi
     dbus_system_bus_path=$(echo "$dbus_system_bus_address" | cut --delimiter = --fields 2 2>&3)
     dbus_system_bus_path=$(readlink --canonicalize "$dbus_system_bus_path" 2>&3)
-
-    if [ -d /var/lib/flatpak ] 2>&3; then
-        flatpak_system_directory_bind="--volume /var/lib/flatpak:/var/lib/flatpak:ro"
-    fi
 
     # Note that 'systemctl show ...' doesn't terminate with a non-zero exit
     # code when used with an unknown unit. eg.:
@@ -1073,7 +1068,6 @@ create()
             $ulimit_host \
             --userns=keep-id \
             --user root:root \
-            $flatpak_system_directory_bind \
             $kcm_socket_bind \
             $libvirt_system_directory_bind \
             $run_media_path_bind \
@@ -1197,6 +1191,10 @@ init_container()
                             >&2
                     return 1
                 fi
+            fi
+
+            if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then
+                return 1
             fi
         fi
 

--- a/toolbox
+++ b/toolbox
@@ -898,7 +898,6 @@ create()
     home_link=""
     kcm_socket=""
     kcm_socket_bind=""
-    libvirt_system_directory_bind=""
     run_media_path_bind=""
     toolbox_profile_bind=""
     ulimit_host=""
@@ -940,10 +939,6 @@ create()
     if [ "$kcm_socket_listen" != "" ] 2>&3; then
         kcm_socket=${kcm_socket_listen%" (Stream)"}
         kcm_socket_bind="--volume $kcm_socket:$kcm_socket"
-    fi
-
-    if [ -d /run/libvirt ] 2>&3; then
-        libvirt_system_directory_bind="--volume /run/libvirt:/run/libvirt"
     fi
 
     echo "$base_toolbox_command: checking if 'podman create' supports --ulimit host" >&3
@@ -1069,7 +1064,6 @@ create()
             --userns=keep-id \
             --user root:root \
             $kcm_socket_bind \
-            $libvirt_system_directory_bind \
             $run_media_path_bind \
             $toolbox_profile_bind \
             --volume "$TOOLBOX_PATH":/usr/bin/toolbox:ro \
@@ -1191,6 +1185,10 @@ init_container()
                             >&2
                     return 1
                 fi
+            fi
+
+            if ! mount_bind /run/host/run/libvirt /run/libvirt; then
+                return 1
             fi
 
             if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then

--- a/toolbox
+++ b/toolbox
@@ -1187,6 +1187,11 @@ init_container()
                 fi
             fi
 
+
+            if ! mount_bind /run/host/etc/machine-id /etc/machine-id ro; then
+                return 1
+            fi
+
             if ! mount_bind /run/host/run/libvirt /run/libvirt; then
                 return 1
             fi

--- a/toolbox
+++ b/toolbox
@@ -1199,6 +1199,10 @@ init_container()
             if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then
                 return 1
             fi
+
+            if ! mount_bind /run/host/var/log/journal /var/log/journal ro; then
+                return 1
+            fi
         fi
 
         if [ -d /run/host/monitor ] 2>&3; then

--- a/toolbox
+++ b/toolbox
@@ -1196,6 +1196,10 @@ init_container()
                 return 1
             fi
 
+            if ! mount_bind /run/host/run/systemd/journal /run/systemd/journal; then
+                return 1
+            fi
+
             if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then
                 return 1
             fi

--- a/toolbox
+++ b/toolbox
@@ -672,6 +672,39 @@ list_container_names()
 )
 
 
+mount_bind()
+(
+    source="$1"
+    target="$2"
+    mount_flags="$3"
+
+    mount_o=""
+
+    ! [ -d "$source" ] 2>&3 && ! [ -f "$source" ] 2>&3 && return 0
+
+    if [ -d "$source" ] 2>&3; then
+        echo "$base_toolbox_command: creating $target" >&3
+
+        if ! mkdir --parents "$target" 2>&3; then
+            echo "$base_toolbox_command: failed to create $target" >&2
+            return 1
+        fi
+    fi
+
+    echo "$base_toolbox_command: binding $target to $source" >&3
+
+    [ "$mount_flags" = "" ] 2>&3 || mount_o="-o $mount_flags"
+
+    # shellcheck disable=SC2086
+    if ! mount --bind $mount_o "$source" "$target" 2>&3; then
+        echo "$base_toolbox_command: failed to bind $target to $source" >&2
+        return 1
+    fi
+
+    return 0
+)
+
+
 pull_base_toolbox_image()
 (
     domain=""


### PR DESCRIPTION
While the rewrite in Go continues, this makes two high level changes to the current code.

First, it gives access to the host's systemd journal inside toolbox containers. This is something that users have been asking for a while and can be useful in the short-term. One can both query the journal using `journalctl(1)` and send log messages to it. However, queries only work for messages logged by the current user when running rootless.

As a fallout from the above, this also changes the way bind mounts are set up to align with the future direction of the Go rewrite and should make it easier to switch. In short, it reduces the number of bind mounts that are specified during `podman create ...` and instead moves them into the containers' entry point, as Colin has been suggesting.