### PR TITLE
Access coredump log from toolbox.

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -58,6 +58,7 @@ var (
 		{"/tmp", "/run/host/tmp", "rslave"},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/lib/libvirt", "/run/host/var/lib/libvirt", ""},
+		{"/var/lib/systemd/coredump", "/run/host/var/lib/systemd/coredump", "ro"},
 		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},
 	}


### PR DESCRIPTION
Hi!


I simply add the mapping of `/run/host/var/lib/systemd/coredump` to `/var/lib/systemd/coredump` so `coredump` can be used to read coredump file inside the toolbox.
To test it, simply run the following:
```bash
me@host:~$ toolbox enter
...
me@toolbox:~$ perl -e 'unpack p, 1x8'
Segmentation fault (core dumped)
me@toolbox:~$ coredumpctl dump
PID: 3545 (perl)
           UID: 1000 (me)
           GID: 1000 (me)
        Signal: 11 (SEGV)
     Timestamp: Mon 2020-11-23 21:18:56 CET (52s ago)
  Command Line: perl -e unpack p, 1x8
    Executable: /usr/bin/perl
...
```

I took a bit of time to figure out this PR because I was using `./toolbox` to test my code which is a shell script and not the go code I was modifying...
By the way, how the old shell script is still used in `toolbox`?


Best regards.