### PR TITLE
playbooks/shellcheck: Add Go to the list of build dependencies

### DIFF
--- a/playbooks/shellcheck.yaml
+++ b/playbooks/shellcheck.yaml
@@ -5,6 +5,7 @@
       become: yes
       package:
         name:
+          - golang
           - golang-github-cpuguy83-go-md2man
           - ninja-build
           - meson


### PR DESCRIPTION
Otherwise, the test fails with:
```
  meson.build:8:0: ERROR: Program(s) ['go'] not found or not executable
```