### PR TITLE
cmd/run: Notify the terminal about the real UID of 'toolbox enter'

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -308,7 +308,7 @@ func runCommand(container string,
 	execArgs = append(execArgs, command...)
 
 	if emitEscapeSequence {
-		fmt.Printf("\033]777;container;push;%s;toolbox\033\\", container)
+		fmt.Printf("\033]777;container;push;%s;toolbox;%s\033\\", container, currentUser.Uid)
 	}
 
 	logrus.Debugf("Running in container %s:", container)
@@ -320,7 +320,7 @@ func runCommand(container string,
 	exitCode, err := shell.RunWithExitCode("podman", os.Stdin, os.Stdout, nil, execArgs...)
 
 	if emitEscapeSequence {
-		fmt.Print("\033]777;container;pop;;\033\\")
+		fmt.Printf("\033]777;container;pop;;;%s\033\\", currentUser.Uid)
 	}
 
 	switch exitCode {


### PR DESCRIPTION
This will let GNOME Terminal handle toolbox(1) running as root, by not
trying to preserve the current toolbox container if it's running as
root. This is similar to how terminals don't preserve the current
working directory for interactive shells running as root.

This needs a VTE that supports the UID parameter in the OSC 777 escape
sequence, as given below:
```
  OSC 777 ; container ; push ; NAME ; RUNTIME ; UID BEL
  OSC 777 ; container ; push ; NAME ; RUNTIME ; UID ST
  OSC 777 ; container ; pop ; NAME ; RUNTIME ; UID BEL
  OSC 777 ; container ; pop ; NAME ; RUNTIME ; UID ST
```