### PR TITLE
Ensure that all unknown error messages are limited to the debug logs

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -602,7 +602,7 @@ func getServiceSocket(serviceName string, unitName string) (string, error) {
 
 	listenVariant, listenFound := result["Listen"]
 	if !listenFound {
-		return "", fmt.Errorf("failed to find the Listen property of %s: %w", unitName, err)
+		return "", fmt.Errorf("failed to find the Listen property of %s", unitName)
 	}
 
 	listenVariantSignature := listenVariant.Signature().String()

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -518,7 +518,11 @@ func getDBusSystemSocket() (string, error) {
 	path := addressSplit[1]
 	pathEvaled, err := filepath.EvalSymlinks(path)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve the path to the D-Bus system socket: %w", err)
+		logrus.Debugf("Resolving path to the D-Bus system socket: failed to evaluate symbolic links in %s: %s",
+			path,
+			err)
+
+		return "", errors.New("failed to resolve the path to the D-Bus system socket")
 	}
 
 	return pathEvaled, nil
@@ -586,7 +590,11 @@ func getServiceSocket(serviceName string, unitName string) (string, error) {
 
 	connection, err := dbus.SystemBus()
 	if err != nil {
-		return "", fmt.Errorf("failed to connect to the D-Bus system instance: %w", err)
+		logrus.Debugf("Resolving path to the %s socket: failed to connect to the D-Bus system instance: %s",
+			serviceName,
+			err)
+
+		return "", errors.New("failed to connect to the D-Bus system instance")
 	}
 
 	unitNameEscaped := systemdPathBusEscape(unitName)
@@ -597,7 +605,12 @@ func getServiceSocket(serviceName string, unitName string) (string, error) {
 	var result map[string]dbus.Variant
 	err = call.Store(&result)
 	if err != nil {
-		return "", fmt.Errorf("failed to get the properties of %s: %w", unitName, err)
+		logrus.Debugf("Resolving path to the %s socket: failed to get the properties of %s: %s",
+			serviceName,
+			unitName,
+			err)
+
+		return "", fmt.Errorf("failed to get the properties of %s", unitName)
 	}
 
 	listenVariant, listenFound := result["Listen"]

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -133,7 +133,8 @@ func getContainers() ([]toolboxContainer, error) {
 	args := []string{"--all", "--sort", "names"}
 	containers, err := podman.GetContainers(args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get containers: %w", err)
+		logrus.Debugf("Fetching all containers failed: %s", err)
+		return nil, errors.New("failed to get containers")
 	}
 
 	var toolboxContainers []toolboxContainer
@@ -195,7 +196,8 @@ func getImages() ([]toolboxImage, error) {
 	args := []string{"--sort", "repository"}
 	images, err := podman.GetImages(args...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get images: %w", err)
+		logrus.Debugf("Fetching all images failed: %s", err)
+		return nil, errors.New("failed to get images")
 	}
 
 	var toolboxImages []toolboxImage

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -197,6 +197,8 @@ func rootUsage(cmd *cobra.Command) error {
 }
 
 func migrate() error {
+	logrus.Debug("Migrating to newer Podman")
+
 	if utils.IsInsideContainer() {
 		return nil
 	}
@@ -371,6 +373,8 @@ func setUpLoggers() error {
 }
 
 func validateSubIDFile(path string) (bool, error) {
+	logrus.Debugf("Validating sub-ID file %s", path)
+
 	file, err := os.Open(path)
 	if err != nil {
 		logrus.Debugf("Validating sub-ID file: failed to open %s: %s", path, err)


### PR DESCRIPTION
This builds upon commit eedfdda535f762dc, which added more information
to the error messages presented to the user by including the errors
thrown by the lower layers of the code.

However, if the errors are being thrown by external modules, or are
coming from functions that are too many layers below, then it is
difficult to guarantee their contents. They might be duplicating
information added by the upper layers, or in extreme cases might even
contain JSON blobs, simply because it made sense for the API contracts
of the functions generating the errors.

Therefore, it's better to put them in the debug logs to retain control
over what gets displayed to the user under normal (ie., non-debug)
operation.