### PR TITLE
cmd/create: Try to avoid 'latest' tags, when looking at RepoTags

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -537,7 +537,18 @@ func getFullyQualifiedImageName(image string) (string, error) {
 			return "", fmt.Errorf("empty RepoTag for image %s", image)
 		}
 
-		imageFull = repoTags[0].(string)
+		for _, repoTag := range repoTags {
+			repoTagString := repoTag.(string)
+			tag := utils.ImageReferenceGetTag(repoTagString)
+			if tag != "latest" {
+				imageFull = repoTagString
+				break
+			}
+		}
+
+		if imageFull == "" {
+			imageFull = repoTags[0].(string)
+		}
 	}
 
 	logrus.Debugf("Resolved image %s to %s", image, imageFull)


### PR DESCRIPTION
The same image ID can be referred to by multiple names. It's common
that one of the names use the 'latest' tag, while another uses a
specific version number. It's better to resolve a short image name to
one with a specific version number, because the meaning of the tag is
clear and won't change with time.