### PR TITLE
cmd/create: Show the spinner only when connected to a terminal

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -31,6 +31,7 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -389,7 +390,9 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel {
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
 		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
 		s.Writer = os.Stdout
 		s.Start()
@@ -634,10 +637,11 @@ func pullImage(image, release string) (bool, error) {
 
 	logrus.Debugf("Pulling image %s", imageFull)
 
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel {
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
 		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
-		s.Writer = os.Stdout
 		s.Start()
 		defer s.Stop()
 	}

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,5 +9,6 @@ require (
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
+	golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9
 	golang.org/x/sys v0.0.0-20190422165155-953cdadca894
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -48,6 +48,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
It doesn't make sense to show a spinner when the output is redirected
to something other than a terminal.

The spinner package we're using [0] has a problem with printing
additional characters when it's output (the standard output, in this
case) is not connected to a terminal.

This causes problems in our test suite (corrupts the output that is
checked). To prevent this the spinner should only be started when the
output of the program is not piped.

This uses the golang.org/x/crypto/ssh/terminal package to check if the
standard output is connected to a terminal or not, which is also what
Podman uses. The other option was the github.com/mattn/go-isatty
package but using it leads to a slightly bigger binary - 7778323 bytes
versus 7782284.

[0] https://github.com/briandowns/spinner