### PR TITLE
README: /etc/machine-id is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Paths:
 * `/etc/hosts`: optional, if present not a bind mount
 * `/etc/krb5.conf.d`: directory, not a bind mount
 * `/etc/localtime`: optional, if present not a bind mount
+* `/etc/machine-id`: not a bind mount
 * `/etc/resolv.conf`: optional, if present not a bind mount
 * `/etc/timezone`: optional, if present not a bind mount
 


### PR DESCRIPTION
See discussion on #710. ArchLinux with a missing machine-id fails, but with a machine-id succeeds.

If this is not supposed to be required, I can open a bug report instead.