### PR TITLE
Unbreak 'enter' when SELinux is disabled

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1229,8 +1229,10 @@ init_container()
                 return 1
             fi
 
-            if ! mount_bind /usr/share/empty /sys/fs/selinux; then
-                return 1
+            if [ -d /sys/fs/selinux ] 2>&3; then
+                if ! mount_bind /usr/share/empty /sys/fs/selinux; then
+                    return 1
+                fi
             fi
 
             if ! mount_bind /run/host/var/lib/flatpak /var/lib/flatpak ro; then


### PR DESCRIPTION
/sys/fs/selinux is only present when SELinux is 'enforcing' or
'permissive'. When it's disabled, /sys/fs/selinux doesn't exist and
sysfs doesn't let you create it either. Therefore, the attempt to wipe
out the toolbox container's /sys/fs/selinux by bind mounting
/usr/share/empty over it fails, and in turn prevents the container from
starting up.

Fallout from f9cca5719d0a3f944647cdd2319fa2596bd4a878

https://github.com/containers/toolbox/issues/344