### PR TITLE
build: Don't assume that libc.so is always in /usr/lib or /usr/lib64

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,9 +1,12 @@
 project(
   'toolbox',
+  'c',
   version: '0.0.99.2',
   license: 'ASL 2.0',
   meson_version: '>= 0.53.0',
 )
+
+cc = meson.get_compiler('c')
 
 go = find_program('go')
 go_md2man = find_program('go-md2man')

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,9 +16,9 @@
 #
 
 
-if [ "$#" -ne 3 ]; then
+if [ "$#" -ne 4 ]; then
     echo "go-build-wrapper: wrong arguments" >&2
-    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION]" >&2
+    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION] [C COMPILER]" >&2
     exit 1
 fi
 
@@ -27,7 +27,22 @@ if ! cd "$1"; then
     exit 1
 fi
 
-go build -trimpath -ldflags "-extldflags '-Wl,-rpath,/run/host/usr/lib -Wl,-rpath,/run/host/usr/lib64' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
+if ! libc_dir=$("$4" --print-file-name=libc.so); then
+    echo "go-build-wrapper: failed to read the path to libc.so" >&2
+    exit 1
+fi
+
+if ! libc_dir_canonical=$(readlink --canonicalize "$libc_dir"); then
+    echo "go-build-wrapper: failed to canonicalize the path to libc.so" >&2
+    exit 1
+fi
+
+if ! libc_dir_canonical_dirname=$(dirname "$libc_dir_canonical"); then
+    echo "go-build-wrapper: failed to read the dirname of the canonicalized path to libc.so" >&2
+    exit 1
+fi
+
+go build -trimpath -ldflags "-extldflags '-Wl,-rpath,/run/host$libc_dir_canonical_dirname' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
 
 if ! interpreter=$(patchelf --print-interpreter "$2/toolbox"); then
     echo "go-build-wrapper: failed to read PT_INTERP from $2/toolbox" >&2

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ custom_target(
     meson.current_source_dir(),
     meson.current_build_dir(),
     meson.project_version(),
+    cc.cmd_array().get(-1),
   ],
   input: sources,
   install: true,


### PR DESCRIPTION
The location for public shared libraries can change from one operating
system distribution to another. eg., while Fedora uses /usr/lib and
/usr/lib64, depending on the hardware architecture, Debian uses paths
like /usr/lib/x86_64-linux-gnu. Therefore, it's best not to assume
anything and ask the toolchain.