### PR TITLE
pkg/utils, cmd/create: Properly check reference being an ID

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -669,7 +669,7 @@ func isPathReadWrite(path string) (bool, error) {
 }
 
 func pullImage(image, release string) (bool, error) {
-	if _, err := utils.ImageReferenceCanBeID(image); err == nil {
+	if ok := utils.ImageReferenceCanBeID(image); ok {
 		logrus.Debugf("Looking for image %s", image)
 
 		if _, err := podman.ImageExists(image); err == nil {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -501,7 +501,7 @@ func HumanDuration(duration int64) string {
 
 // ImageReferenceCanBeID checks if 'image' might be the ID of an image
 func ImageReferenceCanBeID(image string) bool {
-	matched, err := regexp.MatchString("^[a-f0-9]\\{6,64\\}$", image)
+	matched, err := regexp.MatchString("^[a-f0-9]{6,64}$", image)
 	if err != nil {
 		panic("regular expression for ID reference matching is invalid")
 	}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -500,9 +500,12 @@ func HumanDuration(duration int64) string {
 }
 
 // ImageReferenceCanBeID checks if 'image' might be the ID of an image
-func ImageReferenceCanBeID(image string) (bool, error) {
+func ImageReferenceCanBeID(image string) bool {
 	matched, err := regexp.MatchString("^[a-f0-9]\\{6,64\\}$", image)
-	return matched, err
+	if err != nil {
+		panic("regular expression for ID reference matching is invalid")
+	}
+	return matched
 }
 
 func ImageReferenceGetBasename(image string) string {

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageReferenceCanBeID(t *testing.T) {
+	testCases := []struct {
+		name string
+		ref  string
+		ok   bool
+	}{
+		{
+			name: "Valid ID (random 6 chars)",
+			ref:  "34afbc",
+			ok:   true,
+		},
+		{
+			name: "Valid ID (random 64 chars)",
+			ref:  "8215cb84fa588215cb84fa588215cb84fa588215cb84fa588215cb84fa58fbca",
+			ok:   true,
+		},
+		{
+			name: "Valid ID (Podman short)",
+			ref:  "8215cb84fa58",
+			ok:   true,
+		},
+		{
+			name: "Valid ID (Podman long)",
+			ref:  "8b9affd1dbc261a7f586ed06a8fd993d09449a5ac79ebc7e80e86efdf3c223f6",
+			ok:   true,
+		},
+		{
+			name: "Invalid ID (random <6 chars)",
+			ref:  "acbdf",
+			ok:   false,
+		},
+		{
+			name: "Invalid ID (random >64 chars)",
+			ref:  "8215cb84fa588215cb84fa588215cb84fa588215cb84fa588215cb84fa58fbcab",
+			ok:   false,
+		},
+		{
+			name: "Invalid ID (image URI; whole alphabet + slash)",
+			ref:  "fedoraproject.org/fedora-toolbox:32",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok := ImageReferenceCanBeID(tc.ref)
+			assert.Equal(t, tc.ok, ok)
+		})
+	}
+}


### PR DESCRIPTION
Turns out the braces do not need to be escaped. Let's fix it!

Method for matching strings against a regular expressions return
an error when the regular expressions is faulty. The first return value
tells if a match was found. So, we should check for a match and not for
an error.