### PR TITLE
initContainer: Include execution error in message

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -406,7 +406,7 @@ func configureUsers(targetUserUid int,
 		}
 
 		if err := shell.Run("usermod", nil, nil, nil, usermodArgs...); err != nil {
-			return fmt.Errorf("failed to modify user %s with UID %d", targetUser, targetUserUid)
+			return fmt.Errorf("failed to modify user %s with UID %d: %w", targetUser, targetUserUid, err)
 		}
 	} else {
 		logrus.Debugf("Adding user %s with UID %d:", targetUser, targetUserUid)
@@ -426,20 +426,20 @@ func configureUsers(targetUserUid int,
 		}
 
 		if err := shell.Run("useradd", nil, nil, nil, useraddArgs...); err != nil {
-			return fmt.Errorf("failed to add user %s with UID %d", targetUser, targetUserUid)
+			return fmt.Errorf("failed to add user %s with UID %d: %w", targetUser, targetUserUid, err)
 		}
 	}
 
 	logrus.Debugf("Removing password for user %s", targetUser)
 
 	if err := shell.Run("passwd", nil, nil, nil, "--delete", targetUser); err != nil {
-		return fmt.Errorf("failed to remove password for user %s", targetUser)
+		return fmt.Errorf("failed to remove password for user %s: %w", targetUser, err)
 	}
 
 	logrus.Debug("Removing password for user root")
 
 	if err := shell.Run("passwd", nil, nil, nil, "--delete", "root"); err != nil {
-		return errors.New("failed to remove password for root")
+		return fmt.Errorf("failed to remove password for root: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
This will pair with a future change to `Run()` so that we capture
the child process stderr.

But actually this change on its own is enough.  Before:

`Error: failed to remove password for user walters`
After:
`Error: failed to remove password for user walters: passwd(1) not found`

which helps me immediately pinpoint the problem.

I didn't try to go through and change *all* the `Run()` invocations,
but if accepted I may do it (or someone else can).