### PR TITLE
Add env option

### DIFF
--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -7,6 +7,7 @@ toolbox\-run - Run a command in an existing toolbox container
 **toolbox run** [*--container NAME* | *-c NAME*]
             [*--distro DISTRO* | *-d DISTRO*]
             [*--release RELEASE* | *-r RELEASE*]
+            [*--env KEY=VALUE* | *-e KEY=VALUE*]
             [*COMMAND*]
 
 ## DESCRIPTION
@@ -40,6 +41,11 @@ than the host.
 
 Run command inside a toolbox container for a different operating system
 RELEASE than the host.
+
+**--env** KEY=VALUE, **-e** KEY=VALUE
+
+Set environment variables. This option allows arbitrary environment variables
+that are available for the process to be launched inside of the container.
 
 ## EXAMPLES
 

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -154,6 +154,7 @@ func enter(cmd *cobra.Command, args []string) error {
 		image,
 		release,
 		command,
+		nil,
 		emitEscapeSequence,
 		true,
 		false); err != nil {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -235,6 +235,7 @@ func rootRun(cmd *cobra.Command, args []string) error {
 		image,
 		release,
 		command,
+		nil,
 		emitEscapeSequence,
 		true,
 		false); err != nil {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -847,3 +847,21 @@ func ShowManual(manual string) error {
 
 	return nil
 }
+
+// ParseEnvVariables parses the specified environment variables and returns them as a string array
+func ParseEnvVariables(envVariables []string) ([]string, error) {
+	var env []string
+
+	for _, envVariable := range envVariables {
+		data := strings.SplitN(envVariable, "=", 2)
+
+		// catch invalid variables such as "=", "=A" or "A A=A"
+		if data[0] == "" || strings.Contains(data[0], " ") {
+			return nil, errors.New("invalid environment variable: " + envVariable)
+		}
+
+		env = append(env, fmt.Sprintf("--env=%s=%s ", data[0], data[1]))
+	}
+
+	return env, nil
+}


### PR DESCRIPTION
I have implemented this option (see #618). It's similar to podman's implementation. I didn't write any tests, but I did have tested a couple of times.

Here are some examples:
```
[gusta@fedora src]$ ./toolbox run --env KEY=VALUE printenv KEY
VALUE 
[gusta@fedora src]$ ./toolbox run -e KEY=VALUE printenv KEY
VALUE 
[gusta@fedora src]$ ./toolbox run -e A=B -e B=C printenv A B
B 
C 
```
And some errors that may occur:
```
[gusta@fedora src]$ ./toolbox run -e =A printenv
Error: invalid environment variable: =A
[gusta@fedora src]$ ./toolbox run -e = printenv
Error: invalid environment variable: =
[gusta@fedora src]$ ./toolbox run -e "  =A" printenv
Error: invalid environment variable:   =A
```

Closes #618 