### PR TITLE
cmd/initContainer: Don't rely on user D-Bus to track time zone configuration

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -216,13 +216,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	dbusSystemSocketMountArg := dbusSystemSocket + ":" + dbusSystemSocket
 
-	flatpakHelperMonitorPath, err := utils.CallFlatpakSessionHelper()
-	if err != nil {
-		return err
-	}
-
-	flatpakHelperMonitorMountArg := flatpakHelperMonitorPath + ":/run/host/monitor"
-
 	homeDirEvaled, err := filepath.EvalSymlinks(currentUser.HomeDir)
 	if err != nil {
 		return fmt.Errorf("failed to canonicalize %s", currentUser.HomeDir)
@@ -371,7 +364,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"--volume", "/tmp:/run/host/tmp:rslave",
 		"--volume", "/var:/run/host/var:rslave",
 		"--volume", dbusSystemSocketMountArg,
-		"--volume", flatpakHelperMonitorMountArg,
 		"--volume", homeDirMountArg,
 		"--volume", toolboxPathMountArg,
 		"--volume", usrMountArg,

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -168,6 +168,15 @@ func initContainer(cmd *cobra.Command, args []string) error {
 				}
 			}
 
+			if localtimeTarget, err := os.Readlink("/etc/localtime"); err != nil ||
+				localtimeTarget != "/run/host/etc/localtime" {
+				if err := redirectPath("/etc/localtime",
+					"/run/host/etc/localtime",
+					false); err != nil {
+					return err
+				}
+			}
+
 			if _, err := os.Readlink("/etc/resolv.conf"); err != nil {
 				if err := redirectPath("/etc/resolv.conf",
 					"/run/host/etc/resolv.conf",
@@ -191,14 +200,6 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 		if utils.PathExists("/run/host/monitor") {
 			logrus.Debug("Path /run/host/monitor exists")
-
-			if localtimeTarget, err := os.Readlink("/etc/localtime"); err != nil ||
-				localtimeTarget != "/run/host/monitor/localtime" {
-				if err := redirectPath("/etc/localtime",
-					"/run/host/monitor/localtime", false); err != nil {
-					return err
-				}
-			}
 
 			if _, err := os.Readlink("/etc/timezone"); err != nil {
 				if err := redirectPath("/etc/timezone",

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -209,7 +209,7 @@ func runCommand(container string,
 		}
 	}
 
-	if _, err := utils.CallFlatpakSessionHelper(); err != nil {
+	if err := callFlatpakSessionHelper(container); err != nil {
 		return err
 	}
 
@@ -365,6 +365,37 @@ func runHelp(cmd *cobra.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 		return
 	}
+}
+
+func callFlatpakSessionHelper(container string) error {
+	logrus.Debugf("Inspecting mounts of container %s", container)
+
+	info, err := podman.Inspect("container", container)
+	if err != nil {
+		return fmt.Errorf("failed to inspect entry point of container %s", container)
+	}
+
+	var needsFlatpakSessionHelper bool
+
+	mounts := info["Mounts"].([]interface{})
+	for _, mount := range mounts {
+		destination := mount.(map[string]interface{})["Destination"].(string)
+		if destination == "/run/host/monitor" {
+			logrus.Debug("Requires org.freedesktop.Flatpak.SessionHelper")
+			needsFlatpakSessionHelper = true
+			break
+		}
+	}
+
+	if !needsFlatpakSessionHelper {
+		return nil
+	}
+
+	if _, err := utils.CallFlatpakSessionHelper(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func getEntryPointAndPID(container string) (string, int, error) {

--- a/src/go.mod
+++ b/src/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
 	github.com/briandowns/spinner v1.10.0
 	github.com/docker/go-units v0.4.0
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5

--- a/src/go.sum
+++ b/src/go.sum
@@ -16,6 +16,7 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -113,7 +113,7 @@ function run_toolbox() {
 
 function is_toolbox_ready() {
     toolbox_container="$1"
-    expected_string="Going to sleep"
+    expected_string="Listening to file system events"
     num_of_tries=5
     timeout=2
 


### PR DESCRIPTION
This is one more step towards enabling toolbox(1) to be run as root.
When invoked as 'sudo toolbox ...' there's no user or session D-Bus
instance available for the root user, which prevents the use of D-Bus
services like o.fd.Flatpak.SessionHelper.

https://github.com/containers/toolbox/issues/267