### PR TITLE
cmd/create: Drop redundant label when creating a container

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -395,7 +395,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"--hostname", "toolbox",
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
-		"--label", "com.github.debarshiray.toolbox=true",
 	}...)
 
 	createArgs = append(createArgs, devPtsMount...)


### PR DESCRIPTION
The Toolbox repository was moved to the 'containers' organization [some time ago](https://github.com/containers/toolbox/commit/de5e5df9b793edc746cde7125cd437b69f15ccd7) already. The label will remain supported but new containers will not be created with it.