### PR TITLE
Fix warning for Ubuntu containers: "Error: terminfo entry not found for xterm-256color"

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -57,6 +57,7 @@ if [ -f /run/.containerenv ] \
 
         if [ "$TERMINFO" = "" ]; then
           ! [ -e "/usr/share/terminfo/$terminfo_sub_directory" ] \
+            && ! [ -e "/lib/terminfo/$terminfo_sub_directory" ] \
             && ! [ -e "$HOME/.terminfo/$terminfo_sub_directory" ] \
             && echo "$error_message" >&2
         else


### PR DESCRIPTION
On Ubuntu, both /usr/share/terminfo and /lib/terminfo can have contents, and xterm-256color is at /lib/terminfo (provided by ncurses-base package) while xterm+256color is at /usr/share/terminfo (provided by ncurses-term package). This PR checks both directory to suppress the warning.