### PR TITLE
.zuul, playbooks/shellcheck: Use Go 1.13

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,8 +5,8 @@
     timeout: 300
     nodeset:
       nodes:
-        - name: ci-node-30
-          label: cloud-fedora-30-small
+        - name: ci-node-32
+          label: cloud-fedora-32-small
     run: playbooks/shellcheck.yaml
 
 - job:

--- a/playbooks/shellcheck.yaml
+++ b/playbooks/shellcheck.yaml
@@ -6,7 +6,7 @@
       package:
         name:
           - golang
-          - golang-github-cpuguy83-go-md2man
+          - golang-github-cpuguy83-md2man
           - ninja-build
           - meson
           - ShellCheck


### PR DESCRIPTION
Toolbox requires Go 1.13, while Fedora 30 only has Go 1.12.17.
Therefore the test environment needs to be upgraded to something more
recent.

Otherwise, the test fails with:
```
  note: module requires Go 1.13
```

The name of the go-md2man package changed in Fedora 31, and hence had
to be updated.
