### PR TITLE
cmd: Properly wrap around errors

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -125,14 +125,14 @@ func listContainers() ([]toolboxContainer, error) {
 	args := []string{"--all", "--filter", "label=com.github.containers.toolbox=true"}
 	containers_old, err := podman.GetContainers(args...)
 	if err != nil {
-		return nil, errors.New("failed to list containers with label=com.github.containers.toolbox=true")
+		return nil, fmt.Errorf("failed to list containers with label=com.github.containers.toolbox=true: %w", err)
 	}
 
 	logrus.Debug("Fetching containers with label=com.github.debarshiray.toolbox=true")
 	args = []string{"--all", "--filter", "label=com.github.debarshiray.toolbox=true"}
 	containers_new, err := podman.GetContainers(args...)
 	if err != nil {
-		return nil, errors.New("failed to list containers with label=com.github.debarshiray.toolbox=true")
+		return nil, fmt.Errorf("failed to list containers with label=com.github.debarshiray.toolbox=true: %w", err)
 	}
 
 	var containers []map[string]interface{}

--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -74,14 +74,14 @@ func rm(cmd *cobra.Command, args []string) error {
 		args := []string{"--all", "--filter", "label=com.github.containers.toolbox=true"}
 		containers_old, err := podman.GetContainers(args...)
 		if err != nil {
-			return errors.New("failed to list containers with label=com.github.containers.toolbox=true")
+			return fmt.Errorf("failed to list containers with label=com.github.containers.toolbox=true: %w", err)
 		}
 
 		logrus.Debug("Fetching containers with label=com.github.debarshiray.toolbox=true")
 		args = []string{"--all", "--filter", "label=com.github.debarshiray.toolbox=true"}
 		containers_new, err := podman.GetContainers(args...)
 		if err != nil {
-			return errors.New("failed to list containers with com.github.debarshiray.toolbox=true")
+			return fmt.Errorf("failed to list containers with com.github.debarshiray.toolbox=true: %w", err)
 		}
 
 		var idKey string

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -74,14 +74,14 @@ func rmi(cmd *cobra.Command, args []string) error {
 		args := []string{"--filter", "label=com.github.containers.toolbox=true"}
 		images_old, err := podman.GetImages(args...)
 		if err != nil {
-			return errors.New("failed to list images with label=com.github.containers.toolbox=true")
+			return fmt.Errorf("failed to list images with label=com.github.containers.toolbox=true: %w", err)
 		}
 
 		logrus.Debug("Fetching images with label=com.github.debarshiray.toolbox=true")
 		args = []string{"--filter", "label=com.github.debarshiray.toolbox=true"}
 		images_new, err := podman.GetImages(args...)
 		if err != nil {
-			return errors.New("failed to list images with com.github.debarshiray.toolbox=true")
+			return fmt.Errorf("failed to list images with com.github.debarshiray.toolbox=true: %w", err)
 		}
 
 		var idKey string


### PR DESCRIPTION
While we mostly report an error correctly, we do not include (wrap) the
underlying cause. This can make debugging tricky at times.