### PR TITLE
libc-wrappers: Ensure binaries built on Fedora 35 run on older Fedoras

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,6 +16,8 @@
 #
 
 
+readonly LIBC_WRAPPERS="--wrap,pthread_sigmask"
+
 if [ "$#" -ne 4 ]; then
     echo "go-build-wrapper: wrong arguments" >&2
     echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION] [libc-wrappers.a]" >&2
@@ -27,5 +29,5 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -trimpath -ldflags "-extldflags '-Wl,--wrap,pthread_sigmask $4' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
+go build -trimpath -ldflags "-extldflags '-Wl,$LIBC_WRAPPERS $4' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
 exit "$?"

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,7 +16,7 @@
 #
 
 
-readonly LIBC_WRAPPERS="--wrap,pthread_sigmask"
+readonly LIBC_WRAPPERS="--wrap,pthread_attr_getstacksize,--wrap,pthread_create,--wrap,pthread_detach,--wrap,pthread_sigmask"
 
 if [ "$#" -ne 4 ]; then
     echo "go-build-wrapper: wrong arguments" >&2

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,7 +16,7 @@
 #
 
 
-readonly LIBC_WRAPPERS="--wrap,pthread_attr_getstacksize,--wrap,pthread_create,--wrap,pthread_detach,--wrap,pthread_sigmask"
+readonly LIBC_WRAPPERS="--wrap,__libc_start_main,--wrap,pthread_attr_getstacksize,--wrap,pthread_create,--wrap,pthread_detach,--wrap,pthread_sigmask"
 
 if [ "$#" -ne 4 ]; then
     echo "go-build-wrapper: wrong arguments" >&2

--- a/src/libc-wrappers/libc-wrappers.c
+++ b/src/libc-wrappers/libc-wrappers.c
@@ -15,8 +15,61 @@
  */
 
 
+#include <link.h>
 #include <pthread.h>
 #include <signal.h>
+
+
+/*
+ * __libc_start_main < GLIBC_2.34
+ */
+
+
+struct startup_info
+{
+  void *sda_base;
+  int (*main) (int, char **, char **, void *);
+  int (*init) (int, char **, char **, void *);
+  void (*fini) (void);
+};
+
+extern int __libc_start_main (int argc,
+                              char **argv,
+                              char **ev,
+                              ElfW (auxv_t) * auxvec,
+                              void (*rtld_fini) (void),
+                              struct startup_info * stinfo,
+                              char **stack_on_entry);
+
+
+#if defined __aarch64__
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.17");
+#elif defined __arm__
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.4");
+#elif defined __i386__
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.0");
+#elif defined __powerpc64__ && _CALL_ELF == 2 /* ppc64le */
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.17");
+#elif defined __s390x__
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.2");
+#elif defined __x86_64__
+__asm__(".symver __libc_start_main,__libc_start_main@GLIBC_2.2.5");
+#else
+#error "Please specify symbol version for __libc_start_main"
+#endif
+
+
+int
+__wrap___libc_start_main (int argc,
+                          char **argv,
+                          char **ev,
+                          ElfW (auxv_t) * auxvec,
+                          void (*rtld_fini) (void),
+                          struct startup_info * stinfo,
+                          char **stack_on_entry)
+{
+  return __libc_start_main (argc, argv, ev, auxvec, rtld_fini, stinfo, stack_on_entry);
+}
 
 
 /*

--- a/src/libc-wrappers/libc-wrappers.c
+++ b/src/libc-wrappers/libc-wrappers.c
@@ -15,7 +15,95 @@
  */
 
 
+#include <pthread.h>
 #include <signal.h>
+
+
+/*
+ * pthread_attr_getstacksize < GLIBC_2.34
+ */
+
+
+#if defined __aarch64__
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.17");
+#elif defined __arm__
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.4");
+#elif defined __i386__
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.1");
+#elif defined __powerpc64__ && _CALL_ELF == 2 /* ppc64le */
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.17");
+#elif defined __s390x__
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.2");
+#elif defined __x86_64__
+__asm__(".symver pthread_attr_getstacksize,pthread_attr_getstacksize@GLIBC_2.2.5");
+#else
+#error "Please specify symbol version for pthread_attr_getstacksize"
+#endif
+
+
+int
+__wrap_pthread_attr_getstacksize (const pthread_attr_t *attr, size_t *stacksize)
+{
+  return pthread_attr_getstacksize (attr, stacksize);
+}
+
+
+/*
+ * pthread_create < GLIBC_2.34
+ */
+
+
+#if defined __aarch64__
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.17");
+#elif defined __arm__
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.4");
+#elif defined __i386__
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.1");
+#elif defined __powerpc64__ && _CALL_ELF == 2 /* ppc64le */
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.17");
+#elif defined __s390x__
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.2");
+#elif defined __x86_64__
+__asm__(".symver pthread_create,pthread_create@GLIBC_2.2.5");
+#else
+#error "Please specify symbol version for pthread_create"
+#endif
+
+
+int
+__wrap_pthread_create (pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg)
+{
+  return pthread_create(thread, attr, start_routine, arg);
+}
+
+
+/*
+ * pthread_detach < GLIBC_2.34
+ */
+
+
+#if defined __aarch64__
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.17");
+#elif defined __arm__
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.4");
+#elif defined __i386__
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.0");
+#elif defined __powerpc64__ && _CALL_ELF == 2 /* ppc64le */
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.17");
+#elif defined __s390x__
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.2");
+#elif defined __x86_64__
+__asm__(".symver pthread_detach,pthread_detach@GLIBC_2.2.5");
+#else
+#error "Please specify symbol version for pthread_detach"
+#endif
+
+
+int
+__wrap_pthread_detach (pthread_t thread)
+{
+  return pthread_detach (thread);
+}
 
 
 /*

--- a/src/libc-wrappers/libc-wrappers.c
+++ b/src/libc-wrappers/libc-wrappers.c
@@ -18,6 +18,11 @@
 #include <signal.h>
 
 
+/*
+ * pthread_sigmask < GLIBC_2.32
+ */
+
+
 #if defined __aarch64__
 __asm__(".symver pthread_sigmask,pthread_sigmask@GLIBC_2.17");
 #elif defined __arm__


### PR DESCRIPTION
https://github.com/containers/toolbox/issues/821