### PR TITLE
build: Ship the Go implementation by default, not the POSIX shell one

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   meson_version: '>= 0.40.0',
 )
 
-go = find_program('go', required: false)
+go = find_program('go')
 go_md2man = find_program('go-md2man')
 shellcheck = find_program('shellcheck', required: false)
 
@@ -19,11 +19,6 @@ toolbox = files('toolbox')
 if shellcheck.found()
   test('shellcheck', shellcheck, args: [toolbox])
 endif
-
-install_data(
-  toolbox,
-  install_dir: get_option('bindir'),
-)
 
 bash_completion = dependency('bash-completion', required: false)
 if bash_completion.found()

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,15 +19,15 @@ sources = files(
   'pkg/version/version.go',
 )
 
-if go.found()
-  custom_target(
-    'toolbox-go',
-    build_by_default: true,
-    command: [go_build_wrapper_program, meson.current_source_dir(), meson.current_build_dir()],
-    input: sources,
-    output: 'toolbox',
-  )
-endif
+custom_target(
+  'toolbox',
+  build_by_default: true,
+  command: [go_build_wrapper_program, meson.current_source_dir(), meson.current_build_dir()],
+  input: sources,
+  install: true,
+  install_dir: get_option('bindir'),
+  output: 'toolbox',
+)
 
 if shellcheck.found()
   test('shellcheck go-build-wrapper', shellcheck, args: [go_build_wrapper_file])


### PR DESCRIPTION
The Go implementation is now considered stable enough for wider use,
and should have feature parity with its POSIX shell counterpart.