### PR TITLE
WIP: Add binary shims

### DIFF
--- a/data/libexec/host-runner
+++ b/data/libexec/host-runner
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+#
+# Copyright © 2019 – 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+executable=$(basename $0)
+priviledged=false
+
+if [ $# -ge 1 ]; then
+	case "$1" in
+		--host-runner-sudo )
+			shift
+			priviledged=true
+	esac
+fi
+
+if $priviledged; then
+	executable="sudo $executable"
+fi
+
+exec flatpak-spawn --host --watch-bus --forward-fd=1 --forward-fd=2 --directory=$(pwd) --env=TERM=xterm-256color $executable "$@"

--- a/data/libexec/meson.build
+++ b/data/libexec/meson.build
@@ -1,0 +1,12 @@
+host_runner = files('host-runner')
+sudo_wrapper = files('sudo-wrapper')
+
+if shellcheck.found()
+  test('shellcheck', shellcheck, args: [host_runner, sudo_wrapper])
+endif
+
+install_data(
+  host_runner,
+  sudo_wrapper,
+  install_dir: get_option('libexecdir'),
+)

--- a/data/libexec/sudo-wrapper
+++ b/data/libexec/sudo-wrapper
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+#
+# Copyright © 2019 – 2020 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# sudo-wrapper is meant to be used before /bin/sudo to make it possible to run
+# commands on the host from inside of a container with "sudo" prefixed. It
+# checks first if the command, that is to be run with sudo, is to be run on the
+# host by checking if it is a symlink to /usr/libexec/toolbox/host-runner. If it
+# is not, /bin/bash is executed instead.
+
+# Name of the executable that should be ran using sudo
+executable=""
+
+# This is a wrapper but the cli user experience should remain the same.
+# TODO: Parse sudo's command line options
+if [ $# -ge 1 ]; then
+
+	executable=$(basename $1)
+	# Move the executable's name out of the argument list
+	shift
+fi
+
+# Shims are located under /usr/libexec/toolbox; the list should not include
+# "host-runner" and "sudo"
+shims=$(ls /usr/libexec/toolbox | grep -v "host-runner" | grep -v "sudo")
+
+if [ -n "$executable" ] && echo "$shims" | grep "^$executable$" >/dev/null; then
+	set -x
+	exec $executable --host-runner-sudo $@
+fi
+
+# The called command is not a shim-binary -> run 'sudo' as usually
+exec /bin/sudo $executable $@

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,1 +1,2 @@
 subdir('tmpfiles.d')
+subdir('libexec')

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -1,3 +1,7 @@
+# Toolbox provides shim binaries for executing commands on the host from inside
+# of a toolbox container
+export PATH="/usr/libexec/toolbox:$PATH"
+
 [ "$BASH_VERSION" != "" ] || [ "$ZSH_VERSION" != "" ] || return 0
 [ "$PS1" != "" ] || return 0
 

--- a/src/cmd/createShim.go
+++ b/src/cmd/createShim.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright © 2019 – 2020 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+/*
+	import (
+		"errors"
+		"fmt"
+		"os"
+		"strings"
+
+		"github.com/containers/toolbox/pkg/shell"
+		"github.com/containers/toolbox/pkg/utils"
+		"github.com/sirupsen/logrus"
+		"github.com/spf13/cobra"
+	)
+
+	var (
+		forbiddenBinaryShims = []string{
+			"toolbox",
+		}
+	)
+
+	var createShimCmd = &cobra.Command{
+		Use:     "create-shim",
+		Short:   "Create a binary shim for a command to be run on the host",
+		Hidden:  true,
+		Example: "asdasdasd",
+		Args:    cobra.ExactArgs(1),
+		RunE:    createShim,
+	}
+
+	func init() {
+		// flags := initContainerCmd.Flags()
+
+		createShimCmd.SetHelpFunc(createShimHelp)
+		rootCmd.AddCommand(createShimCmd)
+	}
+
+	func createShim(cmd *cobra.Command, args []string) error {
+		if !utils.IsInsideContainer() {
+			var builder strings.Builder
+			fmt.Fprintf(&builder, "the 'create-shim' command can only be used inside containers\n")
+			fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
+
+			errMsg := builder.String()
+			return errors.New(errMsg)
+		}
+
+		shimBinary := fmt.Sprintf("/usr/libexec/toolbox/%s", args[0])
+
+		if !utils.PathExists(hostRunnerShim.containerPath) || !utils.PathExists(sudoShim.containerPath) {
+			var builder strings.Builder
+			fmt.Fprintf(&builder, "This toolbox container is not set up for creating binary shims\n")
+			fmt.Fprintf(&builder, "You're possibly trying to use a newer Toolbox in a container created with an older version\n")
+			fmt.Fprintf(&builder, "Try to update the Toolbox binary used by this container")
+
+			errMsg := builder.String()
+			return errors.New(errMsg)
+		}
+
+		if utils.PathExists(shimBinary) {
+			fmt.Printf("The requested shim binary already exists.\n")
+			return nil
+		}
+
+		err := redirectPath(shimBinary, hostRunnerShim.containerPath, false)
+		if err != nil {
+			return fmt.Errorf("Failed to create shim binary %s: %w", shimBinary, err)
+		}
+
+		return nil
+	}
+
+	func createShimHelp(cmd *cobra.Command, args []string) {
+		if utils.IsInsideContainer() {
+			if !utils.IsInsideToolboxContainer() {
+				fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+				return
+			}
+
+			if _, err := utils.ForwardToHost(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+				return
+			}
+
+			return
+		}
+
+		if err := utils.ShowManual("toolbox-create-shim"); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			return
+		}
+	}
+
+	func runOnHost(command string, commandLineArgs []string) (int, error) {
+		envOptions := utils.GetEnvOptionsForPreservedVariables()
+
+		var flatpakSpawnArgs []string
+
+		flatpakSpawnArgs = append(flatpakSpawnArgs, envOptions...)
+
+		flatpakSpawnArgs = append(flatpakSpawnArgs, []string{
+			"--host",
+			command,
+		}...)
+
+		flatpakSpawnArgs = append(flatpakSpawnArgs, commandLineArgs...)
+
+		logrus.Debug("Forwarding to host:")
+		logrus.Debugf("%s", command)
+		for _, arg := range commandLineArgs {
+			logrus.Debugf("%s", arg)
+		}
+
+		exitCode, err := shell.RunWithExitCode("flatpak-spawn", os.Stdin, os.Stdout, nil, flatpakSpawnArgs...)
+		if err != nil {
+			return exitCode, err
+		}
+
+		return exitCode, nil
+	}
+*/

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -45,6 +45,8 @@ var (
 		user        string
 	}
 
+	toolboxLibexecDirectory = "/usr/libexec/toolbox"
+
 	initContainerMounts = []struct {
 		containerPath string
 		source        string
@@ -56,6 +58,19 @@ var (
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},
+	}
+	hostRunnerShim = struct {
+		containerPath string
+		source        string
+	}{
+		"/usr/libexec/toolbox/host-runner", "/run/host/usr/libexec/toolbox/host-runner",
+	}
+
+	sudoShim = struct {
+		containerPath string
+		source        string
+	}{
+		"/usr/libexec/toolbox/sudo", "/run/host/usr/libexec/toolbox/sudo",
 	}
 )
 
