### PR TITLE
pkg/podman: Print stderr of execs to system stderr when asked for

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -31,7 +31,6 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -457,9 +456,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
+	if canStartSpinner() {
 		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
 		s.Writer = os.Stdout
 		s.Start()
@@ -733,9 +730,7 @@ func pullImage(image, release string) (bool, error) {
 
 	logrus.Debugf("Pulling image %s", imageFull)
 
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
+	if canStartSpinner() {
 		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
 		s.Writer = os.Stdout

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -411,6 +411,7 @@ func setUpLoggers() error {
 	}
 
 	if rootFlags.logPodman {
+		podman.ShowLogs = true
 		podman.SetLogLevel(logLevel)
 	}
 

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 – 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func canStartSpinner() bool {
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+
+	logLevel := logrus.GetLevel()
+
+	return logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt)
+}

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -29,5 +29,5 @@ func canStartSpinner() bool {
 
 	logLevel := logrus.GetLevel()
 
-	return logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt)
+	return !rootFlags.logPodman && logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt)
 }


### PR DESCRIPTION
With this the logs (resp. stderr) of all invocations of Podman are shown
when the '--log-podman' option is set.

This change affects the behaviour of spinner which is now hidden when
the logging is turned on.

Depends on https://github.com/containers/toolbox/pull/826