### PR TITLE
Mount Avahi Daemon socket inside the toolbox container

### DIFF
--- a/images/fedora/f28/extra-packages
+++ b/images/fedora/f28/extra-packages
@@ -18,6 +18,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 PackageKit-command-not-found
 passwd

--- a/images/fedora/f29/extra-packages
+++ b/images/fedora/f29/extra-packages
@@ -19,6 +19,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz

--- a/images/fedora/f30/extra-packages
+++ b/images/fedora/f30/extra-packages
@@ -19,6 +19,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz

--- a/images/fedora/f31/extra-packages
+++ b/images/fedora/f31/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz

--- a/images/fedora/f32/extra-packages
+++ b/images/fedora/f32/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz

--- a/images/fedora/f33/extra-packages
+++ b/images/fedora/f33/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz

--- a/images/fedora/f34/extra-packages
+++ b/images/fedora/f34/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nss-mdns
 openssh-clients
 passwd
 pigz


### PR DESCRIPTION
This series mounts the Avahi daemon socket inside the toolbox container and adds the needed dependencies for having Avahi working out of the box (avahi & nss-mdns).

/cc @debarshiray @HarryMichal 

It also fixes https://github.com/containers/toolbox/issues/209