### PR TITLE
Deprecate all toolbox containers that don't use a reflexive entry point

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1486,6 +1486,9 @@ run()
                 exit 1
             fi
         done
+    else
+        echo "$base_toolbox_command: container $toolbox_container uses deprecated features" >&2
+        echo "Consider recreating it with Toolbox version 0.0.17 or newer." >&2
     fi
 
     if ! $podman_command exec --user root:root "$toolbox_container" touch /run/.toolboxenv 2>&3; then


### PR DESCRIPTION
Toolbox containers created prior to commit 8b84b5e4604921fa didn't use
'toolbox init-container' as their entry points. This prevents the
container from being configured at runtime through the entry point.

Being able to configure a toolbox container at runtime through the
entry point is very handy, as compared to doing it statically via
'podman create', because the configuration doesn't get permanently
baked into the container's definition. Instead, it's codified in
toolbox(1), which can be updated over time, and the container
reconfigured everytime it's started.

A deprecation notice is the precursor to actually dropping support for
these old containers in the future.