### PR TITLE
Wipe out the container's /sys/fs/selinux to stop advertising SELinux

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1201,6 +1201,10 @@ init_container()
                 return 1
             fi
 
+            if ! mount_bind /usr/share/empty /sys/fs/selinux; then
+                return 1
+            fi
+
             if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then
                 return 1
             fi


### PR DESCRIPTION
This is the second time a selinuxfs instance has leaked into
/sys/fs/selinux, tricking various components into trying to use
SELinux. Might be better to work this around in Toolbox until the
situation in Podman is figured out.

Based on an idea from Colin Walters.

https://github.com/containers/libpod/issues/4452