### PR TITLE
playbooks/setup-env: Restore running ShellCheck in the CI

### DIFF
--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -6,6 +6,7 @@
       package:
         use: dnf
         name:
+          - ShellCheck
           - bash-completion
           - bats
           - flatpak-session-helper


### PR DESCRIPTION
Fallout from c33075f3e1c0bad9883caa8d8f7c8ca3d947d2ea