### PR TITLE
utils, help: Show basic help when "man" command is not available

### DIFF
--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -67,7 +67,16 @@ func showManual(manual string) error {
 	manBinary, err := exec.LookPath("man")
 	if err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
-			return errors.New("man(1) not found")
+			fmt.Print(`toolbox - Tool for containerized command line environments on Linux
+
+Common commands are:
+create    Create a new toolbox container
+enter     Enter an existing toolbox container
+list      List all existing toolbox containers and images
+
+Go to https://github.com/containers/toolbox for further information.
+`)
+			return nil
 		}
 
 		return errors.New("failed to lookup man(1)")

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -9,10 +9,14 @@ setup() {
 }
 
 @test "help: Run command 'help'" {
+  if ! hash man 2>/dev/null; then
+    skip "Test works only if man is in PATH"
+  fi
+
   run $TOOLBOX help
 
   assert_success
-  assert_output --partial "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 0 --partial "toolbox(1)()"
 }
 
 @test "help: Run command 'help' with no man present" {

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -15,6 +15,22 @@ setup() {
   assert_output --partial "toolbox - Tool for containerized command line environments on Linux"
 }
 
+@test "help: Run command 'help' with no man present" {
+  if hash man 2>/dev/null; then
+    skip "Test works only if man is not in PATH"
+  fi
+
+  run $TOOLBOX help
+
+  assert_success
+  assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 1 "Common commands are:"
+  assert_line --index 2 "create    Create a new toolbox container"
+  assert_line --index 3 "enter     Enter an existing toolbox container"
+  assert_line --index 4 "list      List all existing toolbox containers and images"
+  assert_line --index 5 "Go to https://github.com/containers/toolbox for further information."
+}
+
 @test "help: Use flag '--help' (it should show usage screen)" {
   run $TOOLBOX --help
 


### PR DESCRIPTION
Fixes #713

Fedora CoreOS systems do not have the man command installed. Running
toolbox --help on such a system results in a "man(1) not found" error.

As a compromise for systems without man, we added a simple help text
showing the most commonly used toolbox commands and an URL that direct
users to the Toolbox website where they can find the manuals in Markdown
format.