### PR TITLE
Support RHEL hosts by creating containers based on UBI

### DIFF
--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -5,6 +5,10 @@ __toolbox_containers() {
   podman ps --all --format '{{.Names}}'
 }
 
+__toolbox_distros() {
+  echo "fedora"
+}
+
 __toolbox_images() {
   podman images --format '{{.Repository}}:{{.Tag}}'
 }
@@ -16,14 +20,14 @@ __toolbox() {
   local commands="create enter help init-container list reset rm rmi run"
 
   declare -A options
-  local options=([create]="--container --image --release" \
-                 [enter]="--container --release" \
+  local options=([create]="--container --distro --image --release" \
+                 [enter]="--container --distro --release" \
                  [help]="$commands" \
                  [init-container]="--home --home-link --monitor-host --shell --uid --user" \
 		 [list]="--containers --images" \
 		 [rm]="--all --force" \
 		 [rmi]="--all --force" \
-		 [run]="--container --release")
+		 [run]="--container --distro --release")
 
   _init_completion -s || return
 
@@ -39,6 +43,10 @@ __toolbox() {
       ;;
     --container | -c)
       mapfile -t COMPREPLY < <(compgen -W "$(__toolbox_containers)" -- "$2")
+      return 0
+      ;;
+    --distro | -d)
+      mapfile -t COMPREPLY < <(compgen -W "$(__toolbox_distros)" -- "$2")
       return 0
       ;;
     --image | -i)

