### PR TITLE
Update references to the default branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ When writing a suggestion:
 Toolbox is written in [Go](https://golang.org) and uses [Meson](https://mesonbuild.com)
 as it's buildsystem.
 
-Instructions for building Toolbox from source are in our [README](https://github.com/containers/toolbox/blob/master/README.md).
+Instructions for building Toolbox from source are in our [README](https://github.com/containers/toolbox/blob/main/README.md).
 
 > You may not need to build the project from source if your contribution is not
 > related to the code of Toolbox itself (e.g., documentation, updating CI

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ It can be built and installed as any other typical Meson-based project:
 ```
 
 Toolbox is written in Go. Consult the
-[src/go.mod](https://github.com/containers/toolbox/blob/master/src/go.mod) file
+[src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file
 for a full list of all the Go dependencies.
 
 By default, Toolbox uses Go modules and all the required Go packages are

--- a/images/fedora/f32/README.md
+++ b/images/fedora/f32/README.md
@@ -86,7 +86,7 @@ It can be built and installed as any other typical Meson-based project:
 ```
 
 Toolbox is written in Go. Consult the
-[src/go.mod](https://github.com/containers/toolbox/blob/master/src/go.mod) file
+[src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file
 for a full list of all the Go dependencies.
 
 By default, Toolbox uses Go modules and all the required Go packages are

--- a/images/fedora/f33/README.md
+++ b/images/fedora/f33/README.md
@@ -86,7 +86,7 @@ It can be built and installed as any other typical Meson-based project:
 ```
 
 Toolbox is written in Go. Consult the
-[src/go.mod](https://github.com/containers/toolbox/blob/master/src/go.mod) file
+[src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file
 for a full list of all the Go dependencies.
 
 By default, Toolbox uses Go modules and all the required Go packages are

--- a/images/fedora/f34/README.md
+++ b/images/fedora/f34/README.md
@@ -86,7 +86,7 @@ It can be built and installed as any other typical Meson-based project:
 ```
 
 Toolbox is written in Go. Consult the
-[src/go.mod](https://github.com/containers/toolbox/blob/master/src/go.mod) file
+[src/go.mod](https://github.com/containers/toolbox/blob/main/src/go.mod) file
 for a full list of all the Go dependencies.
 
 By default, Toolbox uses Go modules and all the required Go packages are


### PR DESCRIPTION
The default branch was renamed from "master" to "main".

https://github.com/containers/toolbox/issues/740