### PR TITLE
test/system: Test that toolboxes start alright

### DIFF
--- a/test/system/201-run.bats
+++ b/test/system/201-run.bats
@@ -2,6 +2,15 @@
 
 load helpers
 
+@test "Start the 'running' container" {
+  run_podman --log-level debug start running
+}
+
+@test "Logs of container 'running' look alright" {
+  run_podman logs running
+  is "${lines[${#lines[@]} - 1]}" "level=debug msg=\"Going to sleep\"" "The last line of the logs should say the entry-point went to sleep"
+}
+
 @test "Echo 'Hello World' inside of the default container" {
   run_toolbox run echo "Hello World"
   # is "$output" "Hello World" "Should say 'Hello World'"


### PR DESCRIPTION
This is useful for getting more info if a container fails to start. The current set of tests does not provide that information.