### PR TITLE
cmd/initContainer: Ignore unknown flags

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -122,6 +122,7 @@ func init() {
 		"Create a user inside the toolbox container whose login name is USER")
 	initContainerCmd.MarkFlagRequired("user")
 
+	initContainerCmd.FParseErrWhitelist.UnknownFlags = true
 	initContainerCmd.SetHelpFunc(initContainerHelp)
 	rootCmd.AddCommand(initContainerCmd)
 }


### PR DESCRIPTION
The init-container command uses several flags. In the future we'd like
to minimize their number. In order to be able to do that without
breaking systems with older versions of Toolbox, the command can't error
out due to usage of unknown flags.