### PR TITLE
build, pkg/version: Embed the version from Meson into the binary

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,9 +16,9 @@
 #
 
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
     echo "go-build-wrapper: wrong arguments" >&2
-    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR]" >&2
+    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION]" >&2
     exit 1
 fi
 
@@ -27,5 +27,5 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -o "$2"
+go build -ldflags "-X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2"
 exit "$?"

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,7 +22,12 @@ sources = files(
 custom_target(
   'toolbox',
   build_by_default: true,
-  command: [go_build_wrapper_program, meson.current_source_dir(), meson.current_build_dir()],
+  command: [
+    go_build_wrapper_program,
+    meson.current_source_dir(),
+    meson.current_build_dir(),
+    meson.project_version(),
+  ],
   input: sources,
   install: true,
   install_dir: get_option('bindir'),

--- a/src/pkg/version/version.go
+++ b/src/pkg/version/version.go
@@ -16,23 +16,12 @@
 
 package version
 
-import "fmt"
-
-// Version is the version of Toolbox
-type Version struct {
-	Major int
-	Minor int
-	Micro int
-}
-
 // currentVersion holds the information about current build version
-var currentVersion = Version{
-	Major: 0,
-	Minor: 0,
-	Micro: 90,
-}
+var (
+	currentVersion = "0.0.90"
+)
 
 // GetVersion returns string with the version of Toolbox
 func GetVersion() string {
-	return fmt.Sprintf("%d.%d.%d", currentVersion.Major, currentVersion.Minor, currentVersion.Micro)
+	return currentVersion
 }

--- a/src/pkg/version/version.go
+++ b/src/pkg/version/version.go
@@ -25,8 +25,8 @@ type Version struct {
 	Micro int
 }
 
-// CurrentVersion holds the information about current build version
-var CurrentVersion = Version{
+// currentVersion holds the information about current build version
+var currentVersion = Version{
 	Major: 0,
 	Minor: 0,
 	Micro: 90,
@@ -34,5 +34,5 @@ var CurrentVersion = Version{
 
 // GetVersion returns string with the version of Toolbox
 func GetVersion() string {
-	return fmt.Sprintf("%d.%d.%d", CurrentVersion.Major, CurrentVersion.Minor, CurrentVersion.Micro)
+	return fmt.Sprintf("%d.%d.%d", currentVersion.Major, currentVersion.Minor, currentVersion.Micro)
 }

--- a/src/pkg/version/version.go
+++ b/src/pkg/version/version.go
@@ -18,7 +18,7 @@ package version
 
 // currentVersion holds the information about current build version
 var (
-	currentVersion = "0.0.90"
+	currentVersion string
 )
 
 // GetVersion returns string with the version of Toolbox


### PR DESCRIPTION
This removes the need to manually update the version in the Go source code when making a release.