### PR TITLE
Simplify container & image fetching using labels

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -34,6 +34,7 @@ type toolboxImage struct {
 	ID      string
 	Names   []string
 	Created string
+	Labels  map[string]string
 }
 
 type toolboxContainer struct {
@@ -42,6 +43,7 @@ type toolboxContainer struct {
 	Status  string
 	Created string
 	Image   string
+	Labels  map[string]string
 }
 
 var (
@@ -323,6 +325,7 @@ func (i *toolboxImage) UnmarshalJSON(data []byte) error {
 		ID      string
 		Names   []string
 		Created interface{}
+		Labels  map[string]string
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -341,6 +344,8 @@ func (i *toolboxImage) UnmarshalJSON(data []byte) error {
 		i.Created = utils.HumanDuration(int64(value))
 	}
 
+	i.Labels = raw.Labels
+
 	return nil
 }
 
@@ -352,6 +357,7 @@ func (c *toolboxContainer) UnmarshalJSON(data []byte) error {
 		State   interface{}
 		Created interface{}
 		Image   string
+		Labels  map[string]string
 	}
 
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -394,6 +400,7 @@ func (c *toolboxContainer) UnmarshalJSON(data []byte) error {
 		c.Created = utils.HumanDuration(int64(value))
 	}
 	c.Image = raw.Image
+	c.Labels = raw.Labels
 
 	return nil
 }

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -51,6 +51,12 @@ var (
 		onlyContainers bool
 		onlyImages     bool
 	}
+
+	// toolboxLabels holds labels used by containers/images that mark them as compatible with Toolbox
+	toolboxLabels = map[string]string{
+		"com.github.debarshiray.toolbox": "true",
+		"com.github.containers.toolbox":  "true",
+	}
 )
 
 var listCmd = &cobra.Command{
@@ -123,35 +129,22 @@ func list(cmd *cobra.Command, args []string) error {
 }
 
 func getContainers() ([]toolboxContainer, error) {
-	logrus.Debug("Fetching containers with label=com.github.containers.toolbox=true")
-	args := []string{"--all", "--filter", "label=com.github.containers.toolbox=true"}
-	containers_old, err := podman.GetContainers(args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list containers with label=com.github.containers.toolbox=true: %w", err)
-	}
-
-	logrus.Debug("Fetching containers with label=com.github.debarshiray.toolbox=true")
-	args = []string{"--all", "--filter", "label=com.github.debarshiray.toolbox=true"}
-	containers_new, err := podman.GetContainers(args...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to list containers with label=com.github.debarshiray.toolbox=true: %w", err)
-	}
-
+	var err error
+	var args []string
 	var containers []map[string]interface{}
-	if podman.CheckVersion("2.0.0") {
-		containers = utils.JoinJSON("Id", containers_old, containers_new)
-		containers = utils.SortJSON(containers, "Names", true)
-	} else {
-		containers = utils.JoinJSON("ID", containers_old, containers_new)
-		containers = utils.SortJSON(containers, "Names", false)
+	var toolboxContainers []toolboxContainer
+
+	logrus.Debug("Fetching all containers")
+	args = []string{"--all", "--sort", "names"}
+	containers, err = podman.GetContainers(args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get containers: %w", err)
 	}
 
-	// This section is a temporary solution that is here to prevent a major
-	// redesign of the way how toolbox containers are fetched.
-	// Remove this in Toolbox v0.2.0
-	var toolboxContainers []toolboxContainer
 	for _, container := range containers {
 		var c toolboxContainer
+		var isToolboxContainer bool = false
+
 		containerJSON, err := json.Marshal(container)
 		if err != nil {
 			logrus.Errorf("failed to marshal container: %v", err)
@@ -163,7 +156,17 @@ func getContainers() ([]toolboxContainer, error) {
 			logrus.Errorf("failed to unmarshal container: %v", err)
 			continue
 		}
-		toolboxContainers = append(toolboxContainers, c)
+
+		for label := range toolboxLabels {
+			if _, ok := c.Labels[label]; ok {
+				isToolboxContainer = true
+				break
+			}
+		}
+
+		if isToolboxContainer {
+			toolboxContainers = append(toolboxContainers, c)
+		}
 	}
 
 	return toolboxContainers, nil
@@ -191,38 +194,22 @@ func listHelp(cmd *cobra.Command, args []string) {
 }
 
 func getImages() ([]toolboxImage, error) {
-	logrus.Debug("Fetching images with label=com.github.containers.toolbox=true")
-	args := []string{"--filter", "label=com.github.containers.toolbox=true"}
-	images_old, err := podman.GetImages(args...)
-	if err != nil {
-		return nil, errors.New("failed to list images with label=com.github.containers.toolbox=true")
-	}
-
-	logrus.Debug("Fetching images with label=com.github.debarshiray.toolbox=true")
-	args = []string{"--filter", "label=com.github.debarshiray.toolbox=true"}
-	images_new, err := podman.GetImages(args...)
-	if err != nil {
-		return nil, errors.New("failed to list images with com.github.debarshiray.toolbox=true")
-	}
-
+	var err error
+	var args []string
 	var images []map[string]interface{}
-	if podman.CheckVersion("2.0.0") {
-		images = utils.JoinJSON("Id", images_old, images_new)
-		images = utils.SortJSON(images, "Names", true)
-	} else if podman.CheckVersion("1.8.3") {
-		images = utils.JoinJSON("ID", images_old, images_new)
-		images = utils.SortJSON(images, "Names", true)
-	} else {
-		images = utils.JoinJSON("id", images_old, images_new)
-		images = utils.SortJSON(images, "names", true)
+	var toolboxImages []toolboxImage
+
+	logrus.Debug("Fetching all images")
+	args = []string{"--sort", "repository"}
+	images, err = podman.GetImages(args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get images: %w", err)
 	}
 
-	// This section is a temporary solution that is here to prevent a major
-	// redesign of the way how toolbox images are fetched.
-	// Remove this in Toolbox v0.2.0
-	var toolboxImages []toolboxImage
 	for _, image := range images {
 		var i toolboxImage
+		var isToolboxImage bool = false
+
 		imageJSON, err := json.Marshal(image)
 		if err != nil {
 			logrus.Errorf("failed to marshal toolbox image: %v", err)
@@ -234,7 +221,17 @@ func getImages() ([]toolboxImage, error) {
 			logrus.Errorf("failed to unmarshal toolbox image: %v", err)
 			continue
 		}
-		toolboxImages = append(toolboxImages, i)
+
+		for label := range toolboxLabels {
+			if _, ok := i.Labels[label]; ok {
+				isToolboxImage = true
+				break
+			}
+		}
+
+		if isToolboxImage {
+			toolboxImages = append(toolboxImages, i)
+		}
 	}
 
 	return toolboxImages, nil


### PR DESCRIPTION
I did not like the way listing of containers was written. There was a lot of duplication and was very prone to error.

Now the labels are tracked in a variable, function for checking if a container/image is more lightweight (requires data to be passed to it) and functions for getting a list of toolboxes and toolbox images are much easier to understand.