### PR TITLE
zuul, playbooks: CI optimizations

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,15 +1,29 @@
 ---
 - job:
-    name: unit-test
-    description: Run Toolbox's unit tests declared in Meson
+    name: build-fedora-33
+    description: Build Toolbox Fedora 33
     timeout: 300
-    irrelevant-files: &excluded_locations ['.github/*', 'completion/*', 'doc/*', 'images/*', 'CODE-OF-CONDUCT.md', 'CONTRIBUTING.md', 'COPYING', 'GOALS.md', 'NEWS', 'README.md', 'SECURITY.md', 'toolbox']
-    requires: build-f33
     nodeset:
       nodes:
         - name: ci-node-33
           label: cloud-fedora-33-small
-    pre-run: playbooks/setup-env.yaml
+    vars:
+      build_job: "build-fedora-33"
+    pre-run: playbooks/build.yaml
+
+- job:
+    name: unit-test
+    description: Run Toolbox's unit tests declared in Meson
+    timeout: 300
+    irrelevant-files: &excluded_locations ['.github/*', 'completion/*', 'doc/*', 'images/*', 'CODE-OF-CONDUCT.md', 'CONTRIBUTING.md', 'COPYING', 'GOALS.md', 'NEWS', 'README.md', 'SECURITY.md', 'toolbox']
+    parent: build-fedora-33
+    nodeset:
+      nodes:
+        - name: ci-node-33
+          label: cloud-fedora-33-small
+    vars:
+      build_job: "build-fedora-33"
+    pre-run: playbooks/setup-test-env.yaml
     run: playbooks/unit-test.yaml
 
 - job:
@@ -17,41 +31,74 @@
     description: Run Toolbox's system tests in Fedora 33
     timeout: 900
     irrelevant-files: *excluded_locations
-    requires: build-f33
+    parent: build-fedora-33
     nodeset:
       nodes:
         - name: ci-node-33
           label: cloud-fedora-33-small
-    pre-run: playbooks/setup-env.yaml
+    vars:
+      build_job: "build-fedora-33"
+    pre-run: playbooks/setup-test-env.yaml
     run: playbooks/system-test.yaml
+
+- job:
+    name: build-fedora-34
+    description: Build Toolbox on Fedora 34
+    timeout: 300
+    nodeset:
+      nodes:
+        - name: ci-node-34
+          label: cloud-fedora-34-small
+    vars:
+      build_job: "build-fedora-34"
+    pre-run: playbooks/build.yaml
 
 - job:
     name: system-test-fedora-34
     description: Run Toolbox's system tests in Fedora 34
     timeout: 900
     irrelevant-files: *excluded_locations
+    parent: build-fedora-34
     nodeset:
       nodes:
         - name: ci-node-34
           label: cloud-fedora-34-small
-    pre-run: playbooks/setup-env.yaml
+    vars:
+      build_job: "build-fedora-34"
+    pre-run: playbooks/setup-test-env.yaml
     run: playbooks/system-test.yaml
+
+- job:
+    name: build-fedora-rawhide
+    description: Build Toolbox Fedora Rawhide
+    timeout: 300
+    nodeset:
+      nodes:
+        - name: ci-node-rawhide
+          label: cloud-fedora-rawhide-small
+    vars:
+      build_job: "build-fedora-rawhide"
+    pre-run: playbooks/build.yaml
 
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 1200
     irrelevant-files: *excluded_locations
+    parent: build-fedora-rawhide
     nodeset:
       nodes:
         - name: ci-node-rawhide
           label: cloud-fedora-rawhide-small
-    pre-run: playbooks/setup-env.yaml
+    vars:
+      build_job: "build-fedora-rawhide"
+    pre-run: playbooks/setup-test-env.yaml
     run: playbooks/system-test.yaml
 
 - project:
     periodic:
       jobs:
+        - unit-test
         - system-test-fedora-33
         - system-test-fedora-34
         - system-test-fedora-rawhide

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,6 +3,8 @@
     name: unit-test
     description: Run Toolbox's unit tests declared in Meson
     timeout: 300
+    irrelevant-files: &excluded_locations ['.github/*', 'completion/*', 'doc/*', 'images/*', 'CODE-OF-CONDUCT.md', 'CONTRIBUTING.md', 'COPYING', 'GOALS.md', 'NEWS', 'README.md', 'SECURITY.md', 'toolbox']
+    requires: build-f33
     nodeset:
       nodes:
         - name: ci-node-33
@@ -13,7 +15,9 @@
 - job:
     name: system-test-fedora-33
     description: Run Toolbox's system tests in Fedora 33
-    timeout: 1200
+    timeout: 900
+    irrelevant-files: *excluded_locations
+    requires: build-f33
     nodeset:
       nodes:
         - name: ci-node-33
@@ -24,7 +28,8 @@
 - job:
     name: system-test-fedora-34
     description: Run Toolbox's system tests in Fedora 34
