### PR TITLE
Correctly check validity of container name

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -115,7 +115,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	if container != "" {
-		if _, err := utils.IsContainerNameValid(container); err != nil {
+		if !utils.IsContainerNameValid(container) {
 			var builder strings.Builder
 			fmt.Fprintf(&builder, "invalid argument for '%s'\n", containerArg)
 			fmt.Fprintf(&builder, "Container names must match '%s'\n", utils.ContainerNameRegexp)

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -86,7 +86,7 @@ func enter(cmd *cobra.Command, args []string) error {
 	if container != "" {
 		nonDefaultContainer = true
 
-		if _, err := utils.IsContainerNameValid(container); err != nil {
+		if !utils.IsContainerNameValid(container) {
 			var builder strings.Builder
 			fmt.Fprintf(&builder, "invalid argument for '%s'\n", containerArg)
 			fmt.Fprintf(&builder, "Container names must match '%s'\n", utils.ContainerNameRegexp)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -81,7 +81,7 @@ func run(cmd *cobra.Command, args []string) error {
 	if runFlags.container != "" {
 		nonDefaultContainer = true
 
-		if _, err := utils.IsContainerNameValid(runFlags.container); err != nil {
+		if !utils.IsContainerNameValid(runFlags.container) {
 			var builder strings.Builder
 			fmt.Fprintf(&builder, "invalid argument for '--container'\n")
 			fmt.Fprintf(&builder, "Container names must match '%s'\n", utils.ContainerNameRegexp)

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -497,10 +497,15 @@ func PathExists(path string) bool {
 }
 
 // IsContainerNameValid checks if the name of a container matches the right pattern
-func IsContainerNameValid(containerName string) (bool, error) {
+func IsContainerNameValid(containerName string) bool {
 	pattern := "^" + ContainerNameRegexp + "$"
 	matched, err := regexp.MatchString(pattern, containerName)
-	return matched, err
+	if err != nil {
+		panicMsg := fmt.Sprintf("failed to parse regular expression for container name: %v", err)
+		panic(panicMsg)
+	}
+
+	return matched
 }
 
 func IsInsideContainer() bool {

--- a/test/system/102-create.bats
+++ b/test/system/102-create.bats
@@ -16,5 +16,5 @@ load helpers
 
 @test "Try to create a container with invalid custom name" {
   run_toolbox 1 -y create "ßpeci@l.Nam€"
-  is "${lines[0]}" "Error: failed to create container ßpeci@l.Nam€" "Toolbox should fail to create a container with such name"
+  is "${lines[0]}" "Error: invalid argument for 'CONTAINER'" "Toolbox should fail to create a container with such name"
 }


### PR DESCRIPTION
regexp.MatchString() should only return an error if a wrong pattern is
used. This does not need to be checked outside of the 'utils' package
because the used pattern does not change and it should work. The only
value that needs to be checked is 'matched' -> IsContainerNameValid
only returns a bool.