### PR TITLE
cmd/create: Mention that private images require 'podman login'

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -716,7 +716,13 @@ func pullImage(image, release string) (bool, error) {
 	}
 
 	if err := podman.Pull(imageFull); err != nil {
-		return false, fmt.Errorf("failed to pull image %s", imageFull)
+		var builder strings.Builder
+		fmt.Fprintf(&builder, "failed to pull image %s\n", imageFull)
+		fmt.Fprintf(&builder, "If it was a private image, log in with: podman login %s\n", domain)
+		fmt.Fprintf(&builder, "Use '%s --verbose ...' for further details.", executableBase)
+
+		errMsg := builder.String()
+		return false, errors.New(errMsg)
 	}
 
 	return true, nil


### PR DESCRIPTION
It's not possible to programmatically detect when an image requires
logging into the registry [1]. Therefore, instead of trying to handle
'podman pull' failures due to lack of authorization, just mention that
private images require 'podman login' and that further details of the
failure can be found by using the --verbose option.

[1] https://github.com/containers/podman/issues/10858

https://github.com/containers/toolbox/issues/754