### PR TITLE
README.md, cmd/initContainer: Don't require /etc/machine-id in images

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Paths:
 * `/etc/hosts`: optional, if present not a bind mount
 * `/etc/krb5.conf.d`: directory, not a bind mount
 * `/etc/localtime`: optional, if present not a bind mount
-* `/etc/machine-id`: not a bind mount
+* `/etc/machine-id`: optional, not a bind mount
 * `/etc/resolv.conf`: optional, if present not a bind mount
 * `/etc/timezone`: optional, if present not a bind mount
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -461,7 +461,7 @@ func mountBind(containerPath, source, flags string) error {
 	if fileMode.IsDir() {
 		logrus.Debugf("Creating directory %s", containerPath)
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
-			return fmt.Errorf("failed to create directory %s", containerPath)
+			return fmt.Errorf("failed to create directory %s: %w", containerPath, err)
 		}
 	}
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -463,6 +463,15 @@ func mountBind(containerPath, source, flags string) error {
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", containerPath, err)
 		}
+	} else if fileMode.IsRegular() {
+		logrus.Debugf("Creating regular file %s", containerPath)
+
+		containerPathFile, err := os.Create(containerPath)
+		if err != nil && !os.IsExist(err) {
+			return fmt.Errorf("failed to create regular file %s: %w", containerPath, err)
+		}
+
+		defer containerPathFile.Close()
 	}
 
 	logrus.Debugf("Binding %s to %s", containerPath, source)

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -456,10 +456,12 @@ func mountBind(containerPath, source, flags string) error {
 		return fmt.Errorf("failed to stat %s", source)
 	}
 
-	if fi.IsDir() {
-		logrus.Debugf("Creating %s", containerPath)
+	fileMode := fi.Mode()
+
+	if fileMode.IsDir() {
+		logrus.Debugf("Creating directory %s", containerPath)
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
-			return fmt.Errorf("failed to create %s", containerPath)
+			return fmt.Errorf("failed to create directory %s", containerPath)
 		}
 	}
 


### PR DESCRIPTION
Since `/etc/machine-id` is bind mounted into the toolbox container from
the host operating system, it doesn't make sense to make it mandatory
for images to have that file. Apparently, (some?) Arch Linux images
don't have `/etc/machine-id`.

Since a missing `containerPath` for a directory is handled the same way,
there's no reason not to do the same for regular files. It will make
life a bit easier for those creating toolbox images for different
distributions.

https://github.com/containers/toolbox/pull/710
