### PR TITLE
Allow to opt out of terminal container tracking

### DIFF
--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -6,6 +6,7 @@ toolbox\-enter - Enter a toolbox container for interactive use
 ## SYNOPSIS
 **toolbox enter** [*--distro DISTRO* | *-d DISTRO*]
               [*--release RELEASE* | *-r RELEASE*]
+              [*--once* | *-o*]
               [*CONTAINER*]
 
 ## DESCRIPTION
@@ -39,6 +40,10 @@ host.
 
 Enter a toolbox container for a different operating system RELEASE than the
 host.
+
+**--once**, **-o**
+
+Do not track container in use, only enter the container once.
 
 ## EXAMPLES
 

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -32,6 +32,7 @@ var (
 		container string
 		distro    string
 		release   string
+		once      bool
 	}
 )
 
@@ -62,6 +63,12 @@ func init() {
 		"r",
 		"",
 		"Enter a toolbox container for a different operating system release than the host")
+
+	flags.BoolVarP(&enterFlags.once,
+		"once",
+		"o",
+		false,
+		"Do not track container in use, only enter the container once.")
 
 	if err := enterCmd.RegisterFlagCompletionFunc("container", completionContainerNames); err != nil {
 		logrus.Panicf("failed to register flag completion function: %v", err)
@@ -160,7 +167,7 @@ func enter(cmd *cobra.Command, args []string) error {
 
 	var emitEscapeSequence bool
 
-	if hostID == "fedora" && (hostVariantID == "silverblue" || hostVariantID == "workstation") {
+	if !enterFlags.once && hostID == "fedora" && (hostVariantID == "silverblue" || hostVariantID == "workstation") {
 		emitEscapeSequence = true
 	}
 


### PR DESCRIPTION
By providing a --once (-o) switch.
Issuing a `toolbox enter --once` means that you do not want
your terminal to track the container in use.
Tracking is enabled by default.

Fixes: #218