### PR TITLE
Allow specifying user shell at toolbox creation

### DIFF
--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -121,13 +121,6 @@ func enter(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	userShell := os.Getenv("SHELL")
-	if userShell == "" {
-		return errors.New("failed to get the current user's default shell")
-	}
-
-	command := []string{userShell, "-l"}
-
 	hostID, err := utils.GetHostID()
 	if err != nil {
 		return fmt.Errorf("failed to get the host ID: %w", err)
@@ -144,18 +137,13 @@ func enter(cmd *cobra.Command, args []string) error {
 		emitEscapeSequence = true
 	}
 
-	if err := runCommand(container,
+	return runCommand(container,
 		!nonDefaultContainer,
 		image,
 		release,
-		command,
+		nil,
 		emitEscapeSequence,
-		true,
-		false); err != nil {
-		return err
-	}
-
-	return nil
+		false)
 }
 
 func enterHelp(cmd *cobra.Command, args []string) {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -71,7 +71,6 @@ var (
 		"DESKTOP_SESSION",
 		"DISPLAY",
 		"LANG",
-		"SHELL",
 		"SSH_AUTH_SOCK",
 		"TERM",
 		"TOOLBOX_PATH",


### PR DESCRIPTION
When creating a toolbox the user shell can be specified and this shell will be
used when entering the toolbox.

Signed-off-by: Yann Soubeyrand <yann.soubeyrand@camptocamp.com>

Closes #413