### PR TITLE
Enable GitHub dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/src"
+    schedule:
+        interval: "daily"


### PR DESCRIPTION
Why update dependencies manually when it can be done by a tool.