### PR TITLE
completion, doc/toolbox-create: Remove --candidate-registry

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -16,7 +16,7 @@ __toolbox() {
   local commands="create enter help init-container list reset rm rmi run"
 
   declare -A options
-  local options=([create]="--candidate-registry --container --image --release" \
+  local options=([create]="--container --image --release" \
                  [enter]="--container --release" \
                  [help]="$commands" \
                  [init-container]="--home --home-link --monitor-host --shell --uid --user" \

--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -4,8 +4,7 @@
 toolbox\-create - Create a new toolbox container
 
 ## SYNOPSIS
-**toolbox create** [*--candidate-registry*]
-               [*--container NAME* | *-c NAME*]
+**toolbox create** [*--container NAME* | *-c NAME*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
 
@@ -28,12 +27,6 @@ with the current user name.
 ## OPTIONS ##
 
 The following options are understood:
-
-**--candidate-registry**
-
-Pull the base image from `candidate-registry.fedoraproject.org`. This is
-useful for testing newly built images before they have moved to the stable
-registry at `registry.fedoraproject.org`.
 
 **--container** NAME, **-c** NAME
 
@@ -70,12 +63,6 @@ $ toolbox create --release f30
 
 ```
 $ toolbox create --container foo --image bar
-```
-
-### Create a toolbox using images from the unstable candidate registry
-
-```
-$ toolbox create --candidate-registry
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
The --candidate-registry is a lesser known option only supported by
the POSIX shell implementation. The Go never implementation never
offered it, and nobody has felt its absence so far. So, it's safe to
assume that there's no urgent need to port it to Go, and it's better to
not confuse users by mentioning it.