### PR TITLE
cmd/run: Unset detach keys when executing commands

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -269,17 +269,31 @@ func runCommand(container string,
 		}
 	}
 
+	logrus.Debug("Checking if 'podman exec' supports disabling the detach keys")
+
+	var detachKeys []string
+
+	if podman.CheckVersion("1.8.1") {
+		logrus.Debug("'podman exec' supports disabling the detach keys")
+		detachKeys = []string{"--detach-keys", ""}
+	}
+
 	envOptions := utils.GetEnvOptionsForPreservedVariables()
 	logLevelString := podman.LogLevel.String()
 
 	execArgs := []string{
 		"--log-level", logLevelString,
 		"exec",
+	}
+
+	execArgs = append(execArgs, detachKeys...)
+
+	execArgs = append(execArgs, []string{
 		"--interactive",
 		"--tty",
 		"--user", currentUser.Username,
 		"--workdir", workingDirectory,
-	}
+	}...)
 
 	execArgs = append(execArgs, envOptions...)
 


### PR DESCRIPTION
Podman sets keys 'ctrl-p' and 'ctrl-q' as the default detach keys. This behaviour is not desirable in Toolbox. Since Podman v1.8.2[0] it is possible to have set no detach keys by passing an empty string to the --detach-keys option.

Thanks to this the 'Ctrl+p' and 'Ctrl-q' combinations are doing what they should do normally in a terminal.

Fixes: https://github.com/containers/toolbox/issues/394

This PR is a reincarnation of #396 that I mistakenly closed by badly updating the author's branch.