### PR TITLE
completion, pkg/utils: Update the range of supported Fedora releases

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -10,8 +10,8 @@ __toolbox_images() {
 }
 
 __toolbox() {
-  local MIN_VERSION=29
-  local RAWHIDE_VERSION=32
+  local MIN_VERSION=32
+  local RAWHIDE_VERSION=34
 
   local commands="create enter help init-container list reset rm rmi run"
 

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	idTruncLength          = 12
-	releaseDefaultFallback = "31"
+	releaseDefaultFallback = "32"
 )
 
 const (


### PR DESCRIPTION
Rawhide currently points to Fedora 34, and Fedora 30 reached End of
Life on 24th November:
https://fedoraproject.org/wiki/End_of_life