### PR TITLE
utils: bump the fallback Fedora version to 34

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -51,7 +51,7 @@ type Distro struct {
 
 const (
 	idTruncLength          = 12
-	releaseDefaultFallback = "33"
+	releaseDefaultFallback = "34"
 )
 
 const (


### PR DESCRIPTION
[skip ci]