### PR TITLE
test/system: Use BATS_RUN_TMPDIR for image cache

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -8,8 +8,7 @@ readonly TOOLBOX=${TOOLBOX:-toolbox}
 readonly SKOPEO=$(command -v skopeo)
 
 # Helpful globals
-readonly PROJECT_DIR=${PWD}
-readonly IMAGE_CACHE_DIR="${PROJECT_DIR}/image-cache"
+readonly IMAGE_CACHE_DIR="${BATS_RUN_TMPDIR}/image-cache"
 
 # Images
 declare -Ag IMAGES=([busybox]="docker.io/library/busybox" \


### PR DESCRIPTION
Using the current working directory for cache is not a good solution
since the test files may reside in a location that is unwritable (e.g.,
/usr/share). The `BATS_RUN_TMPDIR` variable should point to a location
that is sure to be writeable from the test suite.