### PR TITLE
cmd, pkg/utils: Drop release arg from some function signatures

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -190,7 +190,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		return errors.New(errMsg)
 	}
 
-	pulled, err := pullImage(image, release)
+	pulled, err := pullImage(image)
 	if err != nil {
 		return err
 	}
@@ -668,7 +668,7 @@ func isPathReadWrite(path string) (bool, error) {
 	return false, nil
 }
 
-func pullImage(image, release string) (bool, error) {
+func pullImage(image string) (bool, error) {
 	if ok := utils.ImageReferenceCanBeID(image); ok {
 		logrus.Debugf("Looking for image %s", image)
 
@@ -694,7 +694,7 @@ func pullImage(image, release string) (bool, error) {
 		imageFull = image
 	} else {
 		var err error
-		imageFull, err = utils.GetFullyQualifiedImageFromDistros(image, release)
+		imageFull, err = utils.GetFullyQualifiedImageFromDistros(image)
 		if err != nil {
 			return false, fmt.Errorf("image %s not found in local storage and known registries", image)
 		}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -320,7 +320,7 @@ func GetEnvOptionsForPreservedVariables() []string {
 	return envOptions
 }
 
-func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
+func GetFullyQualifiedImageFromDistros(image string) (string, error) {
 	logrus.Debugf("Resolving fully qualified name for image %s from known registries", image)
 
 	if ImageReferenceHasDomain(image) {
@@ -330,6 +330,11 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	basename := ImageReferenceGetBasename(image)
 	if basename == "" {
 		return "", fmt.Errorf("failed to get the basename of image %s", image)
+	}
+
+	release := ImageReferenceGetTag(image)
+	if release == "" {
+		return "", fmt.Errorf("failed to get the release of image %s", image)
 	}
 
 	for _, distroObj := range supportedDistros {


### PR DESCRIPTION
The release string does not have to be passed as an argument in the cmd
package since flag values are globally available and the image argument
is already fully qualified (contains tag -> release).

GetFullyQualifiedImageFromDistros() function already receives an image
reference with tag included. There's no need to pass the release
separately.