### PR TITLE
cmd/run: Pass the UID when notifying the terminal about the container

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -317,7 +317,7 @@ func runCommand(container string,
 	exitCode, err := shell.RunWithExitCode("podman", os.Stdin, os.Stdout, nil, execArgs...)
 
 	if emitEscapeSequence {
-		fmt.Print("\033]777;container;pop;;\033\\")
+		fmt.Print("\033]777;container;pop;%s;toolbox\033\\", container)
 	}
 
 	switch exitCode {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -305,7 +305,7 @@ func runCommand(container string,
 	execArgs = append(execArgs, command...)
 
 	if emitEscapeSequence {
-		fmt.Printf("\033]777;container;push;%s;toolbox\033\\", container)
+		fmt.Printf("\033]777;container;push;%s;toolbox;%s\033\\", container, currentUser.Uid)
 	}
 
 	logrus.Debugf("Running in container %s:", container)
@@ -317,7 +317,7 @@ func runCommand(container string,
 	exitCode, err := shell.RunWithExitCode("podman", os.Stdin, os.Stdout, nil, execArgs...)
 
 	if emitEscapeSequence {
-		fmt.Print("\033]777;container;pop;%s;toolbox\033\\", container)
+		fmt.Print("\033]777;container;pop;%s;toolbox;%s\033\\", container, currentUser.Uid)
 	}
 
 	switch exitCode {


### PR DESCRIPTION
This is one more step towards enabling toolbox(1) to be run as root.
When invoked as 'sudo toolbox enter', GNOME Terminal might choose not
to preserve the current toolbox container when opening a new terminal.
This is similar to how the current working directory of a 'su -'
session isn't preserved when opening a new terminal.

https://github.com/containers/toolbox/issues/267