### PR TITLE
doc: Refer to a newer Fedora release in the examples

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -107,10 +107,10 @@ host. Cannot be used with `--image`.
 $ toolbox create
 ```
 
-### Create a toolbox container using the default image for Fedora 30
+### Create a toolbox container using the default image for Fedora 36
 
 ```
-$ toolbox create --distro fedora --release f30
+$ toolbox create --distro fedora --release f36
 ```
 
 ### Create a custom toolbox container from a custom image

--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -47,10 +47,10 @@ host.
 $ toolbox enter
 ```
 
-### Enter a toolbox container using the default image for Fedora 30
+### Enter a toolbox container using the default image for Fedora 36
 
 ```
-$ toolbox enter --distro fedora --release f30
+$ toolbox enter --distro fedora --release f36
 ```
 
 ### Enter a custom toolbox container using a custom image

--- a/doc/toolbox-rm.1.md
+++ b/doc/toolbox-rm.1.md
@@ -29,10 +29,10 @@ Force the removal of running and paused toolbox containers.
 
 ## EXAMPLES
 
-### Remove a toolbox container named `fedora-toolbox-gegl:30`
+### Remove a toolbox container named `fedora-toolbox-gegl:36`
 
 ```
-$ toolbox rm fedora-toolbox-gegl:30
+$ toolbox rm fedora-toolbox-gegl:36
 ```
 
 ### Remove all toolbox containers, but not those that are running or paused

--- a/doc/toolbox-rmi.1.md
+++ b/doc/toolbox-rmi.1.md
@@ -29,10 +29,10 @@ dependent containers will be removed as well.
 
 ## EXAMPLES
 
-### Remove a toolbox image named `localhost/fedora-toolbox-gegl:30`
+### Remove a toolbox image named `localhost/fedora-toolbox-gegl:36`
 
 ```
-$ toolbox rmi localhost/fedora-toolbox-gegl:30
+$ toolbox rmi localhost/fedora-toolbox-gegl:36
 ```
 
 ### Remove all toolbox images, but not those that are used by containers

--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -49,10 +49,10 @@ RELEASE than the host.
 $ toolbox run ls -la
 ```
 
-### Run emacs inside a toolbox container using the default image for Fedora 30
+### Run emacs inside a toolbox container using the default image for Fedora 36
 
 ```
-$ toolbox run --distro fedora --release f30 emacs
+$ toolbox run --distro fedora --release f36 emacs
 ```
 
 ### Run uptime inside a custom toolbox container using a custom image


### PR DESCRIPTION
Fedora 30 reached End of Life on 26th May 2020:
https://docs.fedoraproject.org/en-US/releases/eol/