### PR TITLE
playbooks/setup-env: Show version of glibc

### DIFF
--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -39,7 +39,7 @@
         creates: /run/media
 
     - name: Check versions of crucial packages
-      command: rpm -qa *kernel* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
+      command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
 
     - name: Show podman versions
       command: podman version


### PR DESCRIPTION
An upgrade of glibc has caused an issue on Fedora Rawhide[0]. We need a
clear indicator that a change in glibc could cause it.

[0] https://github.com/containers/toolbox/issues/821