### PR TITLE
cmd/root: Wire root command to 'enter' command

### DIFF
--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -4,14 +4,6 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
-@test "help: Try to run toolbox with no command (shows usage screen)" {
-  run $TOOLBOX
-
-  assert_failure
-  assert_line --index 0 "Error: missing command"
-  assert_output --partial "Run 'toolbox --help' for usage."
-}
-
 @test "help: Run command 'help'" {
   run $TOOLBOX help
 


### PR DESCRIPTION
One of requirements to get Toolbox to RHEL is to make the root command
('toolbox') have similar functionality as 'toolbox enter'.

Making 'toolbox' behave exactly the same as 'toolbox enter', making it
effectively an alias is not exactly desirable as the root command has
its own behaviour too. Instead, `toolbox` only translates to `toolbox
enter` when no arguments or flags (excluding the global ones) are
provided.