### PR TITLE
tests: Changed container image source for busybox

### DIFF
--- a/images/test/busybox/Containerfile
+++ b/images/test/busybox/Containerfile
@@ -1,0 +1,2 @@
+FROM busybox
+

--- a/images/test/busybox/README.md
+++ b/images/test/busybox/README.md
@@ -1,0 +1,4 @@
+This image is just a clone of the base busybox image used for testing purposes.
+
+The Containerfile is used to build the quay.io/toolbox_tests/busybox image that
+is used in the toolbox test suite.

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -11,7 +11,7 @@ readonly SKOPEO=$(command -v skopeo)
 readonly IMAGE_CACHE_DIR="${BATS_RUN_TMPDIR}/image-cache"
 
 # Images
-declare -Ag IMAGES=([busybox]="docker.io/library/busybox" \
+declare -Ag IMAGES=([busybox]="quay.io/toolbox_tests/busybox" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
                    [rhel]="registry.access.redhat.com/ubi8")
 


### PR DESCRIPTION
Due to docker rate limiting we can not rely in docker.io for retrieving the images.

This was detected when executing our tests for podman fedora gating pipeline. Our busybox image was not downloaded and
one of the list tests was failing.