### PR TITLE
test/system: Fix flaky test

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -45,8 +45,14 @@ teardown() {
 @test "run: Run sudo id inside of the default container" {
   create_default_container
 
-  run $TOOLBOX --verbose run sudo id
+  output="$($TOOLBOX --verbose run sudo id 2>$BATS_TMPDIR/stderr)"
+  status="$?"
+
+  echo "# stderr"
+  cat $BATS_TMPDIR/stderr
+  echo "# stdout"
+  echo $output
 
   assert_success
-  assert_line --index $((${#lines[@]}-1)) --partial "uid=0(root)"
+  assert_output --partial "uid=0(root)"
 }


### PR DESCRIPTION
This is a naive attempt to solve the flaking. It could be caused by what
is going inside of the run function.

Supersedes https://github.com/containers/toolbox/pull/705