### PR TITLE
cmd: Add function to determine if a spinner can be started

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -31,7 +31,6 @@ import (
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -432,9 +431,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
+	if canStartSpinner() {
 		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
 		s.Writer = os.Stdout
 		s.Start()
@@ -708,9 +705,7 @@ func pullImage(image, release string) (bool, error) {
 
 	logrus.Debugf("Pulling image %s", imageFull)
 
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt) {
+	if canStartSpinner() {
 		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
 		s.Writer = os.Stdout

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2019 – 2021 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func canStartSpinner() bool {
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+
+	logLevel := logrus.GetLevel()
+
+	return logLevel < logrus.DebugLevel && terminal.IsTerminal(stdoutFdInt)
+}


### PR DESCRIPTION
The logic for determining if a spinner can be started is non-trivial and
hard to replicate.