### PR TITLE
test/system: Test startup on Rawhide with supported versions

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -35,7 +35,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 1200
+    timeout: 1320
     nodeset:
       nodes:
         - name: ci-node-rawhide

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -5,8 +5,8 @@ load 'libs/helpers'
 @test "test suite: Setup" {
     _setup_environment
     # Cache the default image for the system
-    _pull_and_cache_distro_image $(get_system_id) $(get_system_version) || die
+    _pull_and_cache_distro_image $(get_system_id) $(get_system_version) || false
     # Cache all images that will be needed during the tests
-    _pull_and_cache_distro_image fedora 32 || die
-    _pull_and_cache_distro_image busybox || die
+    _pull_and_cache_distro_image fedora 32 || false
+    _pull_and_cache_distro_image busybox || false
 }

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -3,10 +3,20 @@
 load 'libs/helpers'
 
 @test "test suite: Setup" {
+    local os_release="$(find_os_release)"
+    local system_id="$(get_system_id)"
+    local system_version="$(get_system_version)"
+
     _setup_environment
     # Cache the default image for the system
-    _pull_and_cache_distro_image $(get_system_id) $(get_system_version) || false
+    _pull_and_cache_distro_image "$system_id" "$system_version" || false
     # Cache all images that will be needed during the tests
     _pull_and_cache_distro_image fedora 32 || false
     _pull_and_cache_distro_image busybox || false
+    # If run on Fedora Rawhide, cache 2 extra images (previous Fedora versions)
+    local rawhide_res="$(awk '/rawhide/' $os_release)"
+    if [ "$system_id" = "fedora" ] && [ -n "$rawhide_res" ]; then
+        _pull_and_cache_distro_image fedora "$((system_version-1))" || false
+        _pull_and_cache_distro_image fedora "$((system_version-2))" || false
+    fi
 }

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -19,23 +19,30 @@ teardown() {
 
   create_default_container
 
-  run $PODMAN start $CONTAINER_NAME
+  res="$(container_started $CONTAINER_NAME)"
 
-  CONTAINER_INITIALIZED=0
-
-  for TRIES in 1 2 3 4 5
-  do
-    run $PODMAN logs $CONTAINER_NAME
-    CONTAINER_OUTPUT=$output
-    run grep 'Listening to file system and ticker events' <<< $CONTAINER_OUTPUT
-    if [[ "$status" -eq 0 ]]; then
-      CONTAINER_INITIALIZED=1
-      break
-    fi
-    sleep 1
-  done
-
-  echo $CONTAINER_OUTPUT
-  assert [ "$CONTAINER_INITIALIZED" -eq 1 ]
+  assert [ "$res" -eq 1 ]
 }
 
+@test "container(Fedora Rawhide): Containers with supported versions start without issues" {
+  local os_release="$(find_os_release)"
+  local system_id="$(get_system_id)"
+  local system_version="$(get_system_version)"
+  local rawhide_res="$(awk '/rawhide/' $os_release)"
+
+  if [ "$system_id" != "fedora" ] || [ -z "$rawhide_res" ]; then
+    skip "This test is only for Fedora Rawhide"
+  fi
+
+  create_distro_container "$system_id" "$system_version" latest
+  res1="$(container_started latest)"
+  assert [ "$res1" -eq 1 ]
+
+  create_distro_container "$system_id" "$((system_version-1))" second
+  res2="$(container_started second)"
+  assert [ "$res2" -eq 1 ]
+
+  create_distro_container "$system_id" "$((system_version-2))" third
+  res3="$(container_started third)"
+  assert [ "$res3" -eq 1 ]
+}

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -232,6 +232,38 @@ function start_container() {
 }
 
 
+# Checks if a toolbox container started
+#
+# Parameters:
+# ===========
+# - container_name - name of the container
+function container_started() {
+  local container_name
+  container_name="$1"
+
+  run $PODMAN start $container_name
+
+  container_initialized=0
+
+  for TRIES in 1 2 3 4 5
+  do
+    run $PODMAN logs $container_name
+    container_output=$output
+    # Look for last line of the container startup log
+    run grep 'Listening to file system and ticker events' <<< $container_output
+    if [[ "$status" -eq 0 ]]; then
+      container_initialized=1
+      break
+    fi
+    sleep 1
+  done
+
+  echo $container_output >2
+
+  echo $container_initialized
+}
+
+
 function stop_container() {
   local container_name
   container_name="$1"


### PR DESCRIPTION
We need to know if the latest changes in the libc (that is dynamically
linked to the binary) causes problems in containers based on older
releases of Fedora.

The estimate of the version numbers ís very crude and does not follow
the upstream schedule. That should not be a problem.

A part of an existing test has been reused an made into a helper
function to implement this.