### PR TITLE
Use installed toolbox instead of binary from host

### DIFF
--- a/images/fedora/f33/extra-packages
+++ b/images/fedora/f33/extra-packages
@@ -32,6 +32,7 @@ shadow-utils
 sudo
 tcpdump
 time
+toolbox
 traceroute
 tree
 unzip

--- a/images/fedora/f34/extra-packages
+++ b/images/fedora/f34/extra-packages
@@ -32,6 +32,7 @@ shadow-utils
 sudo
 tcpdump
 time
+toolbox
 traceroute
 tree
 unzip

--- a/images/fedora/f35/extra-packages
+++ b/images/fedora/f35/extra-packages
@@ -32,6 +32,7 @@ shadow-utils
 sudo
 tcpdump
 time
+toolbox
 traceroute
 tree
 unzip

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -205,7 +205,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	toolboxPath := os.Getenv("TOOLBOX_PATH")
 	toolboxPathEnvArg := "TOOLBOX_PATH=" + toolboxPath
-	toolboxPathMountArg := toolboxPath + ":/usr/bin/toolbox:ro"
 
 	var runtimeDirectory string
 	var xdgRuntimeDirEnv []string
@@ -431,7 +430,6 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		"--volume", bootMountArg,
 		"--volume", dbusSystemSocketMountArg,
 		"--volume", homeDirMountArg,
-		"--volume", toolboxPathMountArg,
 		"--volume", usrMountArg,
 		"--volume", runtimeDirectoryMountArg,
 	}...)


### PR DESCRIPTION
I hit an issue (https://github.com/containers/toolbox/issues/821) that was caused by GLIBC mismatch between host and container, so toolbox binary didn't worked inside container. I have an idea to prevent this issue by not using toolbox binary from host, but install toolbox binary in the container using dnf. It will install the binary that is always able to run in the container, so I think this issue should not happen again.

This breaks compatibility with images that does not have installed toolbox, so I think a fllback logic should be implemented that checks if there is an `/usr/bin/toolbox` in the container, and if not, will mount the binary from host like before to have backward compatibility.

What do you think about?