### PR TITLE
src/go-build-wrapper: Explicitly specify final binary name

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -27,5 +27,5 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -trimpath -ldflags "-extldflags '-Wl,--wrap,pthread_sigmask $4' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2"
+go build -trimpath -ldflags "-extldflags '-Wl,--wrap,pthread_sigmask $4' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
 exit "$?"


### PR DESCRIPTION
In some environments (e.g., Fedora's build system) 'go build' takes the
last of path passed to the -o option and uses it for the final binary
name instead of using the project's name.