### PR TITLE
Drop unnecessary and wrong group detection on host

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -191,11 +191,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	toolboxPathEnvArg := "TOOLBOX_PATH=" + toolboxPath
 	toolboxPathMountArg := toolboxPath + ":/usr/bin/toolbox:ro"
 
-	sudoGroup, err := utils.GetGroupForSudo()
-	if err != nil {
-		return err
-	}
-
 	logrus.Debug("Checking if 'podman create' supports '--ulimit host'")
 
 	var ulimitHost []string
@@ -339,7 +334,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"create",
 		"--dns", "none",
 		"--env", toolboxPathEnvArg,
-		"--group-add", sudoGroup,
 		"--hostname", "toolbox",
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",

--- a/toolbox
+++ b/toolbox
@@ -982,11 +982,6 @@ create()
         return 1
     fi
 
-    if ! group_for_sudo=$(get_group_for_sudo); then
-        echo "$base_toolbox_command: failed to create container $toolbox_container: group for sudo not found" >&2
-        return 1
-    fi
-
     if [ -f /etc/profile.d/toolbox.sh ] 2>&3; then
         toolbox_profile_bind="--volume /etc/profile.d/toolbox.sh:/etc/profile.d/toolbox.sh:ro"
     elif [ -f /usr/share/profile.d/toolbox.sh ] 2>&3; then
@@ -1078,7 +1073,6 @@ create()
     $podman_command create \
             --dns none \
             --env TOOLBOX_PATH="$TOOLBOX_PATH" \
-            --group-add "$group_for_sudo" \
             --hostname toolbox \
             --ipc host \
             --label "com.github.containers.toolbox=true" \


### PR DESCRIPTION
Don't call get_group_for_sudo() on the host during create(). That runs
on the host, and thus will check which sudo group exists on the host.
But that is entirely irrelevant for sudo inside the container, and it
breaks when trying to create a Debian or Ubuntu based toolbox on a
Fedora host (or vice versa).

Also, there is no point in running the `podman create` command with an
extra sudo group, normal user privileges are just fine.

init_container() will call get_group_for_sudo() inside the container and
initialize the groups correctly there.