### PR TITLE
cmd/run: Run a login shell when falling back to Bash during 'enter'

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -263,7 +263,7 @@ func runCommand(container string,
 				container)
 			fmt.Fprintf(os.Stderr, "Using /bin/bash instead.\n")
 
-			command = []string{"/bin/bash"}
+			command = []string{"/bin/bash", "-l"}
 		} else {
 			return fmt.Errorf("command %s not found in container %s", command[0], container)
 		}


### PR DESCRIPTION
'toolbox enter' attempts to run the user's preferred shell as a login
shell by passing it the '-l' argument. However, when the user's
preferred shell is missing from the toolbox container and it falls
back to Bash, then it was no longer a login shell because the '-l'
argument went missing.