### PR TITLE
playbooks, test/system: Avoid downloading the images multiple times

### DIFF
--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -54,9 +54,22 @@
       retries: 5
       delay: 10
 
+    - name: Copy the default image to a directory
+      command:
+        cmd: "skopeo copy containers-storage:registry.fedoraproject.org/fedora-toolbox:{{ ansible_distribution_version }} dir:{{ zuul.project.src_dir }}/fedora-toolbox-{{ ansible_distribution_version }}"
+        creates: "{{ zuul.project.src_dir }}/fedora-toolbox-{{ ansible_distribution_version }}/manifest.json"
+
     - name: Pull registry.fedoraproject.org/f29/fedora-toolbox:29
       command: podman pull registry.fedoraproject.org/f29/fedora-toolbox:29
       register: _podman
       until: _podman.rc == 0
       retries: 5
       delay: 10
+
+    - name: Copy registry.fedoraproject.org/f29/fedora-toolbox:29 to a directory
+      command:
+        cmd: "skopeo copy containers-storage:registry.fedoraproject.org/f29/fedora-toolbox:29 dir:{{ zuul.project.src_dir }}/fedora-toolbox-29"
+        creates: "{{ zuul.project.src_dir }}/fedora-toolbox-29/manifest.json"
+
+    - name: Clean up the local containers storage
+      command: podman system reset --force

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -3,6 +3,8 @@
 # Podman and Toolbox commands to run
 readonly PODMAN=${PODMAN:-podman}
 readonly TOOLBOX=${TOOLBOX:-toolbox}
+readonly SKOPEO=$(command -v skopeo)
+readonly PROJECT_DIR=${PWD}
 
 # Helpful globals
 current_os_version=$(awk -F= '/VERSION_ID/ {print $2}' /etc/os-release)
@@ -30,50 +32,22 @@ function get_busybox_image() {
 function pull_image() {
   local version
   local image
-  local -i count
-  local -i max_retries
-  local -i wait_time
   version="$1"
   image="${REGISTRY_URL}/fedora-toolbox:${version}"
-  count=0
-  max_retries=5
-  wait_time=15
 
-  until ${PODMAN} pull "${image}" >/dev/null ; do
-    sleep $wait_time
-    (( count += 1 ))
-
-    if (( "$count" == "$max_retries" )); then
-      # Max number of retries exceeded
-      echo "Podman couldn't pull the image ${image}."
-      return 1
-    fi
-  done
+  $SKOPEO copy "dir:${PROJECT_DIR}/fedora-toolbox-${version}" "containers-storage:${image}"
+  $PODMAN images
 }
 
 
 function pull_image_old() {
   local version
   local image
-  local -i count
-  local -i max_retries
-  local -i wait_time
   version="$1"
   image="${REGISTRY_URL}/f${version}/fedora-toolbox:${version}"
-  count=0
-  max_retries=5
-  wait_time=15
 
-  until ${PODMAN} pull "${image}" >/dev/null ; do
-    sleep $wait_time
-    (( count += 1 ))
-
-    if (( "$count" == "$max_retries" )); then
-      # Max number of retries exceeded
-      echo "Podman couldn't pull the image ${image}."
-      return 1
-    fi
-  done
+  $SKOPEO copy "dir:${PROJECT_DIR}/fedora-toolbox-${version}" "containers-storage:${image}"
+  $PODMAN images
 }
 
 


### PR DESCRIPTION
Since commit b27795a03ec8ae31, each section of the test suite starts
and ends with a clean Podman state. This includes removing all images
from the local containers storage. Therefore, the images get downloaded
multiple times during the course of the test suite.

This commit restores the earlier behaviour where the images would get
downloaded only once, by copying them to separate directories outside
the local containers storage and then restoring them when the tests
are run.

https://github.com/containers/toolbox/pull/517