### PR TITLE
cmd/create: Add option --authfile

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -4,7 +4,8 @@
 toolbox\-create - Create a new toolbox container
 
 ## SYNOPSIS
-**toolbox create** [*--distro DISTRO* | *-d DISTRO*]
+**toolbox create** [*--authfile AUTHFILE*]
+               [*--distro DISTRO* | *-d DISTRO*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
                [*CONTAINER*]
@@ -79,6 +80,14 @@ confusion.
 
 ## OPTIONS ##
 
+**--authfile** FILE
+
+Path to a FILE with credentials for authenticating to the registry for private
+images. The FILE is usually set using `podman login`, and will be used by
+`podman pull` to get the image.
+
+The default location for FILE is `$XDG_RUNTIME_DIR/containers/auth.json`.
+
 **--distro** DISTRO, **-d** DISTRO
 
 Create a toolbox container for a different operating system DISTRO than the
@@ -120,6 +129,12 @@ $ toolbox create --distro fedora --release f36
 $ toolbox create --image bar foo
 ```
 
+### Create a toolbox container from a custom image needing authentication
+
+```
+$ toolbox create --authfile ~/auth.json --image registry.example.com/bar
+```
+
 ## SEE ALSO
 
-`toolbox(1)`, `toolbox-init-container(1)`, `podman(1)`, `podman-create(1)`
+`toolbox(1)`, `toolbox-init-container(1)`, `podman(1)`, `podman-create(1)`, `podman-login(1)`, `podman-pull(1)`

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -12,8 +12,10 @@
           - flatpak-session-helper
           - golang
           - golang-github-cpuguy83-md2man
+          - httpd-tools
           - meson
           - ninja-build
+          - openssl
           - podman
           - skopeo
           - systemd

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -227,9 +227,18 @@ func IsToolboxImage(image string) (bool, error) {
 }
 
 // Pull pulls an image
-func Pull(imageName string) error {
+//
+// authfile is a path to a JSON authentication file and is internally used only
+// if it is not an empty string.
+func Pull(imageName string, authfile string) error {
 	logLevelString := LogLevel.String()
-	args := []string{"--log-level", logLevelString, "pull", imageName}
+	args := []string{"--log-level", logLevelString, "pull"}
+
+	if authfile != "" {
+		args = append(args, []string{"--authfile", authfile}...)
+	}
+
+	args = append(args, imageName)
 
 	if err := shell.Run("podman", nil, nil, nil, args...); err != nil {
 		return err

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -19,4 +19,6 @@ load 'libs/helpers'
         _pull_and_cache_distro_image fedora "$((system_version-1))" || false
         _pull_and_cache_distro_image fedora "$((system_version-2))" || false
     fi
+
+    _setup_docker_registry
 }

--- a/test/system/999-teardown.bats
+++ b/test/system/999-teardown.bats
@@ -6,5 +6,6 @@ load 'libs/helpers'
   _setup_environment
 
   _clean_cached_images
+  _clean_docker_registry
   _clean_temporary_storage
 }

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -13,6 +13,8 @@ Running them won't remove any existing containers or images.
 - `awk`
 - `bats`
 - `GNU coreutils`
+- `httpd-tools`
+- `openssl`
 - `podman`
 - `skopeo`
 - `toolbox`
@@ -69,3 +71,18 @@ Examples:
 - All the tests start with a clean system (no images or containers) to make sure
   that there are no dependencies between tests and they are really isolated. Use
   the `setup()` and `teardown()` functions for that purpose.
+
+### Image registry
+
+- The system tests set up an OCI image registry for testing purposes -
+  `localhost:50000`. The registry requires authentication. There is one account
+  present: `user` (password: `user`)
+
+- The registry contains by default only one image: `fedora-toolbox:32`
+
+Example pull of the `fedora-toolbox:32` image:
+
+```bash
+$PODMAN login --username user --password user "$DOCKER_REG_URI"
+$PODMAN pull "$DOCKER_REG_URI/fedora-toolbox:32"
+```


### PR DESCRIPTION
The option accepts a path to a file that is passed to an internal call
to 'podman pull' via the '--authfile' option. This will make it easier
to pull images from registries with authentication in-place.

The commit repurposes the test work I did for a rejected feature on
registry authentication. A registry is started locally and the use of
auth file is tested against it.

Fixes #689

Depends on: #818 & #1024

Requires a Docker registry image at quay.io/toolbox_tests/registry for running tests.