### PR TITLE
profile.d: Restore compatibility with Z shell

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -6,8 +6,8 @@ host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 
 # shellcheck disable=2046
+# shellcheck disable=SC1091
 eval $(
-          # shellcheck disable=SC1091
           . /usr/lib/os-release
 
           echo ID="$ID"


### PR DESCRIPTION
Otherwise, every zsh instance was running into:
```
  zsh: #: command not found...
```

Fallout from dcdfa3a1f5a3421330397ea72c0df132a260853d