### PR TITLE
test/system: Bump secondary fedora image from 29 to 32

### DIFF
--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -59,17 +59,17 @@
         cmd: "skopeo copy containers-storage:registry.fedoraproject.org/fedora-toolbox:{{ ansible_distribution_version }} dir:{{ zuul.project.src_dir }}/fedora-toolbox-{{ ansible_distribution_version }}"
         creates: "{{ zuul.project.src_dir }}/fedora-toolbox-{{ ansible_distribution_version }}/manifest.json"
 
-    - name: Pull registry.fedoraproject.org/f29/fedora-toolbox:29
-      command: podman pull registry.fedoraproject.org/f29/fedora-toolbox:29
+    - name: Pull registry.fedoraproject.org/fedora-toolbox:32
+      command: podman pull registry.fedoraproject.org/fedora-toolbox:32
       register: _podman
       until: _podman.rc == 0
       retries: 5
       delay: 10
 
-    - name: Copy registry.fedoraproject.org/f29/fedora-toolbox:29 to a directory
+    - name: Copy registry.fedoraproject.org/fedora-toolbox:32 to a directory
       command:
-        cmd: "skopeo copy containers-storage:registry.fedoraproject.org/f29/fedora-toolbox:29 dir:{{ zuul.project.src_dir }}/fedora-toolbox-29"
-        creates: "{{ zuul.project.src_dir }}/fedora-toolbox-29/manifest.json"
+        cmd: "skopeo copy containers-storage:registry.fedoraproject.org/fedora-toolbox:32 dir:{{ zuul.project.src_dir }}/fedora-toolbox-32"
+        creates: "{{ zuul.project.src_dir }}/fedora-toolbox-32/manifest.json"
 
     - name: Clean up the local containers storage
       command: podman system reset --force

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=sh
 
+# shellcheck disable=SC2153
 [ "$BASH_VERSION" != "" ] || [ "$ZSH_VERSION" != "" ] || return 0
 [ "$PS1" != "" ] || return 0
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -27,10 +27,10 @@ teardown() {
   assert_success
 }
 
-@test "create: Create a container with a custom image and name ('fedora29'; f29)" {
-  pull_image_old 29
+@test "create: Create a container with a custom image and name ('fedora32'; f32)" {
+  pull_image 32
 
-  run $TOOLBOX -y create -c "fedora29" -i fedora-toolbox:29
+  run $TOOLBOX -y create -c "fedora32" -i fedora-toolbox:32
 
   assert_success
 }
@@ -53,17 +53,17 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
-@test "create: Create a container with a distro and release options ('fedora'; f29)" {
-  pull_image 29
+@test "create: Create a container with a distro and release options ('fedora'; f32)" {
+  pull_image 32
 
-  run $TOOLBOX -y create -d "fedora" -r f29
+  run $TOOLBOX -y create -d "fedora" -r f32
 
   assert_success
-  assert_output --partial "Created container: fedora-toolbox-29"
-  assert_output --partial "Enter with: toolbox enter --release 29"
+  assert_output --partial "Created container: fedora-toolbox-32"
+  assert_output --partial "Enter with: toolbox enter --release 32"
 
   # Make sure the container has actually been created
   run podman ps -a
 
-  assert_output --regexp "Created[[:blank:]]+fedora-toolbox-29"
+  assert_output --regexp "Created[[:blank:]]+fedora-toolbox-32"
 }

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -50,7 +50,7 @@ teardown() {
 @test "list: Try to list images and containers (no flag) with 3 containers and 2 images (the list should have 3 images and 2 containers)" {
   # Pull the two images
   pull_default_image
-  pull_image_old 29
+  pull_image 32
   # Create tree containers
   create_default_container
   create_container non-default-one
@@ -61,7 +61,7 @@ teardown() {
 
   assert_success
   assert_output --partial "fedora-toolbox:${DEFAULT_FEDORA_VERSION}"
-  assert_output --partial "fedora-toolbox:29"
+  assert_output --partial "fedora-toolbox:32"
 
   # Check containers
   run $TOOLBOX list --containers
@@ -76,7 +76,7 @@ teardown() {
 
   assert_success
   assert_output --partial "fedora-toolbox:${DEFAULT_FEDORA_VERSION}"
-  assert_output --partial "fedora-toolbox:29"
+  assert_output --partial "fedora-toolbox:32"
   assert_output --partial "fedora-toolbox-${DEFAULT_FEDORA_VERSION}"
   assert_output --partial "non-default-one"
   assert_output --partial "non-default-two"

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -40,17 +40,6 @@ function pull_image() {
 }
 
 
-function pull_image_old() {
-  local version
-  local image
-  version="$1"
-  image="${REGISTRY_URL}/f${version}/fedora-toolbox:${version}"
-
-  $SKOPEO copy "dir:${PROJECT_DIR}/fedora-toolbox-${version}" "containers-storage:${image}"
-  $PODMAN images
-}
-
-
 function pull_default_image() {
   pull_image "${DEFAULT_FEDORA_VERSION}"
 }


### PR DESCRIPTION
The fedora-toolbox:32 image is the first of images in the renamed
toolbox image repository[0]. With the change we can drop the
pull_image_old() function because it was kept only for the old image.

[0] https://github.com/containers/toolbox/pull/615