### PR TITLE
cmd/initContainer: Don't ignore unknown flags, yet

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -122,7 +122,6 @@ func init() {
 		"Create a user inside the toolbox container whose login name is USER")
 	initContainerCmd.MarkFlagRequired("user")
 
-	initContainerCmd.FParseErrWhitelist.UnknownFlags = true
 	initContainerCmd.SetHelpFunc(initContainerHelp)
 	rootCmd.AddCommand(initContainerCmd)
 }


### PR DESCRIPTION
The reason for setting FParseErrWhitelist.UnknownFlags to 'true' was to
prepare for a future when the 'init-container' command would have fewer
options than it does now.

However, there's no need to prepare for it, because the version of
toolbox(1) that's bind mounted into the container is the same as the
one on the host. So, FParseErrWhitelist.UnknownFlags can be set in
future if, or when, the number of flags do get reduced.

This reverts commit 5c2086e9ea045f73bdc574734d659807a2d68d1e.