### PR TITLE
playbooks/fedora-33: Fix the image URLs by adding the version suffix

### DIFF
--- a/playbooks/fedora-33/pre-common.yaml
+++ b/playbooks/fedora-33/pre-common.yaml
@@ -1,12 +1,12 @@
-- name: Pull registry.fedoraproject.org/f33/fedora-toolbox
-  command: podman pull registry.fedoraproject.org/f33/fedora-toolbox
+- name: Pull registry.fedoraproject.org/f33/fedora-toolbox:33
+  command: podman pull registry.fedoraproject.org/f33/fedora-toolbox:33
   register: _podman
   until: _podman.rc == 0
   retries: 5
   delay: 10
 
-- name: Pull registry.fedoraproject.org/f29/fedora-toolbox
-  command: podman pull registry.fedoraproject.org/f29/fedora-toolbox
+- name: Pull registry.fedoraproject.org/f29/fedora-toolbox:29
+  command: podman pull registry.fedoraproject.org/f29/fedora-toolbox:29
   register: _podman
   until: _podman.rc == 0
   retries: 5


### PR DESCRIPTION
The system tests for Fedora 33 were failing:
```
  not ok 21 Remove all images (2 should be present; --force should not
    be necessary)
  # (from function `is' in file test/system/helpers.bash, line 287,
  #  in test file test/system/302-rmi.bats, line 7)
  #   `is "$output" "" "The output should be empty"' failed
  # $ /usr/local/bin/toolbox rmi --all
  # Error: image
    3ac100502d2123aff1cf6314760c7a89c55108b8de6ea3c10ddc79a1479f0fca
    has dependent children
  # Error: image
    4a6adf1f2a96adf5ea0c02b61f9fa574306f77fc522f39c2ce6bb164daead882
    has dependent children
  # #/vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
  # #|     FAIL: The output should be empty
  # #| expected: '[no output]'
  # #|   actual: 'Error: image
    3ac100502d2123aff1cf6314760c7a89c55108b8de6ea3c10ddc79a1479f0fca
    has dependent children'
  # #|         > 'Error: image
    4a6adf1f2a96adf5ea0c02b61f9fa574306f77fc522f39c2ce6bb164daead882
    has dependent children'
  # #\^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Fallout from ff4e4905daeb7e65f3fae765fab9f7a0a2ac74a7