### PR TITLE
pkg/utils: Separate container & image name resolution

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -148,10 +148,12 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(container,
-		createFlags.distro,
-		createFlags.image,
-		release)
+	image, release, err := utils.ResolveImageName(createFlags.distro, createFlags.image, release)
+	if err != nil {
+		return err
+	}
+
+	container, err = utils.ResolveContainerName(container, image, release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -116,7 +116,12 @@ func enter(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(container, enterFlags.distro, "", release)
+	image, release, err := utils.ResolveImageName(enterFlags.distro, "", release)
+	if err != nil {
+		return err
+	}
+
+	container, err = utils.ResolveContainerName(container, image, release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -193,7 +193,12 @@ func rootRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames("", "", "", "")
+	image, release, err := utils.ResolveImageName("", "", "")
+	if err != nil {
+		return err
+	}
+
+	container, err := utils.ResolveContainerName("", image, release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -125,7 +125,12 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, runFlags.distro, "", release)
+	image, release, err := utils.ResolveImageName(runFlags.distro, "", release)
+	if err != nil {
+		return err
+	}
+
+	container, err := utils.ResolveContainerName(runFlags.container, image, release)
 	if err != nil {
 		return err
 	}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -672,15 +672,41 @@ func IsInsideToolboxContainer() bool {
 	return false
 }
 
-// ResolveContainerAndImageNames takes care of standardizing names of containers and images.
+// ResolveContainerName standardizes the name of a container
+//
+// If no container name is specified then the name of the image will be used.
+func ResolveContainerName(container, image, release string) (string, error) {
+	logrus.Debug("Resolving container name")
+	logrus.Debugf("Container: '%s'", container)
+	logrus.Debugf("Image: '%s'", image)
+	logrus.Debugf("Release: '%s'", release)
+
+	if container == "" {
+		var err error
+		container, err = GetContainerNamePrefixForImage(image)
+		if err != nil {
+			return "", err
+		}
+
+		tag := ImageReferenceGetTag(image)
+		if tag != "" {
+			container = container + "-" + tag
+		}
+	}
+
+	logrus.Debug("Resolved container name")
+	logrus.Debugf("Container: '%s'", container)
+
+	return container, nil
+}
+
+// ResolveImageName standardizes the name of an image.
 //
 // If no image name is specified then the base image will reflect the platform of the host (even the version).
-// If no container name is specified then the name of the image will be used.
 //
 // If the host system is unknown then the base image will be 'fedora-toolbox' with a default version
-func ResolveContainerAndImageNames(container, distro, image, release string) (string, string, string, error) {
-	logrus.Debug("Resolving container and image names")
-	logrus.Debugf("Container: '%s'", container)
+func ResolveImageName(distro, image, release string) (string, string, error) {
+	logrus.Debug("Resolving image name")
 	logrus.Debugf("Distribution: '%s'", distro)
 	logrus.Debugf("Image: '%s'", image)
 	logrus.Debugf("Release: '%s'", release)
@@ -690,7 +716,7 @@ func ResolveContainerAndImageNames(container, distro, image, release string) (st
 	}
 
 	if distro != distroDefault && release == "" {
-		return "", "", "", fmt.Errorf("release not found for non-default distribution %s", distro)
+		return "", "", fmt.Errorf("release not found for non-default distribution %s", distro)
 	}
 
 	if release == "" {
@@ -706,25 +732,11 @@ func ResolveContainerAndImageNames(container, distro, image, release string) (st
 		}
 	}
 
-	if container == "" {
-		var err error
-		container, err = GetContainerNamePrefixForImage(image)
-		if err != nil {
-			return "", "", "", err
-		}
-
-		tag := ImageReferenceGetTag(image)
-		if tag != "" {
-			container = container + "-" + tag
-		}
-	}
-
-	logrus.Debug("Resolved container and image names")
-	logrus.Debugf("Container: '%s'", container)
+	logrus.Debug("Resolved image name")
 	logrus.Debugf("Image: '%s'", image)
 	logrus.Debugf("Release: '%s'", release)
 
-	return container, image, release, nil
+	return image, release, nil
 }
 
 func ShowManual(manual string) error {


### PR DESCRIPTION
The ResolveContainerAndImageNames() function does too much work. It
makes more sense to have two functions: one for resolving the image
name and another for resolving the container name.

https://github.com/containers/toolbox/pull/828