### PR TITLE
Update bug-report.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -50,3 +50,5 @@ e.g., Fedora Silverblue 32
 Add any other context about the problem here.
 When did the issue start occurring? After an update (what packages were updated)?
 If the issue is about operating with containers/images (creating, using, deleting,..), share here what image you used. If you're unsure, share here the output of `toolbox list -i` (shows all toolbox images on your system).
+
+If you see an error message saying: `Error: invalid entry point PID of container <name-of-container>`, add to the ticket output of command `podman start --attach <name-of-container>`.


### PR DESCRIPTION
A lot of errors are caused by toolboxes not starting up. In such cases we require
the output of `podman start --attach` to see what is going on. It would be easier
if users provided this information right when they are filling a bug.