### PR TITLE
profile.d: Warn if $TERM has no terminfo entry in the container

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -48,6 +48,22 @@ if [ -f /run/.containerenv ] \
         mkdir -p "$toolbox_config"
         touch "$toolbox_welcome_stub"
     fi
+
+    if [ "$TERM" != "" ]; then
+        error_message="Error: terminfo entry not found for $TERM"
+        term_without_first_character="${TERM#?}"
+        term_just_first_character="${TERM%$term_without_first_character}"
+        terminfo_sub_directory="$term_just_first_character/$TERM"
+
+        if [ "$TERMINFO" = "" ]; then
+          ! [ -e "/usr/share/terminfo/$terminfo_sub_directory" ] \
+            && ! [ -e "$HOME/.terminfo/$terminfo_sub_directory" ] \
+            && echo "$error_message" >&2
+        else
+          ! [ -e "$TERMINFO/$terminfo_sub_directory" ] \
+            && echo "$error_message" >&2
+        fi
+    fi
 fi
 
 unset toolbox_config


### PR DESCRIPTION
It tries to loosely mimic ncurses to look up a terminfo entry for the
current terminal, as mentioned in the terminfo(5) manual. Unlike
ncurses, it doesn't handle TERMINFO_DIRS, though, to avoid parsing an
array of directories for the sake of simplicity.

Every line of code in this file is part of the interactive shell's
start-up sequence, which makes it a trade-off between correctness and
speed. Therefore, the purpose of this warning is not to exhaustively
catch all possible corner cases, but to serve as a convenience in the
majority of cases. Ultimately, if someone is using an exotic terminal
set-up, then a missing warning is a minor price to pay in order to not
slow things down for the vast majority of users who don't.

Based on code written by Mert Alp Taytak:
https://github.com/containers/toolbox/pull/515

https://github.com/containers/toolbox/issues/505