### PR TITLE
cmd/initContainer: Remove path on redirection when it exists

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -496,7 +496,7 @@ func redirectPath(containerPath, target string, folder bool) error {
 
 	err := os.Remove(containerPath)
 	if folder {
-		if err != nil {
+		if err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}
 


### PR DESCRIPTION
The `redirectPath()` function does not work correctly if `containerPath`
does not exist (like `/media`). The error message often looks like this:

```
Error: failed to redirect /media to /run/media: remove /media: no such file or directory
```

This makes `redirectPath` try to remove `containerPath` only if it exists.
The existence of `containerPath` is checked using `utils.PathExist()`.

Fixes #539 