### PR TITLE
Add capsh as a container requirement in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ certain tools and paths to be present and have certain characteristics inside
 the OCI image.
 
 Tools:
+* `capsh(1)`
 * `getent(1)`
 * `id(1)`
 * `ln(1)`


### PR DESCRIPTION
Without capsh a toolbox might fail to be entered into with a message about not finding /bin/bash.