### PR TITLE
cmd/rm, cmd/rmi: Style fixes

### DIFF
--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -69,8 +69,6 @@ func rm(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmFlags.deleteAll {
-		var toolboxContainers []toolboxContainer
-
 		toolboxContainers, err := getContainers()
 		if err != nil {
 			return err

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -69,8 +69,6 @@ func rmi(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmiFlags.deleteAll {
-		var toolboxImages []toolboxImage
-
 		toolboxImages, err := getImages()
 		if err != nil {
 			return err


### PR DESCRIPTION
Fallout from 06dcdbe2a6e057f28b1cf02a8193db77dfa2f4f2