### PR TITLE
cmd/create: Make hint more accurate

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -116,7 +116,7 @@ func create(cmd *cobra.Command, args []string) error {
 			var builder strings.Builder
 			fmt.Fprintf(&builder, "invalid argument for '%s'\n", containerArg)
 			fmt.Fprintf(&builder, "Container names must match '%s'\n", utils.ContainerNameRegexp)
-			fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
+			fmt.Fprintf(&builder, "Run '%s create --help' for usage.", executableBase)
 
 			errMsg := builder.String()
 			return errors.New(errMsg)


### PR DESCRIPTION
The hint is printed only when 'toolbox create' is run. The hint should suggest to run 'toolbox create --help' instead of 'toolbox --help'.