### PR TITLE
Initial commit of a Debian sid image for toolbox

### DIFF
--- a/images/debian/unstable/Dockerfile
+++ b/images/debian/unstable/Dockerfile
@@ -1,0 +1,29 @@
+FROM docker.io/library/debian:unstable
+
+ENV NAME=debian-toolbox VERSION=unstable
+LABEL com.github.containers.toolbox="true" \
+      com.github.debarshiray.toolbox="true" \
+      name="$NAME" \
+      version="$VERSION" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Debian sid toolbox containers" \
+      maintainer="Debarshi Ray <rishi@fedoraproject.org>"
+
+COPY README.md /
+
+RUN apt update
+
+RUN apt -y upgrade
+
+COPY extra-packages /
+RUN apt -y install $(cat extra-packages | xargs)
+RUN rm /extra-packages
+
+RUN sed -i -e 's/ ALL$/ NOPASSWD:ALL/' /etc/sudoers
+
+RUN apt clean
+
+RUN echo VARIANT_ID=container >> /etc/os-release
+RUN touch /etc/localtime
+
+CMD /bin/sh

--- a/images/debian/unstable/README.md
+++ b/images/debian/unstable/README.md
@@ -1,0 +1,41 @@
+<img src="data/logo/toolbox-logo-landscape.svg" alt="Toolbox logo landscape" width="800"/>
+
+[Toolbox](https://github.com/debarshiray/toolbox) is a tool that offers a
+familiar RPM based environment for developing and debugging software that runs
+fully unprivileged using [Podman](https://podman.io/).
+
+The toolbox container is a fully *mutable* container; when you see
+`yum install ansible` for example, that's something you can do inside your
+toolbox container, without affecting the base operating system.
+
+This is particularly useful on
+[OSTree](https://ostree.readthedocs.io/en/latest/) based Fedora systems like
+[Silverblue](https://silverblue.fedoraproject.org/).  The intention of these
+systems is to discourage installation of software on the host, and instead
+install software as (or in) containers.
+
+However, this tool doesn't *require* using an OSTree based system — it
+works equally well if you're running e.g. existing Fedora Workstation or
+Server, and that's a useful way to incrementally adopt containerization.
+
+The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
+image. On Fedora this is the `fedora-toolbox` image. This image is used to
+create a toolbox container that seamlessly integrates with the rest of the
+operating system.
+
+## Usage
+
+### Create your toolbox container:
+```
+[user@hostname ~]$ toolbox create
+Created container: fedora-toolbox-30
+Enter with: toolbox enter
+[user@hostname ~]$
+```
+This will create a container called `fedora-toolbox-<version-id>`.
+
+### Enter the toolbox:
+```
+[user@hostname ~]$ toolbox enter
+⬢[user@toolbox ~]$
+```

--- a/images/debian/unstable/extra-packages
+++ b/images/debian/unstable/extra-packages
@@ -1,0 +1,17 @@
+bash-completion
+git
+keyutils
+libcap2-bin
+lsof
+man-db
+mlocate
+mtr
+rsync
+sudo
+tcpdump
+time
+traceroute
+tree
+unzip
+wget
+zip


### PR DESCRIPTION
This is inspired by @kronenpj work in #298 but for Debian `sid`, so a few changes here and there.

It builds with `podman` and no issues with `toolbox create` or `toolbox enter` on a Debian `sid` host.