### PR TITLE
test/system: Rework check if toolbox started successfully

### DIFF
--- a/test/system/201-run.bats
+++ b/test/system/201-run.bats
@@ -2,13 +2,10 @@
 
 load helpers
 
-@test "Start the 'running' container" {
+@test "Start the 'running' container and check it started alright" {
   run_podman --log-level debug start running
-}
 
-@test "Logs of container 'running' look alright" {
-  run_podman logs running
-  is "${lines[${#lines[@]} - 1]}" "level=debug msg=\"Going to sleep\"" "The last line of the logs should say the entry-point went to sleep"
+  is_toolbox_ready running
 }
 
 @test "Echo 'Hello World' inside of the default container" {

--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -109,6 +109,32 @@ function run_toolbox() {
     fi
 }
 
+# Toolbox helper functions
+
+function is_toolbox_ready() {
+    toolbox_container="$1"
+    expected_string="Going to sleep"
+    num_of_tries=5
+    timeout=2
+
+    run_podman logs $toolbox_container
+
+    for ((i = 0; i < $num_of_tries; i++)); do
+        if [[ "$output" =~ .*"$expected_string".* ]]; then
+            return
+        fi
+
+        sleep $timeout
+        run_podman logs $toolbox_container
+    done
+
+    echo "Output of 'podman logs $toolbox_container':"
+    echo "$output"
+    echo ""
+
+    die "container $toolbox_container was not ready in time"
+}
+
 # Functions to prepare environment
 
 


### PR DESCRIPTION
When I added the test that looked at the logs of a toolbox, I did not
realize that the startup of a toolbox takes some time. That caused the
CI to flake even more than usual.

The solution I used was inspired by a helper function in Podman's test
suite (WaitContainerReady()).