-    timeout: 1200
+    timeout: 900
+    irrelevant-files: *excluded_locations
     nodeset:
       nodes:
         - name: ci-node-34
@@ -36,6 +41,7 @@
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 1200
+    irrelevant-files: *excluded_locations
     nodeset:
       nodes:
         - name: ci-node-rawhide

--- a/playbooks/build.yaml
+++ b/playbooks/build.yaml
@@ -1,0 +1,73 @@
+---
+- hosts: all
+  roles:
+    - role: download-artifact
+      download_artifact_api: https://softwarefactory-project.io/zuul/api/tenant/local
+      download_artifact_pipeline: '{{ zuul.pipeline }}'
+      download_artifact_job: '{{ build_job }}'
+      download_artifact_type:
+        - builddir
+        - go-cachedir
+        - go-mod-cachedir
+      download_artifact_directory: '{{ zuul.project.src_dir }}'
+
+  tasks:
+    - name: Get Go cache directory
+      command: go env GOCACHE
+      register: go_cachedir
+
+    - name: Get Go mod cache directory
+      command: go env GOMODCACHE
+      register: go_mod_cachedir
+
+    - name: Set up artifacts
+      shell: |
+        # GOCACHE
+        GOCACHE=$(go env GOCACHE)
+        GOCACHE=${GOCACHE:-$HOME/.cache/go-build}
+        rm -rf $GOCACHE
+        mv ./$(basename "$GOCACHE") $GOCACHE
+        # GOMODCACHE
+        GOMODCACHE=$(go env GOMODCACHE)
+        GOMODCACHE=${GOMODCACHE:-$HOME/go/pkg/mod}
+        rm -rf $GOMODCACHE
+        mv ./$(basename "$GOMODCACHE") $GOMODCACHE 
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Install requirements
+      become: yes
+      package:
+        use: dnf
+        name:
+          - golang
+          - golang-github-cpuguy83-md2man
+          - meson
+          - ninja-build
+          - patchelf
+          - systemd
+
+    - name: Show versions of packages
+      command: rpm -qa golang golang-github-cpuguy83-md2man meson ninja-build patchelf systemd
+
+    - name: Set up build directory
+      command: meson builddir --reconfigure
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - name: Build Toolbox
+      command: ninja -C builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+        creates: builddir/src/toolbox
+
+    - zuul_return:
+        data:
+          zuul:
+            artifacts:
+              - name: builddir
+                url: builddir
+              - name: go-cachedir
+                url: "{{ go_cachedir }}/"
+              - name: go-mod-cachedir
+                url: "{{ go_mod_cachedir }}/"

--- a/playbooks/setup-test-env.yaml
+++ b/playbooks/setup-test-env.yaml
@@ -1,5 +1,17 @@
 ---
 - hosts: all
+  roles:
+    - role: download-artifact
+      download_artifact_api: https://softwarefactory-project.io/zuul/api/tenant/local
+      download_artifact_pipeline: '{{ zuul.pipeline }}'
+      download_artifact_job: '{{ build_job }}'
+      download_artifact_type:
+        - builddir
+        - go-cachedir
+        - go-mod-cachedir
+      download_artifact_directory: '{{ zuul.project.src_dir }}'
+
+
   tasks:
     - name: Install requirements
       become: yes
@@ -20,6 +32,21 @@
           - systemd
           - udisks2
 
+    - name: Set up artifacts
+      shell: |
+        # GOCACHE
+        GOCACHE=$(go env GOCACHE)
+        GOCACHE=${GOCACHE:-$HOME/.cache/go-build}
+        rm -rf $GOCACHE
+        mv ./$(basename "$GOCACHE") $GOCACHE
+        # GOMODCACHE
+        GOMODCACHE=$(go env GOMODCACHE)
+        GOMODCACHE=${GOMODCACHE:-$HOME/go/pkg/mod}
+        rm -rf $GOMODCACHE
+        mv ./$(basename "$GOMODCACHE") $GOMODCACHE 
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
     - name: Setup submodules
       shell: |
         git submodule init
@@ -35,17 +62,6 @@
 
     - name: Show podman debug information
       command: podman info --debug
-
-    - name: Set up build directory
-      command: meson builddir
-      args:
-        chdir: '{{ zuul.project.src_dir }}'
-
-    - name: Build Toolbox
-      command: ninja -C builddir
-      args:
-        chdir: '{{ zuul.project.src_dir }}'
-        creates: builddir/src/toolbox
 
     - name: Install Toolbox
       become: yes


### PR DESCRIPTION
> This is very much experimental and will most likely not work.

The CI is taking quite long time to run all jobs. This applies mainly to the Rawhide pipeline where some deeper problems with the container stack are (maybe because of btrfs). All the jobs could benefit from caching, though. And we don't need to run all the jobs for all changes (e.g., bash completion or documentation).