### PR TITLE
tests: Fixed tests to setup the XDG_RUNTIME_DIR variable when empty

### DIFF
--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -4,6 +4,10 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
+setup() {
+  check_xdg_runtime_dir
+}
+
 @test "help: Run command 'help'" {
   run $TOOLBOX help
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_containers
 }
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_all
 }
 

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_containers
 }
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_containers
 }
 

--- a/test/system/105-rm.bats
+++ b/test/system/105-rm.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_containers
 }
 

--- a/test/system/106-rmi.bats
+++ b/test/system/106-rmi.bats
@@ -5,6 +5,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  check_xdg_runtime_dir
   cleanup_all
 }
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -270,3 +270,11 @@ function get_system_version() {
 
     echo $(awk -F= '/VERSION_ID/ {print $2}' $os_release | head -n 1)
 }
+
+
+# Setup the XDG_RUNTIME_DIR variable if not set
+function check_xdg_runtime_dir() {
+    if [[ -z "${XDG_RUNTIME_DIR}" ]]; then
+        export XDG_RUNTIME_DIR="/run/user/${UID}"
+    fi
+}


### PR DESCRIPTION
Toolbox can't run properly if the XDG_RUNTIME_DIR is not set properly.

Now the tests can run in environments without it by setting it to /run/user/$UID if empty.