### PR TITLE
[WIP] Add support for Red Hat UBI

### DIFF
--- a/src/pkg/toolbox/image.go
+++ b/src/pkg/toolbox/image.go
@@ -1,0 +1,110 @@
+package toolbox
+
+import (
+	"errors"
+	"path/filepath"
+
+	"github.com/containers/toolbox/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// knownImages holds all known toolbox images
+	// These should work out of the box with all Toolbox commands
+	knownImages = map[string]Image{
+		"fedora-toolbox": {
+			"registry.fedoraproject.org",
+			"fedora-toolbox",
+			"latest",
+		},
+	}
+
+	// supportedSystems holds ids of known systems. IDs are taken from the ID
+	// entry of 'os-release'. Every id has a toolbox image attached.
+	supportedSystems = map[string]Image{
+		"fedora": knownImages["fedora-toolbox"],
+	}
+)
+
+// GetFallbackImage returns a Fedora toolbox image
+func GetFallbackImage() Image {
+	return supportedSystems["fedora"]
+}
+
+// GetImageForSystem returns an image matching the given system ID.
+//
+// System ID should be taken from the ID entry of 'os-release'.
+//
+// https://www.freedesktop.org/software/systemd/man/os-release.html#ID=
+func GetImageForSystem(systemID string) (Image, error) {
+	var img Image
+
+	if !IsSystemSupported(systemID) {
+		return img, errors.New("unsupported system")
+	}
+
+	img = supportedSystems[systemID]
+
+	return img, nil
+}
+
+// Image holds parts of a full URI of an image
+type Image struct {
+	Registry   string
+	Repository string
+	Tag        string
+}
+
+// CreateContainerName creates a name suitable for a toolbox container based on
+// image.
+func (img Image) CreateContainerName() string {
+	var containerName string
+
+	logrus.Debug("Resolving container name")
+
+	containerName = filepath.Base(img.Repository)
+
+	if img.Tag != "" {
+		containerName = containerName + "-" + img.Tag
+	}
+
+	logrus.Debugf("Resolved container name to %s", containerName)
+
+	return containerName
+}
+
+// GetImageURI assembles full uri that can be used to access an image through
+// e.g. 'podman pull'
+func (img Image) GetImageURI() string {
+	var imageURI string
+
+	if img.Registry != "" {
+		imageURI += img.Registry + "/"
+	}
+	imageURI += img.Repository
+	if img.Tag != "" {
+		imageURI += ":" + img.Tag
+	}
+
+	return imageURI
+}
+
+// SetImageURI sets the image to target the
+func (img Image) SetImageURI(imageURI string) {
+	img.Registry = utils.ImageReferenceGetDomain(imageURI)
+	img.Repository = utils.ImageReferenceGetRepository(imageURI)
+	img.Tag = utils.ImageReferenceGetTag(imageURI)
+}
+
+// IsImageKnown returns a bool saying whether an image is a known Toolbox
+// image.
+func (img Image) IsImageKnown() bool {
+	for _, knownImage := range knownImages {
+		// Tag does not really affect the type of image, hence is not tested
+		if img.Registry == knownImage.Registry && img.Repository == knownImage.Repository {
+			return true
+		}
+	}
+
+	return false
+}

--- a/src/pkg/toolbox/image.go
+++ b/src/pkg/toolbox/image.go
@@ -17,12 +17,33 @@ var (
 			"fedora-toolbox",
 			"latest",
 		},
+		"ubi7": {
+			"registry.access.redhat.com",
+			"ubi7",
+			"latest",
+		},
+		"ubi7-2": {
+			"registry.access.redhat.com",
+			"ubi7/ubi",
+			"latest",
+		},
+		"ubi8": {
+			"registry.access.redhat.com",
+			"ubi8",
+			"latest",
+		},
+		"ubi8-2": {
+			"registry.access.redhat.com",
+			"ubi8/ubi",
+			"latest",
+		},
 	}
 
 	// supportedSystems holds ids of known systems. IDs are taken from the ID
 	// entry of 'os-release'. Every id has a toolbox image attached.
 	supportedSystems = map[string]Image{
 		"fedora": knownImages["fedora-toolbox"],
+		"rhel":   knownImages["ubi8"],
 	}
 )
 

--- a/src/pkg/toolbox/utils.go
+++ b/src/pkg/toolbox/utils.go
@@ -1,0 +1,41 @@
+package toolbox
+
+import (
+	"github.com/containers/toolbox/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// IsSystemSupported takes a string identifying an operating system and
+// compares it to an internal list of supported systems.
+//
+// The system ids are taken from the ID entry of 'os-release'.
+//
+// https://www.freedesktop.org/software/systemd/man/os-release.html#ID=
+func IsSystemSupported(systemID string) bool {
+	if _, ok := supportedSystems[systemID]; ok {
+		return true
+	}
+
+	return false
+}
+
+// IsHostSystemSupported checks if the systemm where Toolbox is run, has
+// a supported toolbox image (e.g. Fedora has fedora-toolbox).
+//
+// The compared information are: the system ID and an internal list of
+// system IDs where ID is taken from 'os-release'.
+//
+// https://www.freedesktop.org/software/systemd/man/os-release.html#ID=
+func IsHostSystemSupported() bool {
+	hostID, err := utils.GetHostID()
+	if err != nil {
+		logrus.Warnf("There was an error while getting host's ID: %v", err)
+		return false
+	}
+
+	if _, ok := supportedSystems[hostID]; ok {
+		return true
+	}
+
+	return false
+}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -547,53 +547,6 @@ func JoinJSON(joinkey string, maps ...[]map[string]interface{}) []map[string]int
 	return json
 }
 
