### PR TITLE
build: Drop the use of patchelf(1)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c',
   version: '0.0.99.2',
   license: 'ASL 2.0',
-  meson_version: '>= 0.53.0',
+  meson_version: '>= 0.56.0',
 )
 
 cc = meson.get_compiler('c')
@@ -21,13 +21,13 @@ profiledir = get_option('profile_dir')
 tmpfilesdir = get_option('tmpfiles_dir')
 if tmpfilesdir == ''
   systemd_dep = dependency('systemd')
-  tmpfilesdir = systemd_dep.get_pkgconfig_variable('tmpfilesdir')
+  tmpfilesdir = systemd_dep.get_variable(pkgconfig: 'tmpfilesdir')
 endif
 
 if bash_completion.found()
   install_data(
     'completion/bash/toolbox',
-    install_dir: bash_completion.get_pkgconfig_variable('completionsdir')
+    install_dir: bash_completion.get_variable(pkgconfig: 'completionsdir')
   )
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -3,14 +3,13 @@ project(
   'c',
   version: '0.0.99.2',
   license: 'ASL 2.0',
-  meson_version: '>= 0.56.0',
+  meson_version: '>= 0.58.0',
 )
 
 cc = meson.get_compiler('c')
 
 go = find_program('go')
 go_md2man = find_program('go-md2man')
-patchelf = find_program('patchelf')
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -14,7 +14,6 @@
           - golang-github-cpuguy83-md2man
           - meson
           - ninja-build
-          - patchelf
           - podman
           - skopeo
           - systemd
@@ -28,7 +27,7 @@
         chdir: '{{ zuul.project.src_dir }}'
 
     - name: Check versions of crucial packages
-      command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper patchelf
+      command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
 
     - name: Show podman versions
       command: podman version

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -16,9 +16,9 @@
 #
 
 
-if [ "$#" -ne 4 ]; then
+if [ "$#" -ne 5 ]; then
     echo "go-build-wrapper: wrong arguments" >&2
-    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION] [C COMPILER]" >&2
+    echo "Usage: go-build-wrapper [SOURCE DIR] [OUTPUT DIR] [VERSION] [C COMPILER] [DYNAMIC LINKER]" >&2
     exit 1
 fi
 
@@ -42,33 +42,23 @@ if ! libc_dir_canonical_dirname=$(dirname "$libc_dir_canonical"); then
     exit 1
 fi
 
-go build -trimpath -ldflags "-extldflags '-Wl,-rpath,/run/host$libc_dir_canonical_dirname' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
-
-if ! interpreter=$(patchelf --print-interpreter "$2/toolbox"); then
-    echo "go-build-wrapper: failed to read PT_INTERP from $2/toolbox" >&2
+if ! dynamic_linker_basename=$(basename "$5"); then
+    echo "go-build-wrapper: failed to read the basename of dynamic linker $5" >&2
     exit 1
 fi
 
-if ! interpreter_canonical=$(readlink --canonicalize "$interpreter"); then
-    echo "go-build-wrapper: failed to canonicalize PT_INTERP" >&2
+if ! dynamic_linker_canonical=$(readlink --canonicalize "$5"); then
+    echo "go-build-wrapper: failed to canonicalize dynamic linker $5" >&2
     exit 1
 fi
 
-if ! interpreter_basename=$(basename "$interpreter"); then
-    echo "go-build-wrapper: failed to read the basename of PT_INTERP" >&2
+if ! dynamic_linker_canonical_dirname=$(dirname "$dynamic_linker_canonical"); then
+    echo "go-build-wrapper: failed to read the dirname of the canonicalized dynamic linker $dynamic_linker_canonical" >&2
     exit 1
 fi
 
-if ! interpreter_canonical_dirname=$(dirname "$interpreter_canonical"); then
-    echo "go-build-wrapper: failed to read the dirname of the canonicalized PT_INTERP" >&2
-    exit 1
-fi
+dynamic_linker="/run/host$dynamic_linker_canonical_dirname/$dynamic_linker_basename"
 
-interpreter="/run/host$interpreter_canonical_dirname/$interpreter_basename"
-
-if ! patchelf --set-interpreter "$interpreter" "$2/toolbox"; then
-    echo "go-build-wrapper: failed to change PT_INTERP of $2/toolbox to $interpreter" >&2
-    exit 1
-fi
+go build -trimpath -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker -Wl,-rpath,/run/host$libc_dir_canonical_dirname' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$3" -o "$2/toolbox"
 
 exit "$?"

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,29 @@ sources = files(
   'pkg/version/version.go',
 )
 
+cpu_family = host_machine.cpu_family()
+endian = host_machine.endian()
+
+dynamic_linker = ''
+if cpu_family == 'aarch64' and endian == 'little'
+  dynamic_linker = '/lib/ld-linux-aarch64.so.1'
+elif cpu_family == 'arm' and endian == 'little'
+  dynamic_linker = '/lib/ld-linux-armhf.so.3'
+elif cpu_family == 'ppc64' and endian == 'little'
+  dynamic_linker = '/lib64/ld64.so.2'
+elif cpu_family == 's390x' and endian == 'big'
+  dynamic_linker = '/lib/ld64.so.1'
+elif cpu_family == 'x86' and endian == 'little'
+  dynamic_linker = '/lib/ld-linux.so.2'
+elif cpu_family == 'x86_64' and endian == 'little'
+  dynamic_linker = '/lib64/ld-linux-x86-64.so.2'
+else
+  host_machine_description = cpu_family + ' (' + endian + ' endian)'
+  error('Please specify dynamic linker for:', host_machine_description)
+endif
+
+message('Host machine dynamic linker:', dynamic_linker)
+
 custom_target(
   'toolbox',
   build_by_default: true,
@@ -28,6 +51,7 @@ custom_target(
     meson.current_build_dir(),
     meson.project_version(),
     cc.cmd_array().get(-1),
+    dynamic_linker,
   ],
   input: sources,
   install: true,


### PR DESCRIPTION
Some downstream distributors like RHEL don't have patchelf(1). Relying
on patchelf(1) during the build will make it difficult for such
downstreams to distribute Toolbox.

Fortunately, the path of the dynamic linker (ie., PT_INTERP) is
hardcoded in the ABI specification of each architecture [1]. This means
that Toolbox's build system can keep it's own architecture to dynamic
linker mapping, and specify it during the build through the GNU ld
linker's --dynamic-linker flag, as opposed to using a tool like
patchelf(1) to change the path of the dynamic linker in the built
binary to the one inside /run/host. Currently, the list of
architectures covers the ones that Fedora builds for.

[1] https://sourceware.org/glibc/wiki/ABIList