### PR TITLE
cmd/initContainer: Give access to /tmp from the host operating system

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -54,6 +54,7 @@ var (
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
+		{"/tmp", "/run/host/tmp", "rslave"},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},
@@ -143,16 +144,6 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	}
 
 	defer toolboxEnvFile.Close()
-
-	logrus.Debug("Mounting tmpfs at /tmp")
-
-	if err := syscall.Mount("tmpfs",
-		"/tmp",
-		"tmpfs",
-		syscall.MS_NODEV|syscall.MS_STRICTATIME|syscall.MS_NOSUID,
-		"mode=1777"); err != nil {
-		return fmt.Errorf("failed to mount tmpfs at /tmp: %s", err)
-	}
 
 	if initContainerFlags.monitorHost {
 		logrus.Debug("Monitoring host")


### PR DESCRIPTION
Some users tend to put random throwaway files in /tmp, so having that
location shared across the host operating system and toolbox containers
makes it a more pleasant user experience.

One nice side-effect of this is that it also makes the local file
system socket in /tmp/.X11-unix used by X11 clients available to
toolbox containers. So far, X11 clients inside toolbox containers used
the local abstract socket. However, since GNOME 3.38, Mutter no longer
listens on the abstract socket and only uses the file system socket to
start the Xwayland server [1]. Therefore, this makes it possible to
run X11 clients inside toolbox containers running on a GNOME 3.38 host.

[1] Mutter commit e2123768f635ee89
    https://gitlab.gnome.org/GNOME/mutter/-/issues/1289

https://github.com/containers/toolbox/issues/562