### PR TITLE
playbooks/system-test: Show test execution time

### DIFF
--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -24,7 +24,7 @@
         creates: '{{ toolbox_bin }}'
 
     - name: Run system tests
-      command: bats ./test/system
+      command: bats --timing ./test/system
       environment:
         PODMAN: '/usr/bin/podman'
         TOOLBOX: '{{ toolbox_bin }}'


### PR DESCRIPTION
Execution time of a test can be a very useful tool.