### PR TITLE
go-build-wrapper: Ensure reproducible builds

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -27,5 +27,5 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -ldflags "-X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2"
+go build -trimpath -ldflags "-X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2"
 exit "$?"


### PR DESCRIPTION
The go compiler embeds full paths to modules and dependencies into the
binary. This prevents people from reconstructing a bit-for-bit identical
toolbox binary without going through several hoops.

Without patch:

    $ strings build/src/toolbox | grep "$HOME" | wc -l
    105

With patch:

    $ strings build/src/toolbox | grep "$HOME" | wc -l
    0

Signed-off-by: Morten Linderud <morten@linderud.pw>