### PR TITLE
Set up /mnt to match the host

### DIFF
--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -7,6 +7,7 @@ toolbox\-init\-container - Initialize a running container
 **toolbox init-container** *--home HOME*
                        *--home-link*
                        *--media-link*
+                       *--mnt-link*
                        *--monitor-host*
                        *--shell SHELL*
                        *--uid UID*
@@ -34,6 +35,10 @@ Make `/home` a symbolic link to `/var/home`.
 **--media-link**
 
 Make `/media` a symbolic link to `/run/media`.
+
+**--mnt-link**
+
+Make `/mnt` a symbolic link to `/var/mnt`.
 
 **--monitor-host**
 

--- a/toolbox
+++ b/toolbox
@@ -901,6 +901,8 @@ create()
     kcm_socket_bind=""
     media_link=""
     media_path_bind=""
+    mnt_link=""
+    mnt_path_bind=""
     run_media_path_bind=""
     toolbox_profile_bind=""
     ulimit_host=""
@@ -1000,6 +1002,15 @@ create()
         fi
     fi
 
+    echo "$base_toolbox_command: checking if /mnt is a symbolic link to /var/mnt" >&3
+
+    if [ "$(readlink /mnt)" = var/mnt ] 2>&3; then
+        echo "$base_toolbox_command: /mnt is a symbolic link to /var/mnt" >&3
+        mnt_link="--mnt-link"
+    else
+        mnt_path_bind="--volume /mnt:/mnt:rslave"
+    fi
+
     if [ -d /run/media ] 2>&3; then
         run_media_path_bind="--volume /run/media:/run/media:rslave"
     fi
@@ -1079,6 +1090,7 @@ create()
             --user root:root \
             $kcm_socket_bind \
             $media_path_bind \
+            $mnt_path_bind \
             $run_media_path_bind \
             $toolbox_profile_bind \
             --volume "$TOOLBOX_PATH":/usr/bin/toolbox:ro \
@@ -1088,7 +1100,6 @@ create()
             --volume "$home_canonical":"$home_canonical":rslave \
             --volume /etc:/run/host/etc \
             --volume /dev:/dev:rslave \
-            --volume /mnt:/mnt:rslave \
             --volume /run:/run/host/run:rslave \
             --volume /tmp:/run/host/tmp:rslave \
             --volume /usr:/run/host/usr:"$usr_mount_destination_flags",rslave \
@@ -1098,6 +1109,7 @@ create()
                     --home "$HOME" \
                     $home_link \
                     $media_link \
+                    $mnt_link \
                     --monitor-host \
                     --shell "$SHELL" \
                     --uid "$user_id_real" \
@@ -1142,10 +1154,11 @@ init_container()
     init_container_home="$1"
     init_container_home_link="$2"
     init_container_media_link="$3"
-    init_container_monitor_host="$4"
-    init_container_shell="$5"
-    init_container_uid="$6"
-    init_container_user="$7"
+    init_container_mnt_link="$4"
+    init_container_monitor_host="$5"
+    init_container_shell="$6"
+    init_container_uid="$7"
+    init_container_user="$8"
 
     if [ "$XDG_RUNTIME_DIR" = "" ] 2>&3; then
         echo "$base_toolbox_command: XDG_RUNTIME_DIR is unset" >&3
@@ -1272,6 +1285,18 @@ init_container()
               && mkdir --mode 0755 --parents /run/media 2>&3 \
               && ln --symbolic run/media /media 2>&3); then
             echo "$base_toolbox_command: failed to make /media a symbolic link" >&2
+            return 1
+        fi
+    fi
+
+    if $init_container_mnt_link && ! readlink /mnt >/dev/null 2>&3; then
+        echo "$base_toolbox_command: making /mnt a symbolic link to /var/mnt" >&3
+
+        # shellcheck disable=SC2174
+        if ! (rmdir /mnt 2>&3 \
+              && mkdir --mode 0755 --parents /var/mnt 2>&3 \
+              && ln --symbolic var/mnt /mnt 2>&3); then
+            echo "$base_toolbox_command: failed to make /mnt a symbolic link" >&2
             return 1
         fi
     fi
@@ -2257,6 +2282,7 @@ if [ -f /run/.containerenv ] 2>&3; then
         init-container )
             init_container_home_link=false
             init_container_media_link=false
+            init_container_mnt_link=false
             init_container_monitor_host=false
             while has_prefix "$1" -; do
                 case $1 in
@@ -2275,6 +2301,9 @@ if [ -f /run/.containerenv ] 2>&3; then
                         ;;
                     --media-link )
                         init_container_media_link=true
+                        ;;
+                    --mnt-link )
+                        init_container_mnt_link=true
                         ;;
                     --monitor-host )
                         init_container_monitor_host=true
@@ -2303,6 +2332,7 @@ if [ -f /run/.containerenv ] 2>&3; then
                     "$init_container_home" \
                     "$init_container_home_link" \
                     "$init_container_media_link" \
+                    "$init_container_mnt_link" \
                     "$init_container_monitor_host" \
                     "$init_container_shell" \
                     "$init_container_uid" \


### PR DESCRIPTION
On Silverblue /mnt is a symbolic link to /var/mnt. Matching what the
host does will reduce weird side-effects.

https://github.com/containers/toolbox/issues/92