### PR TITLE
pkg/utils: Drop length check when getting mount options

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -447,9 +447,6 @@ func GetMountOptions(target string) (string, error) {
 
 	output := stdout.String()
 	options := strings.Split(output, "\n")
-	if len(options) != 2 {
-		return "", errors.New("unexpected output from findmnt(1)")
-	}
 
 	mountOptions := strings.TrimSpace(options[0])
 	return mountOptions, nil


### PR DESCRIPTION
On Fedora Silverblue 33 the output of 'findmnt --noheadings --output
OPTIONS /usr' is:

  ro,relatime,seclabel,ssd,space_cache,subvolid=257,subvol=/root

(Fedora uses btrfs as it's default filesystem since version 33[0]). But
when you make the current deployment mutable using 'ostree admin unlock'
the output of the command changes to something like this:

  ro,relatime,seclabel,ssd,space_cache,subvolid=257,subvol=/root
  rw,relatime,seclabel,lowerdir=usr,upperdir=/var/tmp/ostree-unlock-ovl.JLXHQ0/upper,workdir=/var/tmp/ostree-unlock-ovl.JLXHQ0/work

This causes utils.GetMountOptions to error out preventing a successful
creation of a container with 'toolbox create' when the deployment is
unlocked.

For Toolbox the first line is the more relevant because even though /usr
is technically writeable, it will cease to be after reboot. This is the
current behaviour of the utils.GetMountOptions. Thanks to that I think
it's safe to remove the length check that prevents to create a container
when the current deployment is unlocked.

[0] https://fedoraproject.org/wiki/Changes/BtrfsByDefault