### PR TITLE
profile.d: Make PROMPT_COMMAND a complete command

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -60,7 +60,7 @@ if [ -f /run/.containerenv ] \
     if ! [ -f /etc/profile.d/vte.sh ] && [ -z "$PROMPT_COMMAND" ] && [ "${VTE_VERSION:-0}" -ge 3405 ]; then
         case "$TERM" in
             xterm*|vte*)
-                [ -n "${BASH_VERSION:-}" ] && PROMPT_COMMAND=" "
+                [ -n "${BASH_VERSION:-}" ] && PROMPT_COMMAND=":"
                 ;;
         esac
     fi


### PR DESCRIPTION
See discussion on #710. Other users may also append a prompt command in a similar way.
Making this a `:` instead ensures that an appended command will not cause an error.