### PR TITLE
cmd/create: Update hint after creating a container

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -466,7 +466,7 @@ func getEnterCommand(container, release string) string {
 	case containerNamePrefixDefaultWithRelease:
 		enterCommand = fmt.Sprintf("%s enter --release %s", executableBase, release)
 	default:
-		enterCommand = fmt.Sprintf("%s enter --container %s", executableBase, container)
+		enterCommand = fmt.Sprintf("%s enter %s", executableBase, container)
 	}
 
 	return enterCommand


### PR DESCRIPTION
Rewritten version of Toolbox supports newer syntax for entering a
container: `toolbox enter <name-of-container>`. This new workflow should
be shown in the hint after creating a container with `toolbox create`.

Before this change:

```
$ toolbox create 123
Created container: 123
Enter with: toolbox enter --container 123
```

After this change:

```
$ toolbox create 123
Created container: 123
Enter with: toolbox enter 123 | toolbox enter --container 123
```

Closes #489 