### PR TITLE
meson: Add option for installing tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,11 @@ if bash_completion.found()
   )
 endif
 
+install_subdir(
+  'test',
+  install_dir: join_paths(get_option('datadir'), meson.project_name())
+)
+
 subdir('data')
 subdir('doc')
 subdir('profile.d')


### PR DESCRIPTION
This adds a new option to Meson called `with_tests` making it possible to install whole 'test' subdir into the system's data dir (usually `/share` or `/usr/share`).