### PR TITLE
cmd/list: Support images without names

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -237,9 +237,14 @@ func listOutput(images []toolboxImage, containers []toolboxContainer) {
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", "IMAGE ID", "IMAGE NAME", "CREATED")
 
 		for _, image := range images {
+			imageName := "<none>"
+			if len(image.Names) != 0 {
+				imageName = image.Names[0]
+			}
+
 			fmt.Fprintf(writer, "%s\t%s\t%s\n",
 				utils.ShortID(image.ID),
-				image.Names[0],
+				imageName,
 				image.Created)
 		}
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -82,3 +82,22 @@ teardown() {
   assert_output --partial "non-default-one"
   assert_output --partial "non-default-two"
 }
+
+@test "list: List an image without a name" {
+    echo -e "FROM scratch\n\nLABEL com.github.containers.toolbox=\"true\"" > "$BATS_TMPDIR"/Containerfile
+
+    run $PODMAN build "$BATS_TMPDIR"
+
+    assert_success
+    assert_line --index 0 "STEP 1: FROM scratch"
+    assert_line --index 1 "STEP 2: LABEL com.github.containers.toolbox=\"true\""
+    assert_line --index 2 "STEP 3: COMMIT"
+    assert_line --index 3 --regexp "^--> [a-z0-9]*$"
+
+    run $TOOLBOX list
+
+    assert_success
+    assert_line --index 1 --partial "<none>"
+
+    rm -f "$BATS_TMPDIR"/Containerfile
+}


### PR DESCRIPTION
Some people create images manually. If such created images are recognize
as toolbox images (they have the proper labels) but do not have
a name/tag then 'toolbox list' will panic due to index being out of
range.