### PR TITLE
Added 'boxhome' argument to toolbox create command

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -46,6 +46,7 @@ var (
 		distro    string
 		image     string
 		release   string
+		boxhome   string
 	}
 
 	createToolboxShMounts = []struct {
@@ -89,6 +90,12 @@ func init() {
 		"r",
 		"",
 		"Create a toolbox container for a different operating system release than the host")
+
+	flags.StringVarP(&createFlags.boxhome,
+		"boxhome",
+		"b",
+		"",
+		"Create a toolbox container with a different home path than the host.")
 
 	createCmd.SetHelpFunc(createHelp)
 	rootCmd.AddCommand(createCmd)
@@ -381,6 +388,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"init-container",
 		"--gid", currentUser.Gid,
 		"--home", currentUser.HomeDir,
+		"--boxhome", createFlags.boxhome,
 		"--shell", userShell,
 		"--uid", currentUser.Uid,
 		"--user", currentUser.Username,

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -38,6 +38,7 @@ var (
 	initContainerFlags struct {
 		gid         int
 		home        string
+		boxhome     string
 		homeLink    bool
 		mediaLink   bool
 		mntLink     bool
@@ -86,6 +87,12 @@ func init() {
 		"",
 		"Create a user inside the toolbox container whose login directory is HOME")
 	initContainerCmd.MarkFlagRequired("home")
+
+	fmt.Println(initContainerFlags.boxhome)
+	flags.StringVar(&initContainerFlags.boxhome,
+		"boxhome",
+		"",
+		"Create a user inside the toolbox container whose login directory is not HOME.")
 
 	flags.BoolVar(&initContainerFlags.homeLink,
 		"home-link",
@@ -228,7 +235,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	if _, err := user.Lookup(initContainerFlags.user); err != nil {
 		if err := configureUsers(initContainerFlags.uid,
 			initContainerFlags.user,
-			initContainerFlags.home,
+			initContainerFlags.home+"/"+initContainerFlags.boxhome,
 			initContainerFlags.shell,
 			initContainerFlags.homeLink,
 			false); err != nil {
@@ -237,7 +244,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	} else {
 		if err := configureUsers(initContainerFlags.uid,
 			initContainerFlags.user,
-			initContainerFlags.home,
+			initContainerFlags.home+"/"+initContainerFlags.boxhome,
 			initContainerFlags.shell,
 			initContainerFlags.homeLink,
 			true); err != nil {


### PR DESCRIPTION
Relates to issues #183, #348, #467
Added optional boxhome argument to create command.
Boxhome is concatenated with homedir in order to be under host's homedir.
Homedir is still mounted. No worries.
Being under host's home enables easy file sharing, and prevents privilege issues.
When boxhome argument is not given, system works as before (uses user's homedir)

User inside the toolbox would have different home path than user at host.
The box home folder is under the host home folder because of privileges.
This enables isolation between host and toolbox.
Host user's home dir is still mounted and does not effect file sharing.
Files created in the container is isolated thus can be easily deleted by user.
Several toolboxes can share same home by supplying the same home path.

Examples:
- Without specifying a home path
```
./toolbox create --container=hometest --image fedora-toolbox:latest && ./toolbox enter hometest       

Created container: hometest
Enter with: toolbox enter hometest

⬢[onurulu@toolbox src]$ echo $HOME
/home/onurulu/
```
- With specifying a home path
```
podman stop hometest && ./toolbox rm hometest

./toolbox create --container=hometest --image fedora-toolbox:latest --boxhome boxhome && ./toolbox enter hometest

Created container: hometest
Enter with: toolbox enter hometest


Welcome to the Toolbox; a container where you can install and run
all your tools.

 - Use DNF in the usual manner to install command line tools.
 - To create a new tools container, run 'toolbox create'.

For more information, see the documentation.

⬢[onurulu@toolbox src]$ echo $HOME
/home/onurulu/boxhome
```