### PR TITLE
cmd/run: Unbreak 'enter' if the shell had exited with 127

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -322,11 +322,9 @@ func runCommandWithFallbacks(container string, command []string, emitEscapeSeque
 			}
 			return nil
 		case 125:
-			err = fmt.Errorf("failed to invoke 'podman exec' in container %s", container)
-			return err
+			return fmt.Errorf("failed to invoke 'podman exec' in container %s", container)
 		case 126:
-			err = fmt.Errorf("failed to invoke command %s in container %s", command[0], container)
-			return err
+			return fmt.Errorf("failed to invoke command %s in container %s", command[0], container)
 		case 127:
 			if pathPresent, _ := isPathPresent(container, workDir); !pathPresent {
 				if runFallbackWorkDirsIndex < len(runFallbackWorkDirs) {
@@ -343,8 +341,7 @@ func runCommandWithFallbacks(container string, command []string, emitEscapeSeque
 					fmt.Fprintf(os.Stderr, "Using %s instead.\n", workDir)
 					runFallbackWorkDirsIndex++
 				} else {
-					err = fmt.Errorf("directory %s not found in container %s", workDir, container)
-					return err
+					return fmt.Errorf("directory %s not found in container %s", workDir, container)
 				}
 			} else {
 				if fallbackToBash && runFallbackCommandsIndex < len(runFallbackCommands) {
@@ -358,8 +355,7 @@ func runCommandWithFallbacks(container string, command []string, emitEscapeSeque
 
 					runFallbackCommandsIndex++
 				} else {
-					err = fmt.Errorf("command %s not found in container %s", command[0], container)
-					return err
+					return fmt.Errorf("command %s not found in container %s", command[0], container)
 				}
 			}
 		default:


### PR DESCRIPTION
Currently, 'toolbox enter' can get into a loop if the user tried to
run something inside the shell that didn't exist, and quit immediately
afterwards:
  $ toolbox enter
  ⬢$ foo
  bash: foo: command not found
  ⬢$
  logout
  Error: command /bin/bash not found in container fedora-toolbox-34
  Using /bin/bash instead.
  ⬢$

This is because:

  * The shell forwards the exit code of the last command that was
    invoked as its own exit code. If the last command that was
    attempted was absent then this exit code is 127.

  * 'podman exec' uses 127 as the exit code when it can't invoke the
    command. If it's able to successfully invoke the command, it
    forwards the exit code of the command itself.

Therefore, in the above example 'podman exec' itself returns with an
exit code of 127 even though both the working directory and the command
that were passed to it were present. Hence, it's necessary to
explicitly check if the requested command was really absent before
attempting the fallbacks.

Fallout from 4536e2c8c28f6c4fed5e0346ea1094156e449f59
