### PR TITLE
Allow override of tmpfilesdir folder

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,11 +15,15 @@ go_md2man = find_program('go-md2man')
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 
-systemd_dep = dependency('systemd')
 bash_completion = dependency('bash-completion', required: false)
 
 profiledir = get_option('profile_dir')
-tmpfilesdir = systemd_dep.get_pkgconfig_variable('tmpfilesdir')
+
+tmpfilesdir = get_option('tmpfiles_dir')
+if tmpfilesdir == ''
+  systemd_dep = dependency('systemd')
+  tmpfilesdir = systemd_dep.get_pkgconfig_variable('tmpfilesdir')
+endif
 
 if bash_completion.found()
   install_data(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,9 @@ option(
   type: 'string',
   value: '/usr/share/profile.d'
 )
+
+option(
+  'tmpfiles_dir',
+  description: 'Directory for system-wide tmpfiles.d(5) files',
+  type: 'string',
+)


### PR DESCRIPTION
* in situations where that directory isn't accessable, it would be nice
  to support installing everything else to a prefix and then instructing
  the user to get those those files installed somehow else.

* I'm not sure if systemd is required if we don't use tmpfilesdir, but
  I'm leaving it outside of the if