### PR TITLE
test/system: Use quay.io/libpod/busybox instead of rolling our own

### DIFF
--- a/images/test/busybox/Containerfile
+++ b/images/test/busybox/Containerfile
@@ -1,2 +1,0 @@
-FROM busybox
-

--- a/images/test/busybox/README.md
+++ b/images/test/busybox/README.md
@@ -1,4 +1,0 @@
-This image is just a clone of the base busybox image used for testing purposes.
-
-The Containerfile is used to build the quay.io/toolbox_tests/busybox image that
-is used in the toolbox test suite.

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -11,7 +11,7 @@ readonly SKOPEO=$(command -v skopeo)
 readonly IMAGE_CACHE_DIR="${BATS_RUN_TMPDIR}/image-cache"
 
 # Images
-declare -Ag IMAGES=([busybox]="quay.io/toolbox_tests/busybox" \
+declare -Ag IMAGES=([busybox]="quay.io/libpod/busybox" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
                    [rhel]="registry.access.redhat.com/ubi8")
 


### PR DESCRIPTION
Commit 09fb2377272b196f switched away from docker.io/library/busybox
because of rate limiting on the docker.io registry. Fortunately,
there's already a quay.io/libpod/busybox image that's used by Podman's
test suite, and all that the Toolbox test suite needs is a non-Toolbox
image. Hence there's no need to maintain a separate busybox image.