### PR TITLE
cmd/run: Use home folder when $PWD is not in toolbox

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -279,6 +279,15 @@ func runCommand(container string,
 		}
 	}
 
+	if pathPresent, _ := isPathPresent(container, workingDirectory); !pathPresent {
+		fmt.Fprintf(os.Stderr, "Error: path %s not found in container %s\n",
+			workingDirectory, container)
+		fmt.Fprintf(os.Stderr, "Using %s instead.\n",
+			currentUser.HomeDir)
+
+		workingDirectory = currentUser.HomeDir
+	}
+
 	logrus.Debug("Checking if 'podman exec' supports disabling the detach keys")
 
 	var detachKeys []string


### PR DESCRIPTION
Since v0.0.91[0] Toolbox throws an error if $PWD is not available in a
toolbox. While this fixes the problem with 'toolbox enter/run' silently
failing to enter/exec in a container, it still requires an action to be
made by the user. I believe it is better to handle such situations more
gracefully by falling back to entering the user's home folder + printing
a warning about doing so.

[0] https://github.com/containers/toolbox/pull/370