### PR TITLE
Mount Smart Card Daemon socket (pcsd) inside the toolbox container

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -289,6 +289,17 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		kcmSocketMount = []string{"--volume", kcmSocketMountArg}
 	}
 
+	var pcscSocketMount []string
+
+	pcscSocket, err := getServiceSocket("pcsc", "pcscd.socket")
+	if err != nil {
+		logrus.Debug(err)
+	}
+	if pcscSocket != "" {
+		pcscSocketMountArg := pcscSocket + ":" + pcscSocket
+		pcscSocketMount = []string{"--volume", pcscSocketMountArg}
+	}
+
 	var mediaLink []string
 	var mediaMount []string
 
@@ -415,6 +426,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, kcmSocketMount...)
 	createArgs = append(createArgs, mediaMount...)
 	createArgs = append(createArgs, mntMount...)
+	createArgs = append(createArgs, pcscSocketMount...)
 	createArgs = append(createArgs, runMediaMount...)
 	createArgs = append(createArgs, toolboxShMount...)
 


### PR DESCRIPTION
This takes insperation from:

* https://github.com/flatpak/flatpak/blob/684e68be094d072da7740223b7cbc5d06e9550f4/common/flatpak-run.c#L359-L383
* https://github.com/containers/toolbox/pull/625

This should allow tools like `ykman` to work with yubikeys.
