### PR TITLE
libc-wrappers: Tighten the definition of the ppc64le definition

### DIFF
--- a/src/libc-wrappers/libc-wrappers.c
+++ b/src/libc-wrappers/libc-wrappers.c
@@ -24,7 +24,7 @@ __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.17");
 __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.4");
 #elif defined __i386__
 __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.0");
-#elif defined __powerpc64__
+#elif defined __powerpc64__ && _CALL_ELF == 2 /* ppc64le */
 __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.17");
 #elif defined __s390x__
 __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.2");


### PR DESCRIPTION
This is based on the output of 'gcc -dM -E - </dev/null' on a ppc64le
system. For what it's worth, the _CALL_ELF macro is defined as 1 on
the big endian variants of the architecture.

The original intention in commit 6ad9c631806961f3 was to support the
architectures that Fedora builds for, and it doesn't care about PowerPC
variants that aren't ppc64le [1].

[1] https://fedoraproject.org/wiki/Architectures/PowerPC