### PR TITLE
cmd/run: Make it more obvious when falling back to /bin/bash

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -257,9 +257,11 @@ func runCommand(container string,
 
 	if _, err := isCommandPresent(container, command[0]); err != nil {
 		if fallbackToBash {
-			logrus.Debugf("command %s not found in container %s; using /bin/bash instead",
+			fmt.Fprintf(os.Stderr,
+				"Error: command %s not found in container %s\n",
 				command[0],
 				container)
+			fmt.Fprintf(os.Stderr, "Using /bin/bash instead.\n")
 
 			command = []string{"/bin/bash"}
 		} else {


### PR DESCRIPTION
Users, who prefer shells other than Bash, tend to get confused when
Toolbox presents a Bash prompt to them. It would be better to be more
upfront about what the problem is, so that users can self-support
themselves.

https://github.com/containers/toolbox/issues/18