### PR TITLE
playbooks: Install Go dependencies using dnf

### DIFF
--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -11,7 +11,19 @@
           - bats
           - flatpak-session-helper
           - golang
+          - golang-github-acobaugh-osrelease-devel
+          - golang-github-briandowns-spinner-devel
           - golang-github-cpuguy83-md2man
+          - golang-github-docker-units-devel
+          - golang-github-fsnotify-devel
+          - golang-github-godbus-dbus-devel
+          - golang-github-harrymichal-version-devel
+          - golang-github-mattn-isatty-devel
+          - golang-github-sirupsen-logrus-devel
+          - golang-github-stretchr-testify-devel
+          - golang-github-spf13-cobra-devel
+          - golang-github-spf13-viper-devel
+          - golang-x-sys-devel
           - meson
           - ninja-build
           - patchelf


### PR DESCRIPTION
Installing Go dependencies using the "Go approach" results in a slightly
different binary than when installing Fedora-hosted versions of the
packages since Fedora does not strictly follow the package versions
defined in the go.mod file. With this regressions in Fedora connected to
package updates should be caught.