### PR TITLE
Add more usage examples to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This will create a container called `fedora-toolbox-<version-id>`.
 
 ### Define toolbox container with a Containerfile:
 
-The parent image must satisfy the [image requirements](##Image-requirements).
+The parent image must satisfy the [image requirements](#Image-requirements).
 
 ```Dockerfile
 FROM registry.opensuse.org/opensuse/toolbox

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This will create a container called `fedora-toolbox-<version-id>`.
 
 ### Specify image for toolbox container:
 ```console
-[user@hostname ~]$ toolbox create --image registry.opensuse.org/opensuse/toolbox
+[user@hostname ~]$ toolbox create --image registry.fedoraproject.org/f34/fedora-toolbox:34 fedora34-toolbox
 [user@hostname ~]$
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,14 +71,14 @@ This will create a container called `fedora-toolbox-<version-id>`.
 
 ### Create multiple toolbox containers:
 ```console
-[user@hostname ~]$ toolbox create --container toolbox1
-[user@hostname ~]$ toolbox create --container toolbox2
+[user@hostname ~]$ toolbox create toolbox1
+[user@hostname ~]$ toolbox create toolbox2
 [user@hostname ~]$
 ```
 
 ### Enter a toolbox container by name:
 ```console
-[user@hostname ~]$ toolbox enter --container toolbox2
+[user@hostname ~]$ toolbox enter toolbox2
 ⬢[user@toolbox ~]$
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,44 @@ This will create a container called `fedora-toolbox-<version-id>`.
 [user@hostname ~]$
 ```
 
+### Specify image for toolbox container:
+```console
+[user@hostname ~]$ toolbox create --image registry.opensuse.org/opensuse/toolbox
+[user@hostname ~]$
+```
+
+### Create multiple toolbox containers:
+```console
+[user@hostname ~]$ toolbox create --container toolbox1
+[user@hostname ~]$ toolbox create --container toolbox2
+[user@hostname ~]$
+```
+
+### Enter a toolbox container by name:
+```console
+[user@hostname ~]$ toolbox enter --container toolbox2
+⬢[user@toolbox ~]$
+```
+
+### Define toolbox container with a Containerfile:
+
+The parent image must satisfy the [image requirements](##Image-requirements).
+
+```Dockerfile
+FROM registry.opensuse.org/opensuse/toolbox
+RUN zypper in -y emacs git
+RUN zypper in -t pattern devel_C_C++
+```
+
+In the directory of the Containerfile do:
+
+```console
+[user@hostname ~]$ podman build -t my-dev-toolbox .
+[user@hostname ~]$ toolbox create --image localhost/my-dev-toolbox --container my-dev-toolbox
+[user@hostname ~]$ toolbox enter --container my-dev-toolbox
+⬢[user@toolbox ~]$
+```
+
 ## Dependencies and Building
 
 Toolbox requires at least Podman 1.4.0 to work, and uses the Meson build


### PR DESCRIPTION
These are things that I did not know was possible until it was pointed out to
me by @pierreprinetti in https://github.com/containers/toolbox/issues/758

I actually looked at the `--help` output and played around a while but gave up thinking this kind of use was not possible.

Use the opensuse toolbox image in the examples partly as that is what I am comfortable with but
also because I suspect that the mention of another distro sets the feeling that this
is not just for Fedora.