@@ -270,6 +285,31 @@ func initContainer(cmd *cobra.Command, args []string) error {
 			kcmConfigBytes,
 			0644); err != nil {
 			return errors.New("failed to set KCM as the defult Kerberos credential cache")
+		}
+	}
+
+	logrus.Debugf("Creating directory libexec directory %s", toolboxLibexecDirectory)
+	if err := os.MkdirAll(toolboxLibexecDirectory, 0755); err != nil {
+		return fmt.Errorf("failed to create toolbox libexec directory %s: %w", toolboxLibexecDirectory, err)
+	}
+
+	// '/usr/libexec/toolbox/host-runner' is a script that makes use of 'flatpak-spawn
+	// --host' to run run commands from inside of a container on the host
+	if utils.PathExists(hostRunnerShim.source) {
+		logrus.Debugf("Seting up %s", hostRunnerShim.containerPath)
+		err = redirectPath(hostRunnerShim.containerPath, hostRunnerShim.source, false)
+		if err != nil {
+			return fmt.Errorf("failed to setup host-runner shim: %w", err)
+		}
+	}
+
+	// '/usr/libexec/toolbox/sudo' is a script that wraps around 'sudo' to make it
+	// possible to run commands from inside of a container on the host with sudo
+	if utils.PathExists(sudoShim.source) {
+		logrus.Debugf("Seting up %s", sudoShim.containerPath)
+		err = redirectPath(sudoShim.containerPath, sudoShim.source, false)
+		if err != nil {
+			return fmt.Errorf("failed to setup sudo shim: %w", err)
 		}
 	}
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,6 +6,7 @@ go_build_wrapper_program = find_program('go-build-wrapper')
 sources = files(
   'toolbox.go',
   'cmd/create.go',
+  'cmd/createShim.go',
   'cmd/enter.go',
   'cmd/help.go',
   'cmd/initContainer.go',


### PR DESCRIPTION
This PR adds support for creating binary shims in toolbox containers for binaries available on the host. This was heavily inspired by code snippets in https://github.com/containers/toolbox/issues/145. There's also very basic support for running the shim binaries with `sudo`.

Closes https://github.com/containers/toolbox/issues/145