### PR TITLE
Use container name as container hostname

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -419,7 +419,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, xdgRuntimeDirEnv...)
 
 	createArgs = append(createArgs, []string{
-		"--hostname", "toolbox",
+		"--hostname", strings.NewReplacer("_", "-", ".", "-").Replace(container),
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
 	}...)


### PR DESCRIPTION
..to distinguish different toolboxes more easily inside a toolbox,
this includes version information too (by default).
Replace underscores with dashes since underscores are not allowed in hostnames.

Fixes: #98, #120