### PR TITLE
Check /usr/share/profile.d when bind mounting toolbox.sh

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -989,6 +989,10 @@ create()
 
     if [ -f /etc/profile.d/toolbox.sh ] 2>&3; then
         toolbox_profile_bind="--volume /etc/profile.d/toolbox.sh:/etc/profile.d/toolbox.sh:ro"
+    elif [ -f /usr/share/profile.d/toolbox.sh ] 2>&3; then
+        toolbox_profile_bind="--volume /usr/share/profile.d/toolbox.sh:/etc/profile.d/toolbox.sh:ro"
+    else
+        echo "$base_toolbox_command: failed to bind mount toolbox.sh" >&3
     fi
 
     if [ -d /media ] 2>&3; then


### PR DESCRIPTION
/usr/share/profile.d is the default location where toolbox.sh is
installed, even though, in practice, most (all?) distributions use
/etc/profile.d. It's reasonable to at least make the code work with the
default build values.