### PR TITLE
cmd/initContainer: Give access to the udev database

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -53,6 +53,7 @@ var (
 		{"/etc/machine-id", "/run/host/etc/machine-id", "ro"},
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
+		{"/run/udev/data", "/run/host/run/udev/data", ""},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},


### PR DESCRIPTION
Enumeration of audio devices using libudev seems to work without this
but some properties are missing. This complicates the development of
software like pipewire.

Closes #468