### PR TITLE
Check if /mnt exists before adding it as a volume mount

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -313,17 +313,19 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		}
 	}
 
-	logrus.Debug("Checking if /mnt is a symbolic link to /var/mnt")
-
 	var mntLink []string
 	var mntMount []string
 
-	mntPath, _ := filepath.EvalSymlinks("/mnt")
-	if mntPath == "/var/mnt" {
-		logrus.Debug("/mnt is a symbolic link to /var/mnt")
-		mntLink = []string{"--mnt-link"}
-	} else {
-		mntMount = []string{"--volume", "/mnt:/mnt:rslave"}
+	if utils.PathExists("/mnt") {
+		logrus.Debug("Checking if /mnt is a symbolic link to /var/mnt")
+
+		mntPath, _ := filepath.EvalSymlinks("/mnt")
+		if mntPath == "/var/mnt" {
+			logrus.Debug("/mnt is a symbolic link to /var/mnt")
+			mntLink = []string{"--mnt-link"}
+		} else {
+			mntMount = []string{"--volume", "/mnt:/mnt:rslave"}
+		}
 	}
 
 	var runMediaMount []string


### PR DESCRIPTION
Some machine don't have /mnt. This just checks if it exists before trying to bind mount it into the container.

cc @tfmoraes
