### PR TITLE
Update the build requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ The following dependencies are required to build it:
 - meson
 - go-md2man
 - systemd
-- a c compiler. gcc is known to work
 - go
 - ninja
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following dependencies are required to build it:
 - go-md2man
 - systemd
 - a c compiler. gcc is known to work
+- go
+- ninja
 
 The following dependencies enable various optional features:
 - bash-completion

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following dependencies are required to build it:
 - meson
 - go-md2man
 - systemd
+- a c compiler. gcc is known to work
 
 The following dependencies enable various optional features:
 - bash-completion


### PR DESCRIPTION
Without this I get an error:
```
$ meson -Dprofile_dir=/etc/profile.d builddir
The Meson build system
Version: 0.55.3
Source dir: /home/user/toolbox
Build dir: /home/user/toolbox/builddir
Build type: native build
Project name: toolbox
Project version: 0.0.97

meson.build:1:0: ERROR: Unknown compiler(s): ['cc', 'gcc', 'clang', 'pgcc', 'icc']
The follow exceptions were encountered:
Running "cc --version" gave "[Errno 2] No such file or directory: 'cc'"
Running "gcc --version" gave "[Errno 2] No such file or directory: 'gcc'"
Running "clang --version" gave "[Errno 2] No such file or directory: 'clang'"
Running "pgcc --version" gave "[Errno 2] No such file or directory: 'pgcc'"
Running "icc --version" gave "[Errno 2] No such file or directory: 'icc'"

A full log can be found at /home/user/toolbox/builddir/meson-logs/meson-log.txt
```