### PR TITLE
Disable shared memory limit size

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -350,6 +350,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"--pid", "host",
 		"--privileged",
 		"--security-opt", "label=disable",
+		"--shm-size", "0",
 	}
 
 	createArgs = append(createArgs, ulimitHost...)


### PR DESCRIPTION
The default shared memory used by podman is 64 MB, so in order to prevent regular crashes on integration tests because of that value, the limit is disabled by using the "--shm-size=0" parameter.

This change was requested on #501 issue.