-// ResolveContainerAndImageNames takes care of standardizing names of containers and images.
-//
-// If no image name is specified then the base image will reflect the platform of the host (even the version).
-// If no container name is specified then the name of the image will be used.
-//
-// If the host system is unknown then the base image will be 'fedora-toolbox' with a default version
-func ResolveContainerAndImageNames(container, image, release string) (string, string, string, error) {
-	logrus.Debug("Resolving container and image names")
-	logrus.Debugf("Container: '%s'", container)
-	logrus.Debugf("Image: '%s'", image)
-	logrus.Debugf("Release: '%s'", release)
-
-	if release == "" {
-		release = releaseDefault
-	}
-
-	if image == "" {
-		image = "fedora-toolbox:" + release
-	} else {
-		release = ImageReferenceGetTag(image)
-		if release == "" {
-			release = releaseDefault
-		}
-	}
-
-	if container == "" {
-		basename := ImageReferenceGetBasename(image)
-		if basename == "" {
-			return "", "", "", fmt.Errorf("failed to get the basename of image %s", image)
-		}
-
-		container = basename
-
-		tag := ImageReferenceGetTag(image)
-		if tag != "" {
-			container = container + "-" + tag
-		}
-	}
-
-	logrus.Debug("Resolved container and image names")
-	logrus.Debugf("Container: '%s'", container)
-	logrus.Debugf("Image: '%s'", image)
-	logrus.Debugf("Release: '%s'", release)
-
-	return container, image, release, nil
-}
-
 func ShowManual(manual string) error {
 	manBinary, err := exec.LookPath("man")
 	if err != nil {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -472,27 +472,6 @@ func ShortID(id string) string {
 	return id
 }
 
-func ParseRelease(str string) (string, error) {
-	var release string
-
-	if strings.HasPrefix(str, "F") || strings.HasPrefix(str, "f") {
-		release = str[1:]
-	} else {
-		release = str
-	}
-
-	releaseN, err := strconv.Atoi(release)
-	if err != nil {
-		return "", err
-	}
-
-	if releaseN <= 0 {
-		return "", errors.New("release must be a positive integer")
-	}
-
-	return release, nil
-}
-
 // PathExists wraps around os.Stat providing a nice interface for checking an existence of a path.
 func PathExists(path string) bool {
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -397,6 +397,23 @@ func ImageReferenceCanBeID(image string) (bool, error) {
 }
 
 func ImageReferenceGetBasename(image string) string {
+	repository := ImageReferenceGetRepository(image)
+
+	basename := filepath.Base(repository)
+	return basename
+}
+
+func ImageReferenceGetDomain(image string) string {
+	if !ImageReferenceHasDomain(image) {
+		return ""
+	}
+
+	i := strings.IndexRune(image, '/')
+	domain := image[:i]
+	return domain
+}
+
+func ImageReferenceGetRepository(image string) string {
 	var i int
 
 	if ImageReferenceHasDomain(image) {
@@ -410,18 +427,7 @@ func ImageReferenceGetBasename(image string) string {
 	}
 
 	path := remainder[:j]
-	basename := filepath.Base(path)
-	return basename
-}
-
-func ImageReferenceGetDomain(image string) string {
-	if !ImageReferenceHasDomain(image) {
-		return ""
-	}
-
-	i := strings.IndexRune(image, '/')
-	domain := image[:i]
-	return domain
+	return path
 }
 
 func ImageReferenceGetTag(image string) string {


### PR DESCRIPTION
Adding support for [Red Hat UBI] (Universal Base Image) is a requirement for Toolbox to be included in RHEL (and in the process replacing https://github.com/coreos/toolbox).

Adding support for a new image requires implementing an internal "store" of supported images. To be frank, this is something I dreaded quite a bit for some time already :). This implements a very basic image store that allows matching based on a [os-release](https://www.freedesktop.org/software/systemd/man/os-release.html):ID (e.g., `fedora` is Fedora, `rhel` is RHEL - in case of Toolbox UBI,..). This matching is available through a new option `--distro | -d`. The existing `--release | -r` option complements the new option.

The updated workflow should look a bit like this:
- Scenario 1 - host machine is Fedora 33
```
$ toolbox create              <- creates a Fedora 33-based container
$ toolbox create -r 31        <- creates a Fedora 31-based container
$ toolbox create -d rhel -r 7 <- creates a RHEL 7-based container
```
- Scenario 2 - host machine is RHEL 8
```
$ toolbox create           <- creates a RHEL 8-based container
$ toolbox create -r 7      <- creates a RHEL 7-based container
$ toolbox create -d fedora <- creates a Fedora 32-based container (default version of Fedora is used)
```
- Scenario 3 - host machine is Arch Linux
```
$ toolbox create <- creates a Fedora 32-based container
```

On distributions without a matching supported image will Fedora stay as the default.

While this adds only support for UBI, technically speaking, it should be possible to add support for even other images. Another matter is who is going to maintain the images and where they will be stored. Before these questions are answered, we'll continue offering only Fedora and UBI images (but you are always free to use an image of your own making!).