### PR TITLE
cmd/create: Make options --image and --release mutually exclusive

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -102,6 +102,9 @@ func create(cmd *cobra.Command, args []string) error {
 
 	var container string
 	var containerArg string
+	if cmd.Flag("image").Changed && cmd.Flag("release").Changed {
+		return errors.New("options --image and --release cannot be used together")
+	}
 
 	if len(args) != 0 {
 		container = args[0]


### PR DESCRIPTION
These two options are incompatible -> make them mutually exclusive.