### PR TITLE
test/system: Adjust asserts for broken test

### DIFF
--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -89,9 +89,9 @@ teardown() {
     run $PODMAN build "$BATS_TMPDIR"
 
     assert_success
-    assert_line --index 0 "STEP 1: FROM scratch"
-    assert_line --index 1 "STEP 2: LABEL com.github.containers.toolbox=\"true\""
-    assert_line --index 2 "STEP 3: COMMIT"
+    assert_line --index 0 --partial "FROM scratch"
+    assert_line --index 1 --partial "LABEL com.github.containers.toolbox=\"true\""
+    assert_line --index 2 --partial "COMMIT"
     assert_line --index 3 --regexp "^--> [a-z0-9]*$"
 
     run $TOOLBOX list


### PR DESCRIPTION
The output of `podman build` has changed a bit. Each line of log
describing the build is now in the format of:

- STEP i/n: msg

instead of:

- STEP i: msg

where i is the current step and n the maximum number of steps.

The exact format is not important for the purpose of testing Toolbox, so
we may fallback to partial string testing.

Also the latest step ("COMMIT") seems to no longer be considered a step,
so just check for the word.