### PR TITLE
Deprecate the --monitor-host option of 'init-container'

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -68,7 +68,7 @@ and grants it `sudo` and `root` access.
 Crucial configuration files, such as `/etc/host.conf`, `/etc/hosts`,
 `/etc/localtime`, `/etc/resolv.conf` and `/etc/timezone`, inside the container
 are kept synchronized with the host. The entry point also bind mounts various
-subsets of the host's filesystem hierarchy to their corresponding locations
+subsets of the host's file system hierarchy to their corresponding locations
 inside the container to provide seamless integration with the host. This
 includes `/run/libvirt`, `/run/systemd/journal`, `/run/udev/data`,
 `/var/lib/libvirt`, `/var/lib/systemd/coredump`, `/var/log/journal` and others.

--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -38,7 +38,7 @@ and grants it `sudo` and `root` access.
 Crucial configuration files, such as `/etc/host.conf`, `/etc/hosts`,
 `/etc/localtime`, `/etc/resolv.conf` and `/etc/timezone`, inside the container
 are kept synchronized with the host. The entry point also bind mounts various
-subsets of the host's filesystem hierarchy to their corresponding locations
+subsets of the host's file system hierarchy to their corresponding locations
 inside the container to provide seamless integration with the host. This
 includes `/run/libvirt`, `/run/systemd/journal`, `/run/udev/data`,
 `/var/lib/libvirt`, `/var/lib/systemd/coredump`, `/var/log/journal` and others.

--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -9,7 +9,6 @@ toolbox\-init\-container - Initialize a running container
                        *--home-link*
                        *--media-link*
                        *--mnt-link*
-                       *--monitor-host*
                        *--shell SHELL*
                        *--uid UID*
                        *--user USER*
@@ -76,31 +75,12 @@ Make `/mnt` a symbolic link to `/var/mnt`.
 
 **--monitor-host**
 
-Ensures that certain configuration files inside the toolbox container are kept
-synchronized with their counterparts on the host, and bind mounts some paths
-from the host's file system into the container.
+Deprecated, does nothing.
 
-The synchronized files are:
-
-- `/etc/host.conf`
-- `/etc/hosts`
-- `/etc/localtime`
-- `/etc/resolv.conf`
-- `/etc/timezone`
-
-The bind mounted paths are:
-
-- `/etc/machine-id`
-- `/run/libvirt`
-- `/run/systemd/journal`
-- `/run/systemd/resolve`
-- `/run/udev/data`
-- `/tmp`
-- `/var/lib/flatpak`
-- `/var/lib/libvirt`
-- `/var/lib/systemd/coredump`
-- `/var/log/journal`
-- `/var/mnt`
+Crucial configuration files inside the toolbox container are always kept
+synchronized with their counterparts on the host, and various subsets of the
+host's file system hierarchy are always bind mounted to their corresponding
+locations inside the toolbox container.
 
 **--shell** SHELL
 

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -386,7 +386,6 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		"--shell", userShell,
 		"--uid", currentUser.Uid,
 		"--user", currentUser.Username,
-		"--monitor-host",
 	}
 
 	entryPoint = append(entryPoint, slashHomeLink...)

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -523,7 +523,7 @@ func mountBind(containerPath, source, flags string) error {
 }
 
 // redirectPath serves for creating symbolic links for crucial system
-// configuration files to their counterparts on the host's filesystem.
+// configuration files to their counterparts on the host's file system.
 //
 // containerPath and target must be absolute paths
 //


### PR DESCRIPTION
The --monitor-host option was added to the 'init-container' command in
commit 8b84b5e4604921fa to accommodate Podman versions older than 1.2.0
that didn't have the '--dns none' and '--no-hosts' options for
'podman create'.  These options are necessary to keep the Toolbx
container's /etc/resolv.conf and /etc/hosts files synchronized with
those of the host.

Note that Podman 1.2.0 was already available a few months before
commit 8b84b5e4604921fa introduced the --monitor-host option.  The
chances of someone using an older Podman back then was already on the
decline, and it's very unlikely that a container created with such a
Podman has survived till this date.

Commit b6b484fa792b442a raised the minimum required Podman version to
1.4.0, and made the '--dns none' and '--no-hosts' options a hard
requirement.  The minimum required Podman version was again raised
recently in commit 8e80dd5db1e6f40b to 1.6.4.  Therefore, these days,
there's no need to separately use the --monitor-host option of
'init-container' for newly created containers to indicate that the
Podman version wasn't older than 1.2.0.

Given all this, it's time to stop using the --monitor-host option of
'init-container', and assume that it's always set.  The option is still
accepted to retain compatibility with existing Toolbx containers.

For containers that were created with the --monitor-host option, a
deprecation notice will be shown as:
```
  $ podman start --attach CONTAINER
  Flag --monitor-host has been deprecated, it does nothing
  ...
```