### PR TITLE
Added error info on non 0 and unknown exit code

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -363,7 +363,13 @@ func runCommandWithFallbacks(container string, command []string, emitEscapeSeque
 				}
 			}
 		default:
-			return nil
+			var newerr error
+			if err != nil {
+				newerr = fmt.Errorf("failed to invoke command %s in container %s (Exit code: %d): %s", command[0], container, exitCode, err)
+			} else {
+				newerr = fmt.Errorf("failed to invoke command %s in container %s (Exit code: %d)", command[0], container, exitCode)
+			}
+			return newerr
 		}
 	}
 


### PR DESCRIPTION
When a command is executed with toolbox run and it returns a non zero exit code, if that exit code is not handled it is just ignored.

This prevents users to identify errors when executing commands in toolbox.

With this fix, the unhandled exit codes are returned as errors to give the user a better error info.