### PR TITLE
cmd/create: Cleanup entry-point command assembly

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -377,22 +377,19 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	}
 
 	entryPoint := []string{
-		"toolbox", "--verbose",
+		"toolbox", "--log-level", "debug",
 		"init-container",
 		"--gid", currentUser.Gid,
 		"--home", currentUser.HomeDir,
+		"--shell", userShell,
+		"--uid", currentUser.Uid,
+		"--user", currentUser.Username,
+		"--monitor-host",
 	}
 
 	entryPoint = append(entryPoint, slashHomeLink...)
 	entryPoint = append(entryPoint, mediaLink...)
 	entryPoint = append(entryPoint, mntLink...)
-
-	entryPoint = append(entryPoint, []string{
-		"--monitor-host",
-		"--shell", userShell,
-		"--uid", currentUser.Uid,
-		"--user", currentUser.Username,
-	}...)
 
 	createArgs := []string{
 		"--log-level", logLevelString,


### PR DESCRIPTION
Too many appends. Instead, put the required sequence into a single array
and append only the variable parts.

Instead of calling "init-container" with "--verbose", call it rather
with "--log-level debug".