### PR TITLE
proposal: Dnf cache between containers

### DIFF
--- a/images/fedora/f28/Dockerfile
+++ b/images/fedora/f28/Dockerfile
@@ -24,4 +24,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/images/fedora/f29/Dockerfile
+++ b/images/fedora/f29/Dockerfile
@@ -25,4 +25,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/images/fedora/f30/Dockerfile
+++ b/images/fedora/f30/Dockerfile
@@ -25,4 +25,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/images/fedora/f31/Dockerfile
+++ b/images/fedora/f31/Dockerfile
@@ -25,4 +25,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/images/fedora/f32/Dockerfile
+++ b/images/fedora/f32/Dockerfile
@@ -24,4 +24,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/images/fedora/f33/Dockerfile
+++ b/images/fedora/f33/Dockerfile
@@ -24,4 +24,6 @@ RUN rm /extra-packages
 
 RUN dnf clean all
 
+RUN echo 'keepcache=True' >> /etc/dnf/dnf.conf
+
 CMD /bin/sh

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -286,6 +286,26 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		runMediaMount = []string{"--volume", "/run/media:/run/media:rslave"}
 	}
 
+	logrus.Debug("Creating the dnf cache")
+	var dnfCacheMount []string
+
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		return fmt.Errorf("failed to get the user cache directory")
+	}
+
+	dnfCacheDir := cacheDir + "/toolbox/" + release
+	logrus.Debugf("Toolbox cache directory is %s", dnfCacheDir)
+
+	if !utils.PathExists(dnfCacheDir) {
+		err = os.MkdirAll(dnfCacheDir, 0775)
+		if err != nil {
+			return fmt.Errorf("failed to create cache directory")
+		}
+	}
+
+	dnfCacheMount = []string{"--volume", dnfCacheDir + ":/var/cache/dnf/:rslave"}
+
 	logrus.Debug("Looking for toolbox.sh")
 
 	var toolboxShMount []string
@@ -375,6 +395,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, mntMount...)
 	createArgs = append(createArgs, runMediaMount...)
 	createArgs = append(createArgs, toolboxShMount...)
+	createArgs = append(createArgs, dnfCacheMount...)
 
 	createArgs = append(createArgs, []string{
 		imageFull,


### PR DESCRIPTION
Hi!

**Disclaimer**: This is just a proposal, but with initial implementation as a PoC. I tried to mimic the code and be the least intrusive as possible, but I'm sure that it can be improved.

## The idea

**Toolbox** is a very useful tool for developers and the fact that create quickly dev environments that can be destroyed is awesome. But when you work with different containers or destroy-and-create containers frequently, you might want your packages cached, so the new container's _provision_ doesn't take long.

Also, some people work in environments with limited Internet connection.

That's why I think it'd be good idea to create external (to the containers) cache for the packages, so it can be shared between the containers and you don't need to download again and again the same packages.

## Inspiration

I've used a lot [Vagrant](https://www.vagrantup.com/) with [vagrant-cachier](https://github.com/fgrehm/vagrant-cachier) and saved me plenty of time and bandwidth.
Also, I read this article recently and it makes think about dong something similar for **Toolbox**:

[Speed up container builds with overlay mounts](https://www.redhat.com/sysadmin/overlay-mounts)

## Some considerations

The external cache is located at: `~/.cache/toolbox/{release}`
The location `~/.cache/{APP_NAME}` seems to be the standard for modern application's user's caches. I added the `{release}` subdirectory to avoid share dnf's caches between containers from different releases and mess it up.

I noticed that `dnf`remove the packages after the installation, so I add the option `keepcache=True` to the config file `/etc/dnf/dnf.conf` at the Dockerfiles for the different Fedora images. Otherwise, the shared cache would be a bit useless.
