### PR TITLE
Include the nano default editor

### DIFF
--- a/images/fedora/f33/extra-packages
+++ b/images/fedora/f33/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nano-default-editor
 nss-mdns
 openssh-clients
 passwd

--- a/images/fedora/f34/extra-packages
+++ b/images/fedora/f34/extra-packages
@@ -20,6 +20,7 @@ man-db
 man-pages
 mlocate
 mtr
+nano-default-editor
 nss-mdns
 openssh-clients
 passwd


### PR DESCRIPTION
Since Fedora 33, `nano` is the default editor[0]. It needs to be
included in the fedora-toolbox image to have the standard Fedora
experience inside the container.

Counterpart of https://src.fedoraproject.org/container/fedora-toolbox/pull-request/3

[0] https://fedoraproject.org/wiki/Changes/UseNanoByDefault