### PR TITLE
Introduce Ubuntu LTS and latest non-LTS images

### DIFF
--- a/.github/workflows/ubuntu-images.yaml
+++ b/.github/workflows/ubuntu-images.yaml
@@ -1,0 +1,61 @@
+name: "Images: Build and push Ubuntu toolbx images"
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - images/ubuntu/**
+      - .github/workflows/ubuntu-images.yaml
+  schedule:
+    - cron: '0 0 * * MON'
+
+# Prevent multiple workflow runs from racing
+concurrency: ${{ github.workflow }}
+
+env:
+  latest_release: '22.04'
+
+jobs:
+  build-and-push-images:
+    strategy:
+      matrix:
+        release: ['16.04', '18.04', '20.04', '22.04', '22.10', '23.04']
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: 'toolbx+github'
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push Ubuntu ${{ matrix.release }} toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: images/ubuntu/${{ matrix.release }}
+          file: images/ubuntu/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          no-cache: true
+          tags: quay.io/toolbx/ubuntu-toolbox:${{ matrix.release }}
+
+      - name: Push latest tag
+        if: env.latest_release == matrix.release
+        uses: docker/build-push-action@v3
+        with:
+          context: images/ubuntu/${{ matrix.release }}
+          file: images/ubuntu/${{ matrix.release }}/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: quay.io/toolbx/ubuntu-toolbox:latest


### PR DESCRIPTION
This adds Ubuntu 16.04, 18.04, 20.04, 21.10 and 22.04 images that play well with `toolbox`:
password-less `sudo`, able to resolve its own hostname (so that `sudo` does not complain), SELinux is masked off, etc.
Since 18.04 Ubuntu images on the Docker Hub are 'minimized', so we have to undo that.
Pushed images to https://hub.docker.com/r/jmennius/ubuntu-toolbox for the time being.

Users may want to generate their locale after toolbox creation with `sudo sed -i "/${LANG}/s/^# //g" /etc/locale.gen && sudo locale-gen` (assuming that you have `LANG` set) to avoid `perl` and others complain about it.

I've been using an 18.04 image for ~several months~ 1.5yrs now with great success.

Some things I'd like to resolve or discuss at least (need help/guidance/decisionmaking/PRs):
- [ ] Use actual quay toolbx robot credentials.
- [x] READMEs are not symlinked. Didn't get this to work as symlink target is out of build context. #723
- [x] Moreover, I'd also like to share `extra-packages` between images. Maybe we can store all Containerfiles in the `ubuntu` and a single readme and extra-packages alongside?
- [x] align READMEs with the rest of the repo before merging
- [x] Needs #401 to function
- [x] I can mention myself as the image maintainer if that's the way to go.
- [x] Any CI/CD integration? Yes, see #1019 
- [x] ~I've only tested this with a shell-based toolbox.~ Works perfectly with golang implementation.
- [x] Did not use `NAME` and `VERSION` variables (discussed in #188)
 
I'd be grateful for any testing and feedback on their use-case and environment.

Alternative-to: #298