### PR TITLE
Unbreak 'sudo' inside toolbox containers with Podman 2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Tools:
 * `touch(1)`
 * `unlink(1)`
 * `useradd(8)`
+* `usermod(8)`
 
 Paths:
 * `/etc/host.conf`: optional, if present not a bind mount


### PR DESCRIPTION
Since Podman 2.0.5, containers that were created with
`podman create --userns=keep-id ...` automatically get the user added
to `/etc/passwd` [1]. However, this user isn't as fully configured as it
needs to be. The home directory is specified as `/` and the shell is
`/bin/sh`.

Note that Podman doesn't add the user's login group to `/etc/group` [2].
This leads to the following error when entering the container:
  /usr/bin/id: cannot find name for group ID 1000

Therefore, the entry point needs to call usermod(8) to update the user,
instead of using useradd(8) to create it.

[1] Podman commit 6c6670f12a3e6b91
    https://github.com/containers/podman/pull/6829

[2] https://github.com/containers/podman/issues/7389

https://github.com/containers/toolbox/issues/523