### PR TITLE
Load fedora-toolbox image in the pre-phase to prevent ci failure

### DIFF
--- a/playbooks/fedora-30/setup-rpm-env.yaml
+++ b/playbooks/fedora-30/setup-rpm-env.yaml
@@ -20,3 +20,5 @@
 
     - name: Check versions of crucial packages
       command: rpm -q podman runc conmon fuse-overlayfs flatpak-session-helper
+
+    - include_tasks: ../pre-common.yaml

--- a/playbooks/fedora-31/setup-rpm-env.yaml
+++ b/playbooks/fedora-31/setup-rpm-env.yaml
@@ -20,3 +20,5 @@
 
     - name: Check versions of crucial packages
       command: rpm -q podman crun conmon fuse-overlayfs flatpak-session-helper
+
+    - include_tasks: ../pre-common.yaml

--- a/playbooks/fedora-rawhide/setup-rpm-env.yaml
+++ b/playbooks/fedora-rawhide/setup-rpm-env.yaml
@@ -21,3 +21,5 @@
 
     - name: Check versions of crucial packages
       command: rpm -q podman crun conmon fuse-overlayfs flatpak-session-helper
+
+    - include_tasks: ../pre-common.yaml

--- a/playbooks/pre-common.yaml
+++ b/playbooks/pre-common.yaml
@@ -1,0 +1,6 @@
+- name: Load registry image in pre-phase and auto restart when registry is flaky
+  command: podman pull registry.fedoraproject.org/f31/fedora-toolbox:31
+  register: _podman
+  until: _podman.rc == 0
+  retries: 5
+  delay: 10


### PR DESCRIPTION
This change adds a pre task to load the fedora-toolbox image from
the registry to prevent false positive failure when:
Trying to pull registry.fedoraproject.org/f31/fedora-toolbox:31...
  invalid status code from registry 503 (Service Unavailable)