### PR TITLE
playbooks: Properly separate builddir setup & build

### DIFF
--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -5,13 +5,18 @@
     toolbox_bin: '/usr/local/bin/toolbox'
 
   tasks:
-    - name: Build toolbox
+    - name: Set up build directory
       command: meson builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Build Toolbox
+      command: ninja -C builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
         creates: builddir/src/toolbox
 
-    - name: Install toolbox
+    - name: Install Toolbox
       become: yes
       command: ninja -C builddir install
       args:

--- a/playbooks/unit-test.yaml
+++ b/playbooks/unit-test.yaml
@@ -11,10 +11,16 @@
           - meson
           - ShellCheck
 
-    - name: Build
+    - name: Set up build directory
       command: meson builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Build Toolbox
+      command: ninja -C builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+        creates: builddir/src/toolbox
 
     - name: Test
       command: ninja -C builddir test


### PR DESCRIPTION
Call "meson builddir" makes Meson create a build directory called
"builddir". It does not make it build the project. A subsequent call to
"meson compile" or "ninja" needs to be made. This subtle detail causes
a minor (purely visual) discrepancy in the CI output. Fix this for both
unit-test & system-test job definitions.