### PR TITLE
New function to ensure compatibility with non-standard terminals

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -40,6 +40,8 @@ environment_variables="COLORTERM \
         SHELL \
         SSH_AUTH_SOCK \
         TERM \
+        TERMINFO \
+        TERMINFO_DIRS \
         TOOLBOX_PATH \
         VTE_VERSION \
         WAYLAND_DISPLAY \
@@ -356,6 +358,69 @@ copy_etc_profile_d_toolbox_to_runtime_directory()
 
     if ! cp /etc/profile.d/toolbox.sh "$toolbox_runtime_directory" 2>&3; then
         echo "$base_toolbox_command: unable to copy /etc/profile.d/toolbox.sh to $toolbox_runtime_directory" >&2
+        return 1
+    fi
+
+    return 0
+)
+
+
+copy_terminfo_entry_to_container()
+(
+    container="$1"
+    host_fs_prefix="/run/host"
+    terminfo_dirs=()
+    terminfo_entry=""
+
+    if [ -n "$TERMINFO" ]; then
+        terminfo_dirs=("$TERMINFO")
+    else
+        terminfo_dirs=("$HOME/.terminfo")
+
+        if [ -n "$TERMINFO_DIRS" ]; then
+            oIFS="$IFS"
+            IFS=":"
+            for dir in "$TERMINFO_DIRS"; do
+                if [ -n "$dir" ]; then
+                    terminfo_dirs=("${terminfo_dirs[@]}" "$dir")
+                fi
+            done
+            IFS="$oIFS"
+        fi
+
+        terminfo_dirs=("${terminfo_dirs[@]}" "/usr/share/terminfo")
+    fi
+
+    regexp="/$TERM$"
+    for dir in "${terminfo_dirs[@]}"; do
+        if [ -d "$dir" ]; then
+            terminfo_entry="$(find "$dir" -name "$TERM" 2>/dev/null | grep "$regexp")"
+            if [ -f "$terminfo_entry" ]; then
+                break
+            fi
+        fi
+    done
+
+    entry_target="/usr/share/terminfo/${TERM:0:1}"
+
+    if [ -z "$terminfo_entry" ] && \
+           ! $podman_command exec "$container" \
+                             sh -c "[ -f \"$entry_target/$TERM\" ]" 2>&3; then
+        echo "$base_toolbox_command: unable to copy host terminfo entry to container $container: missing entry" >&2
+        return 1
+    fi
+
+    if ! $podman_command exec --user root:root "$container" \
+                         sh -c "mkdir --mode 755 --parents \"$entry_target\"" 2>&3; then
+        echo "$base_toolbox_command: unable to copy host '$terminfo_entry' to container $container: container '$entry_target' not created" >&2
+        return 1
+    fi
+
+    echo "$base_toolbox_command: copying host '$terminfo_entry' to container $container" >&3
+
+    if ! $podman_command exec --user root:root "$container" \
+                         sh -c "cp -u \"$host_fs_prefix$terminfo_entry\" --target-directory=\"$entry_target\"" 2>&3; then
+        echo "$base_toolbox_command: unable to copy host '$terminfo_entry' to container $container" >&2
         return 1
     fi
 
@@ -1510,6 +1575,12 @@ run()
         if ! copy_etc_profile_d_toolbox_to_container "$toolbox_container"; then
             exit 1
         fi
+    fi
+
+    echo "$base_toolbox_command: copying terminfo entry to $toolbox_container" >&3
+
+    if ! copy_terminfo_entry_to_container "$toolbox_container"; then
+        exit 1
     fi
 
     echo "$base_toolbox_command: inspecting entry point of container $toolbox_container" >&3


### PR DESCRIPTION
Proposed solution to issue #505 . Maintainers' input is required for some design decisions.

**Problem Summary**
Terminal capabilities are stored in [terminfo](https://linux.die.net/man/5/terminfo) databases and used by libraries such as [ncurses](https://linux.die.net/man/3/ncurses) to give terminal-independent methods of terminal controls.

Default Fedora images pulled by _toolbox_ lack the necessary _terminfo_ entries to support less common terminals that result in unusable shells inside containers. The solution is to provide the _terminfo_ entry of the current terminal described by the _TERM_ environment variable.

**Possible Approaches**

- Add _ncurses-base_ and _ncurses-term_ packages to Fedora images to provide a comprehensive _terminfo_ database that is likely to cover all terminals that can be downloaded through a package manager. It is a simple fix but other images that might be used with _toolbox_ need to include those packages to fix this issue for all possible _toolbox_ users. Also, it will not cover terminals that are not found in _ncurses_ packages. But it might be left as an user responsibility in such edge cases.
- Copy the _terminfo_ entry corresponding to user's terminal described by _TERM_ inside the container _terminfo_ database. This is the approach I took with this pull request. Read below for implementation problems.

**Implementation Problems**

- Standard _terminfo_ database is stored in a directory (/usr/share/terminfo) that requires root privileges for write access. Hence, a read lock cannot be acquired without superuser. Same holds true for every other non-privileged program and it is very unlikely a _terminfo_ entry will ever be changed while _toolbox_ is reading from it. But the possibility is there.
- In the current implementation the host file system is searched at every container entrance in case the necessary _terminfo_ entry gets updated after container creation. This is a tradeoff made in performance against the possibility of a terminal update introducing a change to the corresponding _terminfo_ entry that may cause issues. It can be made so that the host file system is searched only if any _terminfo_ entry for the current terminal is missing from the container.
- I assumed that for any container the host file system (e.g. for "/usr/share/terminfo") can always be accessed through the path "/run/host". I do not know for sure if this assumption is safe in general.

**Implementation Commentary**

1. _terminfo_ entry for the current terminal is searched in the paths with the logic specified by the "Fetching Compiled Descriptions" section of  the [terminfo](https://linux.die.net/man/5/terminfo) manual page.
2. Using "podman-exec" command, necessary directories are created and the _terminfo_ entry is copied into the container.
3. Error cases are checked and reported during the process.
4. The function is called inside _run()_ after _copy\_etc\_profile\_d\_*_ calls.

This process adds around 0.2 seconds to the execution time of "toolbox enter" in my somewhat mid-level laptop.