### PR TITLE
zuul, playbooks: Enable system tests on Fedora 33

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -32,6 +32,17 @@
     run: playbooks/fedora-32/system-test-fedora-32.yaml
 
 - job:
+    name: system-test-fedora-33
+    description: Run Toolbox's system tests in Fedora 33
+    timeout: 1200
+    nodeset:
+      nodes:
+        - name: ci-node-33
+          label: cloud-fedora-33-small
+    pre-run: playbooks/fedora-33/setup-env.yaml
+    run: playbooks/fedora-33/system-test-fedora-33.yaml
+
+- job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 1200

--- a/playbooks/fedora-33/pre-common.yaml
+++ b/playbooks/fedora-33/pre-common.yaml
@@ -1,0 +1,13 @@
+- name: Pull registry.fedoraproject.org/f33/fedora-toolbox
+  command: podman pull registry.fedoraproject.org/f33/fedora-toolbox
+  register: _podman
+  until: _podman.rc == 0
+  retries: 5
+  delay: 10
+
+- name: Pull registry.fedoraproject.org/f29/fedora-toolbox
+  command: podman pull registry.fedoraproject.org/f29/fedora-toolbox
+  register: _podman
+  until: _podman.rc == 0
+  retries: 5
+  delay: 10

--- a/playbooks/fedora-33/setup-env.yaml
+++ b/playbooks/fedora-33/setup-env.yaml
@@ -1,0 +1,26 @@
+---
+- hosts: all
+  tasks:
+    - name: Install requirements
+      become: yes
+      package:
+        use: dnf
+        name:
+          - golang
+          - golang-github-cpuguy83-md2man
+          - ninja-build
+          - meson
+          - flatpak-session-helper
+          - systemd
+          - bats
+          - bash-completion
+          - udisks2
+          - podman
+
+    - name: Setup environment (create missing /run/media)
+      command: sudo systemd-tmpfiles --create
+
+    - name: Check versions of crucial packages
+      command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper
+
+    - include_tasks: ./pre-common.yaml

--- a/playbooks/fedora-33/system-test-fedora-33.yaml
+++ b/playbooks/fedora-33/system-test-fedora-33.yaml
@@ -1,0 +1,21 @@
+---
+- hosts: ci-node-33
+  tasks:
+    - name: Build toolbox
+      command: meson builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Install toolbox
+      become: yes
+      command: ninja -C builddir install
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Run system tests
+      command: bats ./test/system
+      environment:
+        PODMAN: '/usr/bin/podman'
+        TOOLBOX: '/usr/local/bin/toolbox'
+      args:
+        chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
Fedora 33 branched out recently from Fedora Rawhide.

This should not be merged until [softwarefactory](https://softwarefactory-project.io) offers a Fedora 33 [label](https://softwarefactory-project.io/zuul/t/local/labels) (I expect it to be called `cloud-fedora-33-small`).