### PR TITLE
pkg/podman: Remember Podman's version during runtime

### DIFF
--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -35,14 +35,14 @@ var (
 //
 // Takes in one string parameter that should be in the format that is used for versioning (eg. 1.0.0, 2.5.1-dev).
 //
-// Returns true if the Podman version is equal to or higher than the required version.
+// Returns true if the current version is equal to or higher than the required version.
 func CheckVersion(requiredVersion string) bool {
-	podmanVersion, _ := GetVersion()
+	currentVersion, _ := GetVersion()
 
-	podmanVersion = version.Normalize(podmanVersion)
+	currentVersion = version.Normalize(currentVersion)
 	requiredVersion = version.Normalize(requiredVersion)
 
-	return version.CompareSimple(podmanVersion, requiredVersion) >= 0
+	return version.CompareSimple(currentVersion, requiredVersion) >= 0
 }
 
 // ContainerExists checks using Podman if a container with given ID/name exists.

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -28,6 +28,10 @@ import (
 )
 
 var (
+	podmanVersion string
+)
+
+var (
 	LogLevel = logrus.ErrorLevel
 )
 
@@ -119,6 +123,10 @@ func GetImages(args ...string) ([]map[string]interface{}, error) {
 
 // GetVersion returns version of Podman in a string
 func GetVersion() (string, error) {
+	if podmanVersion != "" {
+		return podmanVersion, nil
+	}
+
 	var stdout bytes.Buffer
 
 	logLevelString := LogLevel.String()
@@ -134,7 +142,6 @@ func GetVersion() (string, error) {
 		return "", err
 	}
 
-	var podmanVersion string
 	podmanClientInfoInterface := jsonoutput["Client"]
 	switch podmanClientInfo := podmanClientInfoInterface.(type) {
 	case nil:


### PR DESCRIPTION
We call `podman version` every time we want to check Podman's version. This slows Toolbox down considerably. It's more efficient if we call `podman version` just once and remember the output during runtime and use the cached value.

On Intel i5-6300U calling `time podman version --format json` takes roughly a bit over 100ms.