### PR TITLE
cmd/create: Unbreak the spinner and the hint about using the container

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -203,17 +203,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		return err
 	}
 
-	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
-
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
-		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
-		s.Writer = os.Stdout
-		s.Start()
-		defer s.Stop()
-	}
-
 	toolboxPath := os.Getenv("TOOLBOX_PATH")
 	toolboxPathEnvArg := "TOOLBOX_PATH=" + toolboxPath
 	toolboxPathMountArg := toolboxPath + ":/usr/bin/toolbox:ro"
@@ -466,9 +455,23 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		logrus.Debugf("%s", arg)
 	}
 
+	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
+
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
+		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
+		s.Writer = os.Stdout
+		s.Start()
+		defer s.Stop()
+	}
+
 	if err := shell.Run("podman", nil, nil, nil, createArgs...); err != nil {
 		return fmt.Errorf("failed to create container %s", container)
 	}
+
+	// The spinner must be stopped before showing the 'enter' hit below.
+	s.Stop()
 
 	if showCommandToEnter {
 		fmt.Printf("Created container: %s\n", container)


### PR DESCRIPTION
The spinner needs to be explicitly stopped before showing the example
'enter' command for using the container. Otherwise, it gets misprinted:
```
  $ toolbox create foo
  Creating container foo: / Created container: foo
  Enter with: toolbox enter foo
```

A comment was added to highlight this, since it might not be obvious at
first sight.

Due to such potential quirks, it might be better to keep the spinner
somewhat tightly encapsulated with the code that necessitates it, which
in this case is `podman create`. For instance, we already need to be
careful to avoid enclosing the `pullImage` function with a spinner
because it carries it's own.

The code lying between the `podman pull` and the `podman create` is so
light that a human user isn't able to discern the absence of a
spinner. So, it seems worth leaning towards ease of understanding and
avoiding potential traps.

This reverts commit 3aaa1d30f16e249c11d8680e2d27e64f14142990.