### PR TITLE
playbooks: Improve how 'systemd-tmpfiles --create' is invoked

### DIFF
--- a/playbooks/fedora-31/setup-env.yaml
+++ b/playbooks/fedora-31/setup-env.yaml
@@ -16,8 +16,11 @@
           - udisks2
           - podman
 
-    - name: Setup environment (create missing /run/media)
-      command: sudo systemd-tmpfiles --create
+    - name: Setup environment
+      become: yes
+      command:
+        cmd: systemd-tmpfiles --create
+        creates: /run/media
 
     - name: Check versions of crucial packages
       command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper

--- a/playbooks/fedora-32/setup-env.yaml
+++ b/playbooks/fedora-32/setup-env.yaml
@@ -17,8 +17,11 @@
           - udisks2
           - podman
 
-    - name: Setup environment (create missing /run/media)
-      command: sudo systemd-tmpfiles --create
+    - name: Setup environment
+      become: yes
+      command:
+        cmd: systemd-tmpfiles --create
+        creates: /run/media
 
     - name: Check versions of crucial packages
       command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper

--- a/playbooks/fedora-33/setup-env.yaml
+++ b/playbooks/fedora-33/setup-env.yaml
@@ -17,8 +17,11 @@
           - udisks2
           - podman
 
-    - name: Setup environment (create missing /run/media)
-      command: sudo systemd-tmpfiles --create
+    - name: Setup environment
+      become: yes
+      command:
+        cmd: systemd-tmpfiles --create
+        creates: /run/media
 
     - name: Check versions of crucial packages
       command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper

--- a/playbooks/fedora-rawhide/setup-env.yaml
+++ b/playbooks/fedora-rawhide/setup-env.yaml
@@ -17,8 +17,11 @@
           - udisks2
           - podman
 
-    - name: Setup environment (create missing /run/media)
-      command: sudo systemd-tmpfiles --create
+    - name: Setup environment
+      become: yes
+      command:
+        cmd: systemd-tmpfiles --create
+        creates: /run/media
 
     - name: Check versions of crucial packages
       command: rpm -q golang podman crun conmon fuse-overlayfs flatpak-session-helper


### PR DESCRIPTION
The most important bit is the use of the 'creates' parameter of the
'command' module [1] because it conditionalizes the invocation of
'systemd-tmpfiles' on the presence of /run/media and self-documents its
purpose.

[1] https://docs.ansible.com/ansible/2.4/command_module.html