### PR TITLE
src/go-build-wrapper: Support setting build options via env var

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -27,5 +27,5 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -trimpath -ldflags "-extldflags '-Wl,--wrap,pthread_sigmask $4' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2"
-exit "$?"
+# shellcheck disable=SC2086
+eval go build -o "$2" -trimpath -ldflags \"-extldflags \'-Wl,--wrap,pthread_sigmask $4\' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3\" ${GOBUILDFLAGS:-}


### PR DESCRIPTION
Toolbox uses a build wrapper that is used by Meson becase meson does not
support natively Go. That proved to be troublesome when we tried to
build Toolbox in Fedora's buildsystem that sets a number of CFLAGS,
LDFLAGS and Go specific flags. There was no way to pass those to the
wrapper, hence we hardcoded the most important ones using patches. With
this the patches can be dropped.

To pass an option to the 'go build' command, set GOBUILDFLAGS
environmental variable and export it.