### PR TITLE
ci: Drop testing on Fedora 32

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,20 +5,9 @@
     timeout: 300
     nodeset:
       nodes:
-        - name: ci-node-32
-          label: cloud-fedora-32-small
+        - name: ci-node-33
+          label: cloud-fedora-33-small
     run: playbooks/unit-test.yaml
-
-- job:
-    name: system-test-fedora-32
-    description: Run Toolbox's system tests in Fedora 32
-    timeout: 1200
-    nodeset:
-      nodes:
-        - name: ci-node-32
-          label: cloud-fedora-32-small
-    pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
 
 - job:
     name: system-test-fedora-33
@@ -56,21 +45,18 @@
 - project:
     periodic:
       jobs:
-        - system-test-fedora-32
         - system-test-fedora-33
         - system-test-fedora-34
         - system-test-fedora-rawhide
     check:
       jobs:
         - unit-test
-        - system-test-fedora-32
         - system-test-fedora-33
         - system-test-fedora-34
         - system-test-fedora-rawhide
     gate:
       jobs:
         - unit-test
-        - system-test-fedora-32
         - system-test-fedora-33
         - system-test-fedora-34
         - system-test-fedora-rawhide


### PR DESCRIPTION
Fedora 32 has reached EOL in 25/05/2021[0]. Bye bye...

[0] https://fedorapeople.org/groups/schedule/f-32/f-32-all-tasks.html