### PR TITLE
cmd/create: Style fixes

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -265,13 +265,13 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	logrus.Debugf("%s canonicalized to %s", currentUser.HomeDir, homeDirEvaled)
 	homeDirMountArg := homeDirEvaled + ":" + homeDirEvaled + ":rslave"
 
-	bootMountFlags := "rw"
+	bootMountFlags := "ro"
 	isBootReadWrite, err := isPathReadWrite("/boot")
 	if err != nil {
 		return err
 	}
-	if !isBootReadWrite {
-		bootMountFlags = "ro"
+	if isBootReadWrite {
+		bootMountFlags = "rw"
 	}
 
 	bootMountArg := "/boot:/run/host/boot:" + bootMountFlags + ",rslave"
@@ -423,12 +423,12 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, []string{
 		"--userns", usernsArg,
 		"--user", "root:root",
-		"--volume", bootMountArg,
 		"--volume", "/etc:/run/host/etc",
 		"--volume", "/dev:/dev:rslave",
 		"--volume", "/run:/run/host/run:rslave",
 		"--volume", "/tmp:/run/host/tmp:rslave",
 		"--volume", "/var:/run/host/var:rslave",
+		"--volume", bootMountArg,
 		"--volume", dbusSystemSocketMountArg,
 		"--volume", homeDirMountArg,
 		"--volume", toolboxPathMountArg,


### PR DESCRIPTION
It's good to avoid subtle variations in the logic for /boot and /usr,
unless actually necessary, because it makes the code easier to read.

Fallout from 7ec26a27df7199777b94a17b2935e7ff35757937