### PR TITLE
README.md: Improve the introductory paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 [![Arch Linux package](https://img.shields.io/archlinux/v/community/x86_64/toolbox)](https://www.archlinux.org/packages/community/x86_64/toolbox/)
 [![Fedora package](https://img.shields.io/fedora/v/toolbox/rawhide)](https://src.fedoraproject.org/rpms/toolbox/)
 
-[Toolbox](https://github.com/containers/toolbox) is a tool that offers a
-familiar package based environment for developing and debugging software that
-runs fully unprivileged using [Podman](https://podman.io/).
+[Toolbox](https://github.com/containers/toolbox) is a tool for Linux operating
+systems, which allows the use of containerized command line environments. It is
+built on top of [Podman](https://podman.io/) and other standard container
+technologies from [OCI](https://opencontainers.org/).
 
 The toolbox container is a fully *mutable* container; when you see
 `yum install ansible` for example, that's something you can do inside your


### PR DESCRIPTION
Using the word 'unprivileged' confuses readers because it means
different things to different people. eg., it can mean 'rootless' or
'sandboxed', which are quite different things. It becomes even more
confusing given the ongoing work to make 'sudo toolbox ...' work.

It's nice to mention that Toolbox is targetted at Linux operating
systems and that it relies on standard container technologies from OCI.