### PR TITLE
Give access to /var/mnt from the host operating system

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1227,6 +1227,10 @@ init_container()
             if ! mount_bind /run/host/var/log/journal /var/log/journal ro; then
                 return 1
             fi
+
+            if ! mount_bind /run/host/var/mnt /var/mnt rslave; then
+                return 1
+            fi
         fi
 
         if [ -d /run/host/monitor ] 2>&3; then

--- a/toolbox
+++ b/toolbox
@@ -697,7 +697,7 @@ mount_bind()
     [ "$mount_flags" = "" ] 2>&3 || mount_o="-o $mount_flags"
 
     # shellcheck disable=SC2086
-    if ! mount --bind $mount_o "$source" "$target" 2>&3; then
+    if ! mount --rbind $mount_o "$source" "$target" 2>&3; then
         echo "$base_toolbox_command: failed to bind $target to $source" >&2
         return 1
     fi


### PR DESCRIPTION
On Silverblue, /mnt is a symbolic link to /var/mnt. Matching the
presence of /var/mnt on the host inside the toolbox container would
make things less confusing for users.

https://github.com/containers/toolbox/issues/92