### PR TITLE
pkg/utils: Make it build on aarch64

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -548,7 +548,7 @@ func ShowManual(manual string) error {
 	stderrFdInt := int(stderrFd)
 	stdoutFd := os.Stdout.Fd()
 	stdoutFdInt := int(stdoutFd)
-	if err := syscall.Dup2(stdoutFdInt, stderrFdInt); err != nil {
+	if err := syscall.Dup3(stdoutFdInt, stderrFdInt, 0); err != nil {
 		return errors.New("failed to redirect standard error to standard output")
 	}
 


### PR DESCRIPTION
The syscall.Dup2 wrapper isn't defined on aarch64, which breaks the
build as:
  ../../pkg/utils/utils.go:551:12: undefined: syscall.Dup2