### PR TITLE
cmd/initContainer: Make locate(1) work inside toolbox containers

### DIFF
--- a/test/system/helpers.bash
+++ b/test/system/helpers.bash
@@ -113,7 +113,7 @@ function run_toolbox() {
 
 function is_toolbox_ready() {
     toolbox_container="$1"
-    expected_string="Listening to file system events"
+    expected_string="Listening to file system and ticker events"
     num_of_tries=5
     timeout=2
 


### PR DESCRIPTION
... by running updatedb(8) at 24 hour intervals.

https://github.com/containers/toolbox/issues/391