### PR TITLE
utils: Use Lstat over Stat in PathExists

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -636,9 +636,9 @@ func parseReleaseRHEL(str string) (string, error) {
 	return str, nil
 }
 
-// PathExists wraps around os.Stat providing a nice interface for checking an existence of a path.
+// PathExists wraps around os.Lstat providing a nice interface for checking an existence of a path.
 func PathExists(path string) bool {
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
 		return true
 	}
 


### PR DESCRIPTION
`utils.PathExists` uses `os.Stat` under the hood but `stat` be definition follows symlinks. I think better is to use `os.Lstat` because `lstat` returns info about symlinks themselves.