### PR TITLE
cmd/root: Replace the usage function with a template

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -91,7 +91,7 @@ func init() {
 	persistentFlags.CountVarP(&rootFlags.verbose, "verbose", "v", "Set log-level to 'debug'")
 
 	rootCmd.SetHelpFunc(rootHelp)
-	rootCmd.SetUsageFunc(rootUsage)
+    rootCmd.SetUsageTemplate("Run '{{ .CommandPath }} --help' for usage.")
 }
 
 func preRun(cmd *cobra.Command, args []string) error {
@@ -185,16 +185,10 @@ func rootRun(cmd *cobra.Command, args []string) error {
 	fmt.Fprintf(&builder, "enter     Enter an existing toolbox container\n")
 	fmt.Fprintf(&builder, "list      List all existing toolbox containers and images\n")
 	fmt.Fprintf(&builder, "\n")
-	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
+	fmt.Fprintf(&builder, cmd.UsageString())
 
 	errMsg := builder.String()
 	return errors.New(errMsg)
-}
-
-func rootUsage(cmd *cobra.Command) error {
-	err := fmt.Errorf("Run '%s --help' for usage.", executableBase)
-	fmt.Fprintf(os.Stderr, "%s", err)
-	return err
 }
 
 func migrate() error {


### PR DESCRIPTION
Templates are more dynamic when it comes to context switched. The usage
recognizes as a different context every command/subcommand. Instead of
suggesting:

  "Run 'toolbox --help' for usage."

for every command, it makes more sense to suggest:

  "Run 'toolbox <command> --help.".

This can be achieved either by setting a specific function for every
command, setting a function that gathers all the necessary info or by
using a template string. This implements the third approach.

The approach causes the loss of specific binary in cases when the binary
has been renamed from "toolbox" to something else because the template
relies on data provided to Cobra, the CLI framework. To me this seems
like an acceptable trade-off because we never allowed renaming of the
binary anyway.

To make use of this in all other command, all lines with:

  "Run 'toolbox --help' for usage."

will have to be replaced with cmd.UsageString() or an analogous function
working with the usage string. This is problematic since this requires
access to the cmd variable (cobra.Command) which is not possible in all
cases in cmd/enter.go and cmd/run.go. These functions will have to be
refactored to make use of this.