--- a/completion/bash/toolbox
+++ b/completion/bash/toolbox
@@ -7,6 +7,7 @@ __toolbox_containers() {
 
 __toolbox_distros() {
   echo "fedora"
+  echo "rhel"
 }
 
 __toolbox_images() {

--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -5,6 +5,7 @@ toolbox\-create - Create a new toolbox container
 
 ## SYNOPSIS
 **toolbox create** [*--container NAME* | *-c NAME*]
+               [*--distro DISTRO* | *-d DISTRO*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
 
@@ -15,9 +16,10 @@ to interact with the container at any point.
 
 A toolbox container is an OCI container created from an OCI image. On Fedora
 the base image is known as `fedora-toolbox`. If the image is not present
-locally, then it is pulled from `registry.fedoraproject.org`. The base image is
-locally customized for the current user to create a second image, from which
-the container is finally created.
+locally, then it is pulled from a well-known registry like
+`registry.fedoraproject.org`. The base image is locally customized for the
+current user to create a second image, from which the container is finally
+created.
 
 Toolbox containers and images are tagged with the version of the OS that
 corresponds to the content inside them. The user-specific images and the
@@ -33,6 +35,11 @@ The following options are understood:
 Assign a different NAME to the toolbox container. This is useful for creating
 multiple toolbox containers from the same base image, or for entirely
 customized containers from custom-built base images.
+
+**--distro** DISTRO, **-d** DISTRO
+
+Create a toolbox container for a different operating system DISTRO than the
+host. Cannot be used with `--image`.
 
 **--image** NAME, **-i** NAME
 
@@ -56,7 +63,7 @@ $ toolbox create
 ### Create a toolbox container using the default image for Fedora 30
 
 ```
-$ toolbox create --release f30
+$ toolbox create --distro fedora --release f30
 ```
 
 ### Create a custom toolbox container from a custom image

--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -5,6 +5,7 @@ toolbox\-enter - Enter a toolbox container for interactive use
 
 ## SYNOPSIS
 **toolbox enter** [*--container NAME* | *-c NAME*]
+              [*--distro DISTRO* | *-d DISTRO*]
               [*--release RELEASE* | *-r RELEASE*]
 
 ## DESCRIPTION
@@ -18,7 +19,7 @@ fall back to it, even if it doesn't match the default name.
 A toolbox container is an OCI container. Therefore, `toolbox enter` is
 analogous to a `podman start` followed by a `podman exec`.
 
-On Fedora the toolbox containers are tagged with the version of the OS that
+By default, the toolbox containers are tagged with the version of the OS that
 corresponds to the content inside them. Their names are prefixed with the name
 of the base image and suffixed with the current user name.
 
@@ -31,6 +32,11 @@ The following options are understood:
 Enter a toolbox container with the given NAME. This is useful when there are
 multiple toolbox containers created from the same base image, or entirely
 customized containers created from custom-built base images.
+
+**--distro** DISTRO, **-d** DISTRO
+
+Enter a toolbox container for a different operating system DISTRO than the
+host.
 
 **--release** RELEASE, **-r** RELEASE
 
@@ -48,7 +54,7 @@ $ toolbox enter
 ### Enter a toolbox container using the default image for Fedora 30
 
 ```
-$ toolbox enter --release f30
+$ toolbox enter --distro fedora --release f30
 ```
 
 ### Enter a custom toolbox container using a custom image

--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -5,6 +5,7 @@ toolbox\-run - Run a command in an existing toolbox container
 
 ## SYNOPSIS
 **toolbox run** [*--container NAME* | *-c NAME*]
+            [*--distro DISTRO* | *-d DISTRO*]
             [*--release RELEASE* | *-r RELEASE*] [*COMMAND*]
 
 ## DESCRIPTION
@@ -15,7 +16,7 @@ been created using the `toolbox create` command.
 A toolbox container is an OCI container. Therefore, `toolbox run` is analogous
 to a `podman start` followed by a `podman exec`.
 
-On Fedora the toolbox containers are tagged with the version of the OS that
+By default, the toolbox containers are tagged with the version of the OS that
 corresponds to the content inside them. Their names are prefixed with the name
 of the base image and suffixed with the current user name.
 
@@ -28,6 +29,11 @@ The following options are understood:
 Run command inside a toolbox container with the given NAME. This is useful
 when there are multiple toolbox containers created from the same base image,
 or entirely customized containers created from custom-built base images.
+
+**--distro** DISTRO, **-d** DISTRO
+
+Run command inside a toolbox container for a different operating system DISTRO
+than the host.
 
 **--release** RELEASE, **-r** RELEASE
 
@@ -45,7 +51,7 @@ $ toolbox run ls -la
 ### Run emacs inside a toolbox container using the default image for Fedora 30
 
 ```
-$ toolbox run --release f30 emacs
+$ toolbox run --distro fedora --release f30 emacs
 ```
 
 ### Run uptime inside a custom toolbox container using a custom image

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -55,6 +55,14 @@ if [ -f /run/.containerenv ] \
         touch "$toolbox_welcome_stub"
     fi
 
+    if ! [ -f /etc/profile.d/vte.sh ] && [ -z "$PROMPT_COMMAND" ] && [ "${VTE_VERSION:-0}" -ge 3405 ]; then
+        case "$TERM" in
+            xterm*|vte*)
+                [ -n "${BASH_VERSION:-}" ] && PROMPT_COMMAND=" "
+                ;;
+        esac
+    fi
+
     if [ "$TERM" != "" ]; then
         error_message="Error: terminfo entry not found for $TERM"
         term_without_first_character="${TERM#?}"

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -130,7 +130,7 @@ func create(cmd *cobra.Command, args []string) error {
 	var release string
 	if createFlags.release != "" {
 		var err error
-		release, err = utils.ParseRelease(createFlags.release)
+		release, err = utils.ParseRelease("", createFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
@@ -138,6 +138,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	container, image, release, err := utils.ResolveContainerAndImageNames(container,
+		"",
 		createFlags.image,
 		release)
 	if err != nil {
@@ -659,7 +660,11 @@ func pullImage(image, release string) (bool, error) {
 	if hasDomain {
 		imageFull = image
 	} else {
-		imageFull = fmt.Sprintf("registry.fedoraproject.org/f%s/%s", release, image)
+		var err error
+		imageFull, err = utils.GetFullyQualifiedImageFromDistros(image, release)
+		if err != nil {
+			return false, fmt.Errorf("image %s not found in local storage and known registries", image)
+		}
 	}
 
 	logrus.Debugf("Looking for image %s", imageFull)

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -100,11 +100,12 @@ func create(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	var container string
-	var containerArg string
 	if cmd.Flag("image").Changed && cmd.Flag("release").Changed {
 		return errors.New("options --image and --release cannot be used together")
 	}
+
+	var container string
+	var containerArg string
 
 	if len(args) != 0 {
 		container = args[0]

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -185,7 +185,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		return nil
 	}
 
-	imageFull, err := getFullyQualifiedImageName(image)
+	imageFull, err := getFullyQualifiedImageFromRepoTags(image)
 	if err != nil {
 		return err
 	}
@@ -515,8 +515,8 @@ func getEnterCommand(container, release string) string {
 	return enterCommand
 }
 
-func getFullyQualifiedImageName(image string) (string, error) {
-	logrus.Debugf("Resolving fully qualified name for image %s", image)
+func getFullyQualifiedImageFromRepoTags(image string) (string, error) {
+	logrus.Debugf("Resolving fully qualified name for image %s from RepoTags", image)
 
 	var imageFull string
 

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -43,6 +43,7 @@ const (
 var (
 	createFlags struct {
 		container string
+		distro    string
 		image     string
 		release   string
 	}
@@ -71,6 +72,12 @@ func init() {
 		"",
 		"Assign a different name to the toolbox container")
 
+	flags.StringVarP(&createFlags.distro,
+		"distro",
+		"d",
+		"",
+		"Create a toolbox container for a different operating system distribution than the host")
+
 	flags.StringVarP(&createFlags.image,
 		"image",
 		"i",
@@ -98,6 +105,10 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 
 		return nil
+	}
+
+	if cmd.Flag("distro").Changed && cmd.Flag("image").Changed {
+		return errors.New("options --distro and --image cannot be used together")
 	}
 
 	if cmd.Flag("image").Changed && cmd.Flag("release").Changed {
@@ -130,7 +141,7 @@ func create(cmd *cobra.Command, args []string) error {
 	var release string
 	if createFlags.release != "" {
 		var err error
-		release, err = utils.ParseRelease("", createFlags.release)
+		release, err = utils.ParseRelease(createFlags.distro, createFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
@@ -138,7 +149,7 @@ func create(cmd *cobra.Command, args []string) error {
 	}
 
 	container, image, release, err := utils.ResolveContainerAndImageNames(container,
-		"",
+		createFlags.distro,
 		createFlags.image,
 		release)
 	if err != nil {

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -29,6 +29,7 @@ import (
 var (
 	enterFlags struct {
 		container string
+		distro    string
 		release   string
 	}
 )
@@ -47,6 +48,12 @@ func init() {
 		"c",
 		"",
 		"Enter a toolbox container with the given name")
+
+	flags.StringVarP(&enterFlags.distro,
+		"distro",
+		"d",
+		"",
+		"Enter a toolbox container for a different operating system distribution than the host")
 
 	flags.StringVarP(&enterFlags.release,
 		"release",
@@ -102,14 +109,14 @@ func enter(cmd *cobra.Command, args []string) error {
 		nonDefaultContainer = true
 
 		var err error
-		release, err = utils.ParseRelease("", enterFlags.release)
+		release, err = utils.ParseRelease(enterFlags.distro, enterFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
 		}
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(container, "", "", release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(container, enterFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -123,7 +123,7 @@ func enter(cmd *cobra.Command, args []string) error {
 
 	hostID, err := utils.GetHostID()
 	if err != nil {
-		return errors.New("failed to get the host ID")
+		return fmt.Errorf("failed to get the host ID: %w", err)
 	}
 
 	hostVariantID, err := utils.GetHostVariantID()

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -102,14 +102,14 @@ func enter(cmd *cobra.Command, args []string) error {
 		nonDefaultContainer = true
 
 		var err error
-		release, err = utils.ParseRelease(enterFlags.release)
+		release, err = utils.ParseRelease("", enterFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
 		}
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(container, "", release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(container, "", "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -97,7 +97,7 @@ func run(cmd *cobra.Command, args []string) error {
 		nonDefaultContainer = true
 
 		var err error
-		release, err = utils.ParseRelease(runFlags.release)
+		release, err = utils.ParseRelease("", runFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
@@ -115,7 +115,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, "", release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, "", "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -33,6 +33,7 @@ import (
 var (
 	runFlags struct {
 		container string
+		distro    string
 		release   string
 	}
 )
@@ -52,6 +53,12 @@ func init() {
 		"c",
 		"",
 		"Run command inside a toolbox container with the given name")
+
+	flags.StringVarP(&runFlags.distro,
+		"distro",
+		"d",
+		"",
+		"Run command inside a toolbox container for a different operating system distribution than the host")
 
 	flags.StringVarP(&runFlags.release,
 		"release",
@@ -97,7 +104,7 @@ func run(cmd *cobra.Command, args []string) error {
 		nonDefaultContainer = true
 
 		var err error
-		release, err = utils.ParseRelease("", runFlags.release)
+		release, err = utils.ParseRelease(runFlags.distro, runFlags.release)
 		if err != nil {
 			err := utils.CreateErrorInvalidRelease(executableBase)
 			return err
@@ -115,7 +122,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, "", "", release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, runFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -676,6 +676,10 @@ func ResolveContainerAndImageNames(container, distro, image, release string) (st
 		distro = distroDefault
 	}
 
+	if distro != distroDefault && release == "" {
+		return "", "", "", fmt.Errorf("release not found for non-default distribution %s", distro)
+	}
+
 	if release == "" {
 		release = releaseDefault
 	}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -101,6 +101,14 @@ var (
 			"f%s",
 			true,
 		},
+		"rhel": {
+			"rhel-toolbox",
+			"ubi",
+			parseReleaseRHEL,
+			"registry.access.redhat.com",
+			"ubi8",
+			false,
+		},
 	}
 )
 
@@ -598,6 +606,23 @@ func parseReleaseFedora(str string) (string, error) {
 	}
 
 	return release, nil
+}
+
+func parseReleaseRHEL(str string) (string, error) {
+	if i := strings.IndexRune(str, '.'); i == -1 {
+		return "", errors.New("release must have a '.'")
+	}
+
+	releaseN, err := strconv.ParseFloat(str, 32)
+	if err != nil {
+		return "", err
+	}
+
+	if releaseN <= 0 {
+		return "", errors.New("release must be a positive number")
+	}
+
+	return str, nil
 }
 
 // PathExists wraps around os.Stat providing a nice interface for checking an existence of a path.

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -39,20 +39,31 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+type ParseReleaseFunc func(string) (string, error)
+
+type Distro struct {
+	ContainerNamePrefix    string
+	ImageBasename          string
+	ParseRelease           ParseReleaseFunc
+	Registry               string
+	Repository             string
+	RepositoryNeedsRelease bool
+}
+
 const (
 	idTruncLength          = 12
 	releaseDefaultFallback = "32"
 )
 
 const (
-	ContainerNamePrefixDefault = "fedora-toolbox"
-
 	// Based on the nameRegex value in:
 	// https://github.com/containers/libpod/blob/master/libpod/options.go
 	ContainerNameRegexp = "[a-zA-Z0-9][a-zA-Z0-9_.-]*"
 )
 
 var (
+	distroDefault = "fedora"
+
 	preservedEnvironmentVariables = []string{
 		"COLORTERM",
 		"DBUS_SESSION_BUS_ADDRESS",
@@ -80,10 +91,22 @@ var (
 	}
 
 	releaseDefault string
+
+	supportedDistros = map[string]Distro{
+		"fedora": {
+			"fedora-toolbox",
+			"fedora-toolbox",
+			parseReleaseFedora,
+			"registry.fedoraproject.org",
+			"f%s",
+			true,
+		},
+	}
 )
 
 var (
-	ContainerNameDefault string
+	ContainerNameDefault       string
+	ContainerNamePrefixDefault = "fedora-toolbox"
 )
 
 func init() {
@@ -91,9 +114,11 @@ func init() {
 
 	hostID, err := GetHostID()
 	if err == nil {
-		if hostID == "fedora" {
+		if distroObj, supportedDistro := supportedDistros[hostID]; supportedDistro {
 			release, err := GetHostVersionID()
 			if err == nil {
+				ContainerNamePrefixDefault = distroObj.ContainerNamePrefix
+				distroDefault = hostID
 				releaseDefault = release
 			}
 		}
@@ -236,6 +261,38 @@ func GetCgroupsVersion() (int, error) {
 	return version, nil
 }
 
+func GetContainerNamePrefixForImage(image string) (string, error) {
+	basename := ImageReferenceGetBasename(image)
+	if basename == "" {
+		return "", fmt.Errorf("failed to get the basename of image %s", image)
+	}
+
+	for _, distroObj := range supportedDistros {
+		if distroObj.ImageBasename != basename {
+			continue
+		}
+
+		return distroObj.ContainerNamePrefix, nil
+	}
+
+	return basename, nil
+}
+
+func GetDefaultImageForDistro(distro, release string) string {
+	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
+		distro = "fedora"
+	}
+
+	distroObj, supportedDistro := supportedDistros[distro]
+	if !supportedDistro {
+		panicMsg := fmt.Sprintf("failed to find %s in the list of supported distributions", distro)
+		panic(panicMsg)
+	}
+
+	image := distroObj.ImageBasename + ":" + release
+	return image
+}
+
 func GetEnvOptionsForPreservedVariables() []string {
 	logrus.Debug("Creating list of environment variables to forward")
 
@@ -253,6 +310,41 @@ func GetEnvOptionsForPreservedVariables() []string {
 	}
 
 	return envOptions
+}
+
+func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
+	logrus.Debugf("Resolving fully qualified name for image %s from known registries", image)
+
+	if ImageReferenceHasDomain(image) {
+		return image, nil
+	}
+
+	basename := ImageReferenceGetBasename(image)
+	if basename == "" {
+		return "", fmt.Errorf("failed to get the basename of image %s", image)
+	}
+
+	for _, distroObj := range supportedDistros {
+		if distroObj.ImageBasename != basename {
+			continue
+		}
+
+		var repository string
+
+		if distroObj.RepositoryNeedsRelease {
+			repository = fmt.Sprintf(distroObj.Repository, release)
+		} else {
+			repository = distroObj.Repository
+		}
+
+		imageFull := distroObj.Registry + "/" + repository + "/" + image
+
+		logrus.Debugf("Resolved image %s to %s", image, imageFull)
+
+		return imageFull, nil
+	}
+
+	return "", fmt.Errorf("failed to resolve image %s")
 }
 
 // GetGroupForSudo returns the name of the sudoers group.
@@ -467,7 +559,27 @@ func ShortID(id string) string {
 	return id
 }
 
-func ParseRelease(str string) (string, error) {
+func ParseRelease(distro, str string) (string, error) {
+	if distro == "" {
+		distro = distroDefault
+	}
+
+	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
+		distro = "fedora"
+	}
+
+	distroObj, supportedDistro := supportedDistros[distro]
+	if !supportedDistro {
+		panicMsg := fmt.Sprintf("failed to find %s in the list of supported distributions", distro)
+		panic(panicMsg)
+	}
+
+	parseRelease := distroObj.ParseRelease
+	release, err := parseRelease(str)
+	return release, err
+}
+
+func parseReleaseFedora(str string) (string, error) {
 	var release string
 
 	if strings.HasPrefix(str, "F") || strings.HasPrefix(str, "f") {
@@ -553,18 +665,23 @@ func JoinJSON(joinkey string, maps ...[]map[string]interface{}) []map[string]int
 // If no container name is specified then the name of the image will be used.
 //
 // If the host system is unknown then the base image will be 'fedora-toolbox' with a default version
-func ResolveContainerAndImageNames(container, image, release string) (string, string, string, error) {
+func ResolveContainerAndImageNames(container, distro, image, release string) (string, string, string, error) {
 	logrus.Debug("Resolving container and image names")
 	logrus.Debugf("Container: '%s'", container)
+	logrus.Debugf("Distribution: '%s'", distro)
 	logrus.Debugf("Image: '%s'", image)
 	logrus.Debugf("Release: '%s'", release)
+
+	if distro == "" {
+		distro = distroDefault
+	}
 
 	if release == "" {
 		release = releaseDefault
 	}
 
 	if image == "" {
-		image = "fedora-toolbox:" + release
+		image = GetDefaultImageForDistro(distro, release)
 	} else {
 		release = ImageReferenceGetTag(image)
 		if release == "" {
@@ -573,12 +690,11 @@ func ResolveContainerAndImageNames(container, image, release string) (string, st
 	}
 
 	if container == "" {
-		basename := ImageReferenceGetBasename(image)
-		if basename == "" {
-			return "", "", "", fmt.Errorf("failed to get the basename of image %s", image)
+		var err error
+		container, err = GetContainerNamePrefixForImage(image)
+		if err != nil {
+			return "", "", "", err
 		}
-
-		container = basename
 
 		tag := ImageReferenceGetTag(image)
 		if tag != "" {


### PR DESCRIPTION
This is based on https://github.com/containers/toolbox/pull/658

It splits up the commits a bit, contains some fix-ups, but most importantly skips some parts of the container & image tracking backend to side-step issues like the one caused by the use of `latest` tags. We can introduce the rest of the new backend later once we have solved all those issues.