### PR TITLE
Update fallback fedora version from EOL 30

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	idTruncLength          = 12
-	releaseDefaultFallback = "30"
+	releaseDefaultFallback = "31"
 )
 
 const (


### PR DESCRIPTION
fedora 30 went EOL this may, thus it makes sense to update the default fallback image to fedora 32.  This only affects distributions w/o a vendor-supplied toolbox image, e.g. ArchLinux.