### PR TITLE
profile.d: Don't leak all the os-release fields into the shell

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -5,8 +5,14 @@ toolbox_config="$HOME/.config/toolbox"
 host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 
-# shellcheck disable=SC1091
-. /usr/lib/os-release
+# shellcheck disable=2046
+eval $(
+          # shellcheck disable=SC1091
+          . /usr/lib/os-release
+
+          echo ID="$ID"
+          echo VARIANT_ID="$VARIANT_ID"
+      )
 
 if [ -f /run/ostree-booted ] \
    && ! [ -f "$host_welcome_stub" ] \


### PR DESCRIPTION
All the fields defined in /usr/lib/os-release were being injected into
the shell as environment variables. This is unintentional. Some of the
variables have relatively generic names, and having them in the
environment can lead to unexpected surprises.

Fallout from c6e37cdef37e2276207b34a42919f1e0ac4a04dc