### PR TITLE
playbooks: Add Go to the list of build dependencies

### DIFF
--- a/playbooks/fedora-31/setup-rpm-env.yaml
+++ b/playbooks/fedora-31/setup-rpm-env.yaml
@@ -5,6 +5,7 @@
       become: yes
       package:
         name:
+          - golang
           - golang-github-cpuguy83-md2man
           - ninja-build
           - meson
@@ -19,6 +20,6 @@
       command: sudo systemd-tmpfiles --create
 
     - name: Check versions of crucial packages
-      command: rpm -q podman crun conmon fuse-overlayfs flatpak-session-helper
+      command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper
 
     - include_tasks: ./pre-common.yaml

--- a/playbooks/fedora-rawhide/setup-rpm-env.yaml
+++ b/playbooks/fedora-rawhide/setup-rpm-env.yaml
@@ -6,6 +6,7 @@
       package:
         use: dnf
         name:
+          - golang
           - golang-github-cpuguy83-md2man
           - ninja-build
           - meson
@@ -20,6 +21,6 @@
       command: sudo systemd-tmpfiles --create
 
     - name: Check versions of crucial packages
-      command: rpm -q podman crun conmon fuse-overlayfs flatpak-session-helper
+      command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper
 
     - include_tasks: ./pre-common.yaml


### PR DESCRIPTION
Otherwise, the tests on Fedora 31 and Rawhide fail with:
  meson.build:8:0: ERROR: Program(s) ['go'] not found or not executable