### PR TITLE
src/cmd, playbooks: Drop image prefix for fedora-toolbox

### DIFF
--- a/images/fedora/f32/Dockerfile
+++ b/images/fedora/f32/Dockerfile
@@ -4,7 +4,7 @@ ENV NAME=fedora-toolbox VERSION=32
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
-      name="$FGC/$NAME" \
+      name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
       summary="Base image for creating Fedora toolbox containers" \

--- a/images/fedora/f33/Dockerfile
+++ b/images/fedora/f33/Dockerfile
@@ -4,7 +4,7 @@ ENV NAME=fedora-toolbox VERSION=33
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
-      name="$FGC/$NAME" \
+      name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
       summary="Base image for creating Fedora toolbox containers" \

--- a/images/fedora/f34/Dockerfile
+++ b/images/fedora/f34/Dockerfile
@@ -4,7 +4,7 @@ ENV NAME=fedora-toolbox VERSION=34
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
       com.redhat.component="$NAME" \
-      name="$FGC/$NAME" \
+      name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
       summary="Base image for creating Fedora toolbox containers" \

--- a/playbooks/fedora-32/setup-env.yaml
+++ b/playbooks/fedora-32/setup-env.yaml
@@ -44,8 +44,8 @@
     - name: Show podman debug information
       command: podman info --debug
 
-    - name: Pull registry.fedoraproject.org/f32/fedora-toolbox:32
-      command: podman pull registry.fedoraproject.org/f32/fedora-toolbox:32
+    - name: Pull registry.fedoraproject.org/fedora-toolbox:32
+      command: podman pull registry.fedoraproject.org/fedora-toolbox:32
       register: _podman
       until: _podman.rc == 0
       retries: 5

--- a/playbooks/fedora-33/setup-env.yaml
+++ b/playbooks/fedora-33/setup-env.yaml
@@ -44,8 +44,8 @@
     - name: Show podman debug information
       command: podman info --debug
 
-    - name: Pull registry.fedoraproject.org/f33/fedora-toolbox:33
-      command: podman pull registry.fedoraproject.org/f33/fedora-toolbox:33
+    - name: Pull registry.fedoraproject.org/fedora-toolbox:33
+      command: podman pull registry.fedoraproject.org/fedora-toolbox:33
       register: _podman
       until: _podman.rc == 0
       retries: 5

--- a/playbooks/fedora-34/setup-env.yaml
+++ b/playbooks/fedora-34/setup-env.yaml
@@ -44,8 +44,8 @@
     - name: Show podman debug information
       command: podman info --debug
 
-    - name: Pull registry.fedoraproject.org/f34/fedora-toolbox:34
-      command: podman pull registry.fedoraproject.org/f34/fedora-toolbox:34
+    - name: Pull registry.fedoraproject.org/fedora-toolbox:34
+      command: podman pull registry.fedoraproject.org/fedora-toolbox:34
       register: _podman
       until: _podman.rc == 0
       retries: 5

--- a/playbooks/fedora-rawhide/setup-env.yaml
+++ b/playbooks/fedora-rawhide/setup-env.yaml
@@ -44,8 +44,8 @@
     - name: Show podman debug information
       command: podman info --debug
 
-    - name: Pull registry.fedoraproject.org/f34/fedora-toolbox:34
-      command: podman pull registry.fedoraproject.org/f34/fedora-toolbox:34
+    - name: Pull registry.fedoraproject.org/fedora-toolbox:34
+      command: podman pull registry.fedoraproject.org/fedora-toolbox:34
       register: _podman
       until: _podman.rc == 0
       retries: 5

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -98,8 +98,8 @@ var (
 			"fedora-toolbox",
 			parseReleaseFedora,
 			"registry.fedoraproject.org",
-			"f%s",
-			true,
+			"",
+			false,
 		},
 		"rhel": {
 			"rhel-toolbox",
@@ -345,7 +345,13 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 			repository = distroObj.Repository
 		}
 
-		imageFull := distroObj.Registry + "/" + repository + "/" + image
+		imageFull := distroObj.Registry
+
+		if repository != "" {
+			imageFull = imageFull + "/" + repository
+		}
+
+		imageFull = imageFull + "/" + image
 
 		logrus.Debugf("Resolved image %s to %s", image, imageFull)
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -28,7 +28,7 @@ teardown() {
 }
 
 @test "create: Create a container with a custom image and name ('fedora29'; f29)" {
-  pull_image 29
+  pull_image_old 29
 
   run toolbox -y create -c "fedora29" -i fedora-toolbox:29
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -50,7 +50,7 @@ teardown() {
 @test "list: Try to list images and containers (no flag) with 3 containers and 2 images (the list should have 3 images and 2 containers)" {
   # Pull the two images
   pull_default_image
-  pull_image 29
+  pull_image_old 29
   # Create tree containers
   create_default_container
   create_container non-default-one

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -34,6 +34,31 @@ function pull_image() {
   local -i max_retries
   local -i wait_time
   version="$1"
+  image="${REGISTRY_URL}/fedora-toolbox:${version}"
+  count=0
+  max_retries=5
+  wait_time=15
+
+  until ${PODMAN} pull "${image}" >/dev/null ; do
+    sleep $wait_time
+    (( count += 1 ))
+
+    if (( "$count" == "$max_retries" )); then
+      # Max number of retries exceeded
+      echo "Podman couldn't pull the image ${image}."
+      return 1
+    fi
+  done
+}
+
+
+function pull_image_old() {
+  local version
+  local image
+  local -i count
+  local -i max_retries
+  local -i wait_time
+  version="$1"
   image="${REGISTRY_URL}/f${version}/fedora-toolbox:${version}"
   count=0
   max_retries=5
@@ -63,7 +88,7 @@ function create_container() {
   local image
   container_name="$1"
   version="$DEFAULT_FEDORA_VERSION"
-  image="${REGISTRY_URL}/f${version}/fedora-toolbox:${version}"
+  image="${REGISTRY_URL}/fedora-toolbox:${version}"
 
   pull_image "$version"
 


### PR DESCRIPTION
Due to historical reasons, the 'fedora-toolbox' image hosted in Fedora's
image registry[0] needed to have a special prefix (so called Fedora
generational core). That puts more strain on the image registry because
the toolbox images are periodically refreshed and the previous ones are
kept in the registry. Also, the code of Toolbox needed to account for
this.

This special prefix is no longer required and so we'll start creating
images simply called 'fedora-toolbox'. To be able to use them, Toolbox
needs to be updated, too.

This cannot be merged until all required `fedora-toolbox` images are
available for use.

Here's a [link](https://src.fedoraproject.org/container/fedora-toolbox/pull-request/2) to the PR in Fedora's dist-git to remove the prefix.