### PR TITLE
images/fedora: Remove mlocate

### DIFF
--- a/images/fedora/f34/extra-packages
+++ b/images/fedora/f34/extra-packages
@@ -20,7 +20,6 @@ less
 lsof
 man-db
 man-pages
-mlocate
 mtr
 nano-default-editor
 nss-mdns

--- a/images/fedora/f35/extra-packages
+++ b/images/fedora/f35/extra-packages
@@ -20,7 +20,6 @@ less
 lsof
 man-db
 man-pages
-mlocate
 mtr
 nano-default-editor
 nss-mdns

--- a/images/fedora/f36/extra-packages
+++ b/images/fedora/f36/extra-packages
@@ -20,7 +20,6 @@ less
 lsof
 man-db
 man-pages
-mlocate
 mtr
 nano-default-editor
 nss-mdns


### PR DESCRIPTION
Remove mlocate from the base image. mlocate being installed by default
will trigger disk wide file listing scanning updates after each dnf
operation via the updatedb process.

This is probably not wanted in most cases and especially for ephemeral
containers usage where the scanning will happen every time and thus be
very IO intensive.