### PR TITLE
test/system: Use env var for invoking Toolbox

### DIFF
--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -2,9 +2,10 @@
 
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
+load 'libs/helpers.bash'
 
 @test "version: Check version using option --version" {
-  run toolbox --version
+  run $TOOLBOX --version
 
   assert_output --regexp '^toolbox version [0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'
 }

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -2,9 +2,10 @@
 
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
+load 'libs/helpers.bash'
 
 @test "help: Try to run toolbox with no command (shows usage screen)" {
-  run toolbox
+  run $TOOLBOX
 
   assert_failure
   assert_line --index 0 "Error: missing command"
@@ -12,21 +13,21 @@ load 'libs/bats-assert/load'
 }
 
 @test "help: Run command 'help'" {
-  run toolbox help
+  run $TOOLBOX help
 
   assert_success
   assert_output --partial "toolbox - Unprivileged development environment"
 }
 
 @test "help: Use flag '--help' (it should show usage screen)" {
-  run toolbox --help
+  run $TOOLBOX --help
 
   assert_success
   assert_output --partial "toolbox - Unprivileged development environment"
 }
 
 @test "help: Try to run toolbox with non-existent command (shows usage screen)" {
-  run toolbox foo
+  run $TOOLBOX foo
 
   assert_failure
   assert_line --index 0 "Error: unknown command \"foo\" for \"toolbox\""

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -16,13 +16,13 @@ teardown() {
 @test "create: Create the default container" {
   pull_default_image
 
-  run toolbox -y create
+  run $TOOLBOX -y create
 
   assert_success
 }
 
 @test "create: Create a container with a valid custom name ('custom-containerName')" {
-  run toolbox -y create -c "custom-containerName"
+  run $TOOLBOX -y create -c "custom-containerName"
 
   assert_success
 }
@@ -30,13 +30,13 @@ teardown() {
 @test "create: Create a container with a custom image and name ('fedora29'; f29)" {
   pull_image_old 29
 
-  run toolbox -y create -c "fedora29" -i fedora-toolbox:29
+  run $TOOLBOX -y create -c "fedora29" -i fedora-toolbox:29
 
   assert_success
 }
 
 @test "create: Try to create a container with invalid custom name ('ßpeci@l.Nam€'; using positional argument)" {
-  run toolbox -y create "ßpeci@l.Nam€"
+  run $TOOLBOX -y create "ßpeci@l.Nam€"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for 'CONTAINER'"
@@ -45,7 +45,7 @@ teardown() {
 }
 
 @test "create: Try to create a container with invalid custom name ('ßpeci@l.Nam€'; using option --container)" {
-  run toolbox -y create -c "ßpeci@l.Nam€"
+  run $TOOLBOX -y create -c "ßpeci@l.Nam€"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--container'"
@@ -56,7 +56,7 @@ teardown() {
 @test "create: Create a container with a distro and release options ('fedora'; f29)" {
   pull_image 29
 
-  run toolbox -y create -d "fedora" -r f29
+  run $TOOLBOX -y create -d "fedora" -r f29
 
   assert_success
   assert_output --partial "Created container: fedora-toolbox-29"

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -14,21 +14,21 @@ teardown() {
 
 
 @test "list: Run 'list' with zero containers and zero images (the list should be empty)" {
-  run toolbox list
+  run $TOOLBOX list
 
   assert_success
   assert_output ""
 }
 
 @test "list: Run 'list -c' with zero containers (the list should be empty)" {
-  run toolbox list -c
+  run $TOOLBOX list -c
 
   assert_success
   assert_output ""
 }
 
 @test "list: Run 'list -i' with zero images (the list should be empty)" {
-  run toolbox list -c
+  run $TOOLBOX list -c
 
   assert_success
   assert_output ""
@@ -41,7 +41,7 @@ teardown() {
 
   assert_output --partial "$BUSYBOX_IMAGE"
 
-  run toolbox list
+  run $TOOLBOX list
 
   assert_success
   assert_output ""
@@ -57,14 +57,14 @@ teardown() {
   create_container non-default-two
 
   # Check images
-  run toolbox list --images
+  run $TOOLBOX list --images
 
   assert_success
   assert_output --partial "fedora-toolbox:${DEFAULT_FEDORA_VERSION}"
   assert_output --partial "fedora-toolbox:29"
 
   # Check containers
-  run toolbox list --containers
+  run $TOOLBOX list --containers
 
   assert_success
   assert_output --partial "fedora-toolbox-${DEFAULT_FEDORA_VERSION}"
@@ -72,7 +72,7 @@ teardown() {
   assert_output --partial "non-default-two"
 
   # Check all together
-  run toolbox list
+  run $TOOLBOX list
 
   assert_success
   assert_output --partial "fedora-toolbox:${DEFAULT_FEDORA_VERSION}"

--- a/test/system/103-run.bats
+++ b/test/system/103-run.bats
@@ -21,7 +21,7 @@ teardown() {
 
 
 @test "run: Try to run echo 'Hello World' with no containers created" {
-  run toolbox run echo "Hello World"
+  run $TOOLBOX run echo "Hello World"
 
   assert_failure
   assert_line --index 0 --regexp 'Error: container .* not found'
@@ -33,7 +33,7 @@ teardown() {
 @test "run: Run echo 'Hello World' inside of the default container" {
   create_default_container
 
-  run toolbox --verbose run echo "Hello World"
+  run $TOOLBOX --verbose run echo "Hello World"
 
   assert_success
   assert_output --partial "Hello World"
@@ -45,7 +45,7 @@ teardown() {
   start_container running
   stop_container running
 
-  run toolbox --verbose run --container running echo -n "Hello World"
+  run $TOOLBOX --verbose run --container running echo -n "Hello World"
 
   assert_success
   assert_output --partial "Hello World"
@@ -54,7 +54,7 @@ teardown() {
 @test "run: Run sudo id inside of the default container" {
   create_default_container
 
-  run toolbox --verbose run sudo id
+  run $TOOLBOX --verbose run sudo id
 
   assert_success
   assert_output --partial "uid=0(root)"

--- a/test/system/104-rm.bats
+++ b/test/system/104-rm.bats
@@ -15,7 +15,7 @@ teardown() {
 
 @test "rm: Try to remove a non-existent container" {
   container_name="nonexistentcontainer"
-  run toolbox rm "$container_name"
+  run $TOOLBOX rm "$container_name"
 
   #assert_failure  #BUG: it should return 1
   assert_output "Error: failed to inspect container $container_name"
@@ -26,7 +26,7 @@ teardown() {
   create_container running
   start_container running
 
-  run toolbox rm running
+  run $TOOLBOX rm running
 
   #assert_failure  #BUG: it should return 1
   assert_output "Error: container running is running"
@@ -35,7 +35,7 @@ teardown() {
 @test "rm: Remove a not running container" {
   create_container not-running
 
-  run toolbox rm not-running
+  run $TOOLBOX rm not-running
 
   assert_success
   assert_output ""
@@ -45,7 +45,7 @@ teardown() {
   create_container running
   start_container running
 
-  run toolbox rm --force running
+  run $TOOLBOX rm --force running
 
   assert_success
   assert_output ""
@@ -59,7 +59,7 @@ teardown() {
   create_container not-running
   start_container running
 
-  run toolbox rm --force --all
+  run $TOOLBOX rm --force --all
 
   assert_success
   assert_output ""

--- a/test/system/105-rmi.bats
+++ b/test/system/105-rmi.bats
@@ -19,7 +19,7 @@ teardown() {
 
   pull_default_image
 
-  run toolbox rmi --all
+  run $TOOLBOX rmi --all
 
   assert_success
   assert_output ""
@@ -37,7 +37,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run toolbox rmi --all
+  run $TOOLBOX rmi --all
 
   assert_failure
   assert_output --regexp "Error: image .* has dependent children"
@@ -54,7 +54,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run toolbox rmi --all --force
+  run $TOOLBOX rmi --all --force
 
   assert_success
   assert_output ""


### PR DESCRIPTION
The system test refactor[0] replaced the 'run_toolbox' helper function
with 'run toolbox', which is a normal invocation of Toolbox. This makes
it impossible to override Toolbox used during the tests using env var.

[0] https://github.com/containers/toolbox/pull/693