### PR TITLE
utils: bump Fedora fallback version to 33

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -52,7 +52,7 @@ type Distro struct {
 
 const (
 	idTruncLength          = 12
-	releaseDefaultFallback = "32"
+	releaseDefaultFallback = "33"
 )
 
 const (


### PR DESCRIPTION
32 is approaching EOL

see also #546