### PR TITLE
cmd/create: Expose the host's /boot inside the container at /run/host

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -358,6 +358,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, []string{
 		"--userns=keep-id",
 		"--user", "root:root",
+		"--volume", "/boot:/run/host/boot:rslave",
 		"--volume", "/etc:/run/host/etc",
 		"--volume", "/dev:/dev:rslave",
 		"--volume", "/run:/run/host/run:rslave",


### PR DESCRIPTION
As requested by Colin Walters.