### PR TITLE
profile.d: Silence SC2148

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=sh
+
 [ "$BASH_VERSION" != "" ] || [ "$ZSH_VERSION" != "" ] || return 0
 [ "$PS1" != "" ] || return 0
 


### PR DESCRIPTION
While Toolbox's test suite explicitly uses --shell=sh when running
shellcheck(1) on profile.d/toolbox.sh, external tools like Coverity
can't be expected to do the same. So they complain:
  Line 1:
  [ "$BASH_VERSION" != "" ] || [ "$ZSH_VERSION" != "" ] || return 0
  ^-- SC2148: Tips depend on target shell and yours is unknown. Add a
    shebang or a 'shell' directive.

See: https://github.com/koalaman/shellcheck/wiki/SC2148