### PR TITLE
test/system: fix typo in 102-list.bats

### DIFF
--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -29,7 +29,7 @@ teardown() {
 }
 
 @test "list: Run 'list -i' with zero images (the list should be empty)" {
-  run $TOOLBOX list -c
+  run $TOOLBOX list -i
 
   assert_success
   assert_output ""


### PR DESCRIPTION
Signed-off-by: Alex Jia <chuanchang.jia@gmail.com>