### PR TITLE
cmd/initContainer: Avoid RPM failures due to unexpected file owners

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -264,6 +264,24 @@ func initContainer(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if utils.PathExists("/usr/lib/rpm/macros.d") {
+		logrus.Debug("Configuring RPM to ignore bind mounts")
+
+		var builder strings.Builder
+		fmt.Fprintf(&builder, "# Written by Toolbox\n")
+		fmt.Fprintf(&builder, "# https://github.com/containers/toolbox\n")
+		fmt.Fprintf(&builder, "\n")
+		fmt.Fprintf(&builder, "%%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt\n")
+
+		rpmConfigString := builder.String()
+		rpmConfigBytes := []byte(rpmConfigString)
+		if err := ioutil.WriteFile("/usr/lib/rpm/macros.d/macros.toolbox",
+			rpmConfigBytes,
+			0644); err != nil {
+			return fmt.Errorf("failed to configure RPM to ignore bind mounts: %w", err)
+		}
+	}
+
 	logrus.Debug("Setting up daily ticker")
 
 	daily, err := time.ParseDuration("24h")


### PR DESCRIPTION
When running rootless, files and directories bind mounted from the
host operating system can have their ownership listed as
`nobody:nobody`. This is because the UIDs and GIDs that actually own
those locations are not available inside the container.

Some distribution packages are particular about the file ownerships of
some of these locations. eg., Fedora's `filesystem` RPM. Encountering
`nobody:nobody` as the owner can fail package management transactions
involving such packages leading to unforeseen consequences.

Therefore, configure RPM to leave these locations alone.