### PR TITLE
Add errors to pkg/podman & wrap errors across codebase

### DIFF
--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -111,8 +111,21 @@ func rm(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, container := range args {
+			if exists, err := podman.ContainerExists(container); !exists {
+				if errors.Is(err, podman.ErrContainerNotExist) {
+					fmt.Fprintf(os.Stderr, "Error: container %s does not exist\n", container)
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				}
+				continue
+			}
+
 			if _, err := podman.IsToolboxContainer(container); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				if errors.Is(err, podman.ErrContainerNotToolbox) {
+					fmt.Fprintf(os.Stderr, "Error: container %s is not a toolbox container\n", container)
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				}
 				continue
 			}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -113,8 +113,21 @@ func rmi(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, image := range args {
+			if exists, err := podman.ImageExists(image); !exists {
+				if errors.Is(err, podman.ErrImageNotExist) {
+					fmt.Fprintf(os.Stderr, "Error: image %s does not exist\n", image)
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				}
+				continue
+			}
+
 			if _, err := podman.IsToolboxImage(image); err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				if errors.Is(err, podman.ErrImageNotToolbox) {
+					fmt.Fprintf(os.Stderr, "Error: image %s is not a toolbox image\n", image)
+				} else {
+					fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				}
 				continue
 			}
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -216,7 +216,7 @@ func migrate() error {
 
 	podmanVersion, err := podman.GetVersion()
 	if err != nil {
-		return fmt.Errorf("failed to get the Podman version")
+		return fmt.Errorf("failed to get the Podman version: %w", err)
 	}
 
 	logrus.Debugf("Current Podman version is %s", podmanVersion)
@@ -274,7 +274,7 @@ func migrate() error {
 	}
 
 	if err = podman.SystemMigrate(""); err != nil {
-		return fmt.Errorf("failed to migrate containers")
+		return fmt.Errorf("failed to migrate containers: %w", err)
 	}
 
 	logrus.Debugf("Migration to Podman version %s was ok", podmanVersion)

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -130,7 +130,7 @@ func CallFlatpakSessionHelper() (string, error) {
 
 	connection, err := dbus.SessionBus()
 	if err != nil {
-		return "", errors.New("failed to connect to the D-Bus session instance")
+		return "", fmt.Errorf("failed to connect to the D-Bus session instance: %w", err)
 	}
 
 	sessionHelper := connection.Object("org.freedesktop.Flatpak", "/org/freedesktop/Flatpak/SessionHelper")
@@ -146,7 +146,7 @@ func CallFlatpakSessionHelper() (string, error) {
 	pathVariant := result["path"]
 	pathVariantSignature := pathVariant.Signature().String()
 	if pathVariantSignature != "s" {
-		return "", errors.New("unknown reply from org.freedesktop.Flatpak.SessionHelper.RequestSession")
+		return "", fmt.Errorf("unknown reply from org.freedesktop.Flatpak.SessionHelper.RequestSession: %w", err)
 	}
 
 	pathValue := pathVariant.Value()
@@ -559,11 +559,11 @@ func ShowManual(manual string) error {
 	stdoutFd := os.Stdout.Fd()
 	stdoutFdInt := int(stdoutFd)
 	if err := syscall.Dup3(stdoutFdInt, stderrFdInt, 0); err != nil {
-		return errors.New("failed to redirect standard error to standard output")
+		return fmt.Errorf("failed to redirect standard error to standard output: %w", err)
 	}
 
 	if err := syscall.Exec(manBinary, manualArgs, env); err != nil {
-		return errors.New("failed to invoke man(1)")
+		return fmt.Errorf("failed to invoke man(1): %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
In a lot of places in the code, we use Go errors in this fashion: `fmt.Errorf("container %s...", container)`. This is alright if we use the error messages immediately and don't care if a function may return different errors. At the moment we need to check for different errors coming from functions, this style becomes bothersome.

This is the most noticeable in the case of removing containers/images. Commands `podman rm/rmi` may fail with different errors. Either a container/image does not exist or it is running/used. Without dedicated error variables, this is rather hard to catch. We've been going about it by using the approach briefly shown above.

The solution is to add error variables to the package (`podman`) that can be checked for using the `errors` (`errors.Is` and `errors.As`) library of Go.

The second part of this PR is that in a lot of places in the code, we return errors but don't wrap them around the errors that hold the information about the cause. I encountered this recently when Podman V2 introduced a regression about the option `--userns keep-id` not working properly. It caused Toolbox to crash (specifically the container entry-point `init-container`) due to being unable to find info about current user but there was no helpful error message because we dropped it when returning Toolbox's error message.

A good side-effect of this is that commands `toolbox rm/rmi` now detect if a container is running/image has dependent containers and print a helpful message with a hint on how to delete them.