### PR TITLE
When bind-mounting a file, create the target path if it doesn't exist

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -683,12 +683,22 @@ mount_bind()
 
     ! [ -d "$source" ] 2>&3 && ! [ -f "$source" ] 2>&3 && return 0
 
-    if [ -d "$source" ] 2>&3; then
-        echo "$base_toolbox_command: creating $target" >&3
+    if ! [ -e "$target" ] 2>&3; then
+        if [ -d "$source" ] 2>&3; then
+            echo "$base_toolbox_command: creating $target" >&3
 
-        if ! mkdir --parents "$target" 2>&3; then
-            echo "$base_toolbox_command: failed to create $target" >&2
-            return 1
+            if ! mkdir --parents "$target" 2>&3; then
+                echo "$base_toolbox_command: failed to create $target" >&2
+                return 1
+            fi
+        fi
+        if [ -f "$source" ] 2>&3; then
+            echo "$base_toolbox_command: creating $target" >&3
+
+            if ! touch "$target" 2>&3; then
+                echo "$base_toolbox_command: failed to create $target" >&2
+                return 1
+            fi
         fi
     fi
 


### PR DESCRIPTION
If the target path doesn't exist, 'mount' fails with this error:

> mount: <TARGET>: mount point does not exist.

I got this error when in a toolbox the path `/etc/machine-id` does not exist.  

This PR just `touch`es the target path if it doesn't exist.