### PR TITLE
cmd: Remove periods at the end of flag descriptions

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -69,19 +69,19 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Assign a different name to the toolbox container.")
+		"Assign a different name to the toolbox container")
 
 	flags.StringVarP(&createFlags.image,
 		"image",
 		"i",
 		"",
-		"Change the name of the base image used to create the toolbox container.")
+		"Change the name of the base image used to create the toolbox container")
 
 	flags.StringVarP(&createFlags.release,
 		"release",
 		"r",
 		"",
-		"Create a toolbox container for a different operating system release than the host.")
+		"Create a toolbox container for a different operating system release than the host")
 
 	createCmd.SetHelpFunc(createHelp)
 	rootCmd.AddCommand(createCmd)

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -46,13 +46,13 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Enter a toolbox container with the given name.")
+		"Enter a toolbox container with the given name")
 
 	flags.StringVarP(&enterFlags.release,
 		"release",
 		"r",
 		"",
-		"Enter a toolbox container for a different operating system release than the host.")
+		"Enter a toolbox container for a different operating system release than the host")
 
 	enterCmd.SetHelpFunc(enterHelp)
 	rootCmd.AddCommand(enterCmd)

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -77,42 +77,42 @@ func init() {
 	flags.StringVar(&initContainerFlags.home,
 		"home",
 		"",
-		"Create a user inside the toolbox container whose login directory is HOME.")
+		"Create a user inside the toolbox container whose login directory is HOME")
 	initContainerCmd.MarkFlagRequired("home")
 
 	flags.BoolVar(&initContainerFlags.homeLink,
 		"home-link",
 		false,
-		"Make /home a symbolic link to /var/home.")
+		"Make /home a symbolic link to /var/home")
 
 	flags.BoolVar(&initContainerFlags.mediaLink,
 		"media-link",
 		false,
-		"Make /media a symbolic link to /run/media.")
+		"Make /media a symbolic link to /run/media")
 
-	flags.BoolVar(&initContainerFlags.mntLink, "mnt-link", false, "Make /mnt a symbolic link to /var/mnt.")
+	flags.BoolVar(&initContainerFlags.mntLink, "mnt-link", false, "Make /mnt a symbolic link to /var/mnt")
 
 	flags.BoolVar(&initContainerFlags.monitorHost,
 		"monitor-host",
 		false,
-		"Ensure that certain configuration files inside the toolbox container are in sync with the host.")
+		"Ensure that certain configuration files inside the toolbox container are in sync with the host")
 
 	flags.StringVar(&initContainerFlags.shell,
 		"shell",
 		"",
-		"Create a user inside the toolbox container whose login shell is SHELL.")
+		"Create a user inside the toolbox container whose login shell is SHELL")
 	initContainerCmd.MarkFlagRequired("shell")
 
 	flags.IntVar(&initContainerFlags.uid,
 		"uid",
 		0,
-		"Create a user inside the toolbox container whose numerical user ID is UID.")
+		"Create a user inside the toolbox container whose numerical user ID is UID")
 	initContainerCmd.MarkFlagRequired("uid")
 
 	flags.StringVar(&initContainerFlags.user,
 		"user",
 		"",
-		"Create a user inside the toolbox container whose login name is USER.")
+		"Create a user inside the toolbox container whose login name is USER")
 	initContainerCmd.MarkFlagRequired("user")
 
 	initContainerCmd.SetHelpFunc(initContainerHelp)

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -64,13 +64,13 @@ func init() {
 		"containers",
 		"c",
 		false,
-		"List only toolbox containers, not images.")
+		"List only toolbox containers, not images")
 
 	flags.BoolVarP(&listFlags.onlyImages,
 		"images",
 		"i",
 		false,
-		"List only toolbox images, not containers.")
+		"List only toolbox images, not containers")
 
 	listCmd.SetHelpFunc(listHelp)
 	rootCmd.AddCommand(listCmd)

--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -44,13 +44,13 @@ var rmCmd = &cobra.Command{
 func init() {
 	flags := rmCmd.Flags()
 
-	flags.BoolVarP(&rmFlags.deleteAll, "all", "a", false, "Remove all toolbox containers.")
+	flags.BoolVarP(&rmFlags.deleteAll, "all", "a", false, "Remove all toolbox containers")
 
 	flags.BoolVarP(&rmFlags.forceDelete,
 		"force",
 		"f",
 		false,
-		"Force the removal of running and paused toolbox containers.")
+		"Force the removal of running and paused toolbox containers")
 
 	rmCmd.SetHelpFunc(rmHelp)
 	rootCmd.AddCommand(rmCmd)

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -44,13 +44,13 @@ var rmiCmd = &cobra.Command{
 func init() {
 	flags := rmiCmd.Flags()
 
-	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all toolbox containers.")
+	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all toolbox containers")
 
 	flags.BoolVarP(&rmiFlags.forceDelete,
 		"force",
 		"f",
 		false,
-		"Force the removal of running and paused toolbox containers.")
+		"Force the removal of running and paused toolbox containers")
 
 	rmiCmd.SetHelpFunc(rmiHelp)
 	rootCmd.AddCommand(rmiCmd)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -81,19 +81,19 @@ func init() {
 		"assumeyes",
 		"y",
 		false,
-		"Automatically answer yes for all questions.")
+		"Automatically answer yes for all questions")
 
 	persistentFlags.StringVar(&rootFlags.logLevel,
 		"log-level",
 		"error",
-		"Log messages at the specified level: trace, debug, info, warn, error, fatal or panic.")
+		"Log messages at the specified level: trace, debug, info, warn, error, fatal or panic")
 
 	persistentFlags.BoolVar(&rootFlags.logPodman,
 		"log-podman",
 		false,
-		"Show the log output of Podman. The log level is handled by the log-level option.")
+		"Show the log output of Podman. The log level is handled by the log-level option")
 
-	persistentFlags.CountVarP(&rootFlags.verbose, "verbose", "v", "Set log-level to 'debug'.")
+	persistentFlags.CountVarP(&rootFlags.verbose, "verbose", "v", "Set log-level to 'debug'")
 
 	rootCmd.SetHelpFunc(rootHelp)
 	rootCmd.SetUsageFunc(rootUsage)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -51,13 +51,13 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Run command inside a toolbox container with the given name.")
+		"Run command inside a toolbox container with the given name")
 
 	flags.StringVarP(&runFlags.release,
 		"release",
 		"r",
 		"",
-		"Run command inside a toolbox container for a different operating system release than the host.")
+		"Run command inside a toolbox container for a different operating system release than the host")
 
 	runCmd.SetHelpFunc(runHelp)
 	rootCmd.AddCommand(runCmd)


### PR DESCRIPTION
I noticed we put periods at the end of descriptions of flags while most tools (e.g. git, podman, skopeo, buildah, tools from coreutils,..) do not. Let's not deviate :). This is not very pressing because we don't show the description anyway.