### PR TITLE
[cmd/root] Use string verb format for string path instead of slice

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -380,5 +380,5 @@ func validateSubIDFile(path string) (bool, error) {
 		}
 	}
 
-	return false, fmt.Errorf("failed to find an entry for user %s in %p", currentUser.Username, path)
+	return false, fmt.Errorf("failed to find an entry for user %s in %s", currentUser.Username, path)
 }


### PR DESCRIPTION
Minor fix on root command, it was using slice verb format(`%p`) on an string instead of the corresponding verb (`%s`).