### PR TITLE
cmd/create: Restore the spinner, when pulling an image, to stdout

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -642,6 +642,7 @@ func pullImage(image, release string) (bool, error) {
 	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
 		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
+		s.Writer = os.Stdout
 		s.Start()
 		defer s.Stop()
 	}


### PR DESCRIPTION
This doesn't seem to have any user-visible effect. However, since the
line was inadvertently removed, it's good to put it back.

Fallout from 950f510872404da8089ad7ce5911d8342bf7a116

Fix-up for https://github.com/containers/toolbox/pull/496