### PR TITLE
cmd/initContainer: Fix typo

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -242,7 +242,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 		sudoGroup, err := utils.GetGroupForSudo()
 		if err != nil {
-			return fmt.Errorf("failed to add user %s: %s", initContainerFlags.user, err)
+			return fmt.Errorf("failed to get group for sudo: %w", err)
 		}
 
 		logrus.Debugf("Adding user %s with UID %d:", initContainerFlags.user, initContainerFlags.uid)


### PR DESCRIPTION
Fallout from 772b66bf3e962785730e55f6242fa74066de0743