### PR TITLE
cmd/initContainer: Mount a tmpfs at /tmp to match the host

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -142,6 +142,16 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 	defer toolboxEnvFile.Close()
 
+	logrus.Debug("Mounting tmpfs at /tmp")
+
+	if err := syscall.Mount("tmpfs",
+		"/tmp",
+		"tmpfs",
+		syscall.MS_NODEV|syscall.MS_STRICTATIME|syscall.MS_NOSUID,
+		"mode=1777"); err != nil {
+		return fmt.Errorf("failed to mount tmpfs at /tmp: %s", err)
+	}
+
 	if initContainerFlags.monitorHost {
 		logrus.Debug("Monitoring host")
 


### PR DESCRIPTION
Podman doesn't mount a tmpfs at /tmp by default - it needs to be
separately requested. However, doing it as part of 'podman create ...'
won't add a tmpfs at /tmp for existing toolbox containers. Therefore,
it's best done as part of the entry point.

The mount options are the same as used by systemd (see tmp.mount) to
provide a tmpfs at the host's /tmp.

For what it's worth, the mount flags do differ slightly from the host.

The host has:
$ findmnt --output OPTIONS,PROPAGATION /tmp
OPTIONS                  PROPAGATION
rw,nosuid,nodev,seclabel shared

The container has:
$ findmnt --output OPTIONS,PROPAGATION /tmp
OPTIONS                                        PROPAGATION
rw,nosuid,nodev,seclabel,uid=100000,gid=100000 private

This difference was ignored because it doesn't appear to cause any real
problem.

https://github.com/containers/toolbox/issues/513