### PR TITLE
Fix running of GUI apps from toolboxes

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -33,6 +33,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type initContainerMount struct {
+	containerPath string
+	source        string
+	flags         string
+}
+
+type initContainerSymlink struct {
+	containerPath string
+	source        string
+	folder        bool
+}
+
 var (
 	initContainerFlags struct {
 		home        string
@@ -45,11 +57,7 @@ var (
 		user        string
 	}
 
-	initContainerMounts = []struct {
-		containerPath string
-		source        string
-		flags         string
-	}{
+	initContainerMounts = []initContainerMount{
 		{"/etc/machine-id", "/run/host/etc/machine-id", "ro"},
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -494,12 +494,14 @@ func redirectPath(containerPath, target string, folder bool) error {
 	logrus.Debugf("Preparing to redirect %s to %s", containerPath, target)
 	targetSanitized := sanitizeRedirectionTarget(target)
 
-	err := os.Remove(containerPath)
-	if folder {
-		if err != nil {
+	if utils.PathExists(containerPath) {
+		err := os.Remove(containerPath)
+		if err != nil && folder {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}
+	}
 
+	if folder {
 		if err := os.MkdirAll(target, 0755); err != nil {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}


### PR DESCRIPTION
GNOME Shell 3.38 stopped using an abstract unix socket for communication with X for XWayland. This change causes GUI apps fail to start when ran from a toolbox. To fix this, the unix socket available in a container under `/run/host/tmp` needs to be available under `/tmp`.

Fixes #562 

PS: I'm marking this as WIP until the final solution is found. This seems to work but I'm wondering if we could simply mount `/run/host/tmp` to `/tmp` as a whole instead of cherry-picking what goes in or not.

PPS: I'm not entirely sure which of the symlinked paths are really necessary. I'd appreciate any insight on this because my knowledge of X is very limited.

PPPS: This also relies on some other patches to work/look properly so those will probably need to be merged first.