### PR TITLE
test/system: Don't use sudo for executing commands as root

### DIFF
--- a/test/system/103-run.bats
+++ b/test/system/103-run.bats
@@ -51,10 +51,10 @@ teardown() {
   assert_output --partial "Hello World"
 }
 
-@test "run: Run sudo id inside of the default container" {
+@test "run: Run id inside of the default container as root" {
   create_default_container
 
-  run $TOOLBOX --verbose run sudo id
+  run $TOOLBOX --verbose run su -c "id"
 
   assert_success
   assert_output --partial "uid=0(root)"


### PR DESCRIPTION
The use of sudo when executing commands in a toolbox using 'toolbox run'
causes problem in the Zuul environment. I don't know what is causing
that but it makes the CI unreliable. Replace the use of sudo with
'su -c'.

Supersedes #705 