### PR TITLE
build: Drop ShellCheck on Shell Toolbox

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -21,12 +21,6 @@ bash_completion = dependency('bash-completion', required: false)
 profiledir = get_option('profile_dir')
 tmpfilesdir = systemd_dep.get_pkgconfig_variable('tmpfilesdir')
 
-toolbox = files('toolbox')
-
-if shellcheck.found()
-  test('shellcheck', shellcheck, args: [toolbox])
-endif
-
 if bash_completion.found()
   install_data(
     'completion/bash/toolbox',


### PR DESCRIPTION
Shell Toolbox has been replaced by the Go implementation a quite while
ago. It is kept in the repository but is no longer actively developed.
There is no need to continue checking it with ShellCheck.