### PR TITLE
cmd/create: Use the host's user namespace when running as root

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -227,6 +227,13 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		ulimitHost = []string{"--ulimit", "host"}
 	}
 
+	var usernsArg string
+	if currentUser.Uid == "0" {
+		usernsArg = "host"
+	} else {
+		usernsArg = "keep-id"
+	}
+
 	dbusSystemSocket, err := getDBusSystemSocket()
 	if err != nil {
 		return err
@@ -376,7 +383,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, ulimitHost...)
 
 	createArgs = append(createArgs, []string{
-		"--userns=keep-id",
+		"--userns", usernsArg,
 		"--user", "root:root",
 		"--volume", "/boot:/run/host/boot:rslave",
 		"--volume", "/etc:/run/host/etc",


### PR DESCRIPTION
One of the biggest advantages of running as root is the ability to have
all the UIDs from the host operating system mapped into the container
by using the host's user namespace.

This can be a big help when faced with permission problems.

https://github.com/containers/toolbox/issues/267