### PR TITLE
Update the labels used for filtering toolbox containers images

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -121,11 +121,11 @@ func list(cmd *cobra.Command, args []string) error {
 }
 
 func listContainers() ([]toolboxContainer, error) {
-	logrus.Debug("Fetching containers with label=com.redhat.component=fedora-toolbox")
-	args := []string{"--all", "--filter", "label=com.redhat.component=fedora-toolbox"}
+	logrus.Debug("Fetching containers with label=com.github.containers.toolbox=true")
+	args := []string{"--all", "--filter", "label=com.github.containers.toolbox=true"}
 	containers_old, err := podman.GetContainers(args...)
 	if err != nil {
-		return nil, errors.New("failed to list containers with com.redhat.component=fedora-toolbox")
+		return nil, errors.New("failed to list containers with label=com.github.containers.toolbox=true")
 	}
 
 	logrus.Debug("Fetching containers with label=com.github.debarshiray.toolbox=true")
@@ -189,11 +189,11 @@ func listHelp(cmd *cobra.Command, args []string) {
 }
 
 func listImages() ([]toolboxImage, error) {
-	logrus.Debug("Fetching images with label=com.redhat.component=fedora-toolbox")
-	args := []string{"--filter", "label=com.redhat.component=fedora-toolbox"}
+	logrus.Debug("Fetching images with label=com.github.containers.toolbox=true")
+	args := []string{"--filter", "label=com.github.containers.toolbox=true"}
 	images_old, err := podman.GetImages(args...)
 	if err != nil {
-		return nil, errors.New("failed to list images with com.redhat.component=fedora-toolbox")
+		return nil, errors.New("failed to list images with label=com.github.containers.toolbox=true")
 	}
 
 	logrus.Debug("Fetching images with label=com.github.debarshiray.toolbox=true")

--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -70,11 +70,11 @@ func rm(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmFlags.deleteAll {
-		logrus.Debug("Fetching containers with label=com.redhat.component=fedora-toolbox")
-		args := []string{"--all", "--filter", "label=com.redhat.component=fedora-toolbox"}
+		logrus.Debug("Fetching containers with label=com.github.containers.toolbox=true")
+		args := []string{"--all", "--filter", "label=com.github.containers.toolbox=true"}
 		containers_old, err := podman.GetContainers(args...)
 		if err != nil {
-			return errors.New("failed to list containers with com.redhat.component=fedora-toolbox")
+			return errors.New("failed to list containers with label=com.github.containers.toolbox=true")
 		}
 
 		logrus.Debug("Fetching containers with label=com.github.debarshiray.toolbox=true")

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -70,11 +70,11 @@ func rmi(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmiFlags.deleteAll {
-		logrus.Debug("Fetching images with label=com.redhat.component=fedora-toolbox")
-		args := []string{"--filter", "label=com.redhat.component=fedora-toolbox"}
+		logrus.Debug("Fetching images with label=com.github.containers.toolbox=true")
+		args := []string{"--filter", "label=com.github.containers.toolbox=true"}
 		images_old, err := podman.GetImages(args...)
 		if err != nil {
-			return errors.New("failed to list images with com.redhat.component=fedora-toolbox")
+			return errors.New("failed to list images with label=com.github.containers.toolbox=true")
 		}
 
 		logrus.Debug("Fetching images with label=com.github.debarshiray.toolbox=true")

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -201,8 +201,7 @@ func IsToolboxContainer(container string) (bool, error) {
 	}
 
 	labels, _ := info["Config"].(map[string]interface{})["Labels"].(map[string]interface{})
-	if labels["com.redhat.component"] != "fedora-toolbox" &&
-		labels["com.github.debarshiray.toolbox"] != "true" {
+	if labels["com.github.containers.toolbox"] != "true" && labels["com.github.debarshiray.toolbox"] != "true" {
 		return false, fmt.Errorf("%s is not a toolbox container", container)
 	}
 
@@ -220,8 +219,7 @@ func IsToolboxImage(image string) (bool, error) {
 	}
 
 	labels := info["Labels"].(map[string]interface{})
-	if labels["com.redhat.component"] != "fedora-toolbox" &&
-		labels["com.github.debarshiray.toolbox"] != "true" {
+	if labels["com.github.containers.toolbox"] != "true" && labels["com.github.debarshiray.toolbox"] != "true" {
 		return false, fmt.Errorf("%s is not a toolbox image", image)
 	}
 


### PR DESCRIPTION
The com.github.debarshiray.toolbox label was introduced in commit
0ab6eb7401fb3964 to replace the com.redhat.component label for
filtering toolbox containers and images. This happened right before
the release of Fedora 30, which hasn't been supported for a while [1].
Therefore, it's time to stop using the old label.

It's also time to start using the newer com.github.containers.toolbox
label that was introduced in commit de5e5df9b793edc7 to reflect the
project's new home under the Containers organization on GitHub.

[1] https://fedoraproject.org/wiki/Releases/30/Schedule