### PR TITLE
cmd/list, test/system: Ignore the problem of UBI not being listed

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -52,18 +52,11 @@ var (
 		onlyImages     bool
 	}
 
-	// toolboxImageLabels holds labels used by images that mark them as compatible with Toolbox
-	toolboxImageLabels = map[string]string{
+	// toolboxLabels holds labels used by containers/images that mark them as compatible with Toolbox
+	toolboxLabels = map[string]string{
 		"com.github.debarshiray.toolbox": "true",
 		"com.github.containers.toolbox":  "true",
-        "com.redhat.component": "ubi8-container",
 	}
-
-    // toolboxContainerLabels holds labels used by container that mark them as compatible with Toolbox
-    toolboxContainerLabels = map[string]string{
-        "com.github.debarshiray.toolbox": "true",
-        "com.github.containers.toolbox": "true",
-    }
 )
 
 var listCmd = &cobra.Command{
@@ -164,7 +157,7 @@ func getContainers() ([]toolboxContainer, error) {
 			continue
 		}
 
-		for label := range toolboxContainerLabels {
+		for label := range toolboxLabels {
 			if _, ok := c.Labels[label]; ok {
 				isToolboxContainer = true
 				break
@@ -229,7 +222,7 @@ func getImages() ([]toolboxImage, error) {
 			continue
 		}
 
-		for label := range toolboxImageLabels {
+		for label := range toolboxLabels {
 			if _, ok := i.Labels[label]; ok {
 				isToolboxImage = true
 				break

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -7,6 +7,5 @@ load 'libs/helpers'
     _pull_and_cache_distro_image $(get_system_id) $(get_system_version) || die
     # Cache all images that will be needed during the tests
     _pull_and_cache_distro_image fedora 32 || die
-    _pull_and_cache_distro_image rhel 8.4 || die
     _pull_and_cache_distro_image busybox || die
 }

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -82,31 +82,3 @@ teardown() {
   assert_output --partial "non-default-one"
   assert_output --partial "non-default-two"
 }
-
-@test "list: Run 'list -i' with UBI image (8.4; public) present" {
-  pull_distro_image rhel 8.4
-
-  run toolbox list --images
-
-  assert_success
-  assert_output --partial "registry.access.redhat.com/ubi8/ubi:8.4"
-}
-
-@test "list: Run 'list' with UBI image (8.4; public), toolbox container and non-toolbox container" {
-  local num_of_containers
-
-  pull_distro_image rhel 8.4
-
-  create_distro_container rhel 8.4 rhel-toolbox
-  podman create --name podman-container ubi8/ubi:8.4 /bin/sh
-
-  num_of_containers=$(list_containers)
-  assert [ $num_of_containers -eq 2 ]
-
-  run toolbox list
-
-  assert_success
-  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/ubi:8.4"
-  assert_line --index 3 --partial "rhel-toolbox"
-  refute_output --partial "podman-container"
-}

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -14,7 +14,7 @@ readonly IMAGE_CACHE_DIR="${PROJECT_DIR}/image-cache"
 # Images
 declare -Ag IMAGES=([busybox]="docker.io/library/busybox" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
-                   [rhel]="registry.access.redhat.com/ubi8/ubi")
+                   [rhel]="registry.access.redhat.com/ubi8")
 
 
 function cleanup_all() {


### PR DESCRIPTION
Not having the corresponding image for UBI toolbox containers show up
in 'toolbox list' is a rough edge. However, the whole UBI feature is
a bit experimental. It's about a gratis RHEL environment getting
created in a jiffy on any host, which is something that hasn't been
done before, and those containers also suffer from various shortcomings
because of the limited package set of UBI.

So it's not that big of a problem if it takes a release or two to
hammer out the details. Especially since it's likely that there will
be a special Toolbox-specific image that's created out of the UBI RPM
repositories, which will likely have the com.github.containers.toolbox
label.

There's also the issue that 0.1.0 needs to be finished, and for that
the the churn needs to be kept down. Changing the labels can very
likely lead to compatibility issues in the future, because of which it
either can't be removed for a while or the wrong images start to get
listed. Some of the older labels have finally been removed, so it's
better not to add more to the list.

In short, this problem will likely fix itself in the coming months, so
it's wise not to create complications trying to rush through a fix.

This reverts commits 1df36591d02d4fe32c2579c8b4d6c96fca9a406f and
e09de9f3e53dee80eec33619b8773a85a1fb863d.

https://github.com/containers/toolbox/issues/753