### PR TITLE
images: Add gvfs-client to Fedoras 31, 32 and 33

### DIFF
--- a/images/fedora/f31/extra-packages
+++ b/images/fedora/f31/extra-packages
@@ -8,6 +8,7 @@ fpaste
 git
 gnupg
 gnupg2-smime
+gvfs-client
 hostname
 iputils
 jwhois

--- a/images/fedora/f32/extra-packages
+++ b/images/fedora/f32/extra-packages
@@ -8,6 +8,7 @@ fpaste
 git
 gnupg
 gnupg2-smime
+gvfs-client
 hostname
 iputils
 jwhois

--- a/images/fedora/f33/extra-packages
+++ b/images/fedora/f33/extra-packages
@@ -8,6 +8,7 @@ fpaste
 git
 gnupg
 gnupg2-smime
+gvfs-client
 hostname
 iputils
 jwhois


### PR DESCRIPTION
The gvfs-client package is necessary for GIO-based processes inside
toolbox containers to use the GVfs backend and volume monitor daemons,
and it comes preinstalled on Fedora Silverblue and Workstation.

Only the images for currently maintained Fedoras (ie., 31, 32 and 33)
were updated.