### PR TITLE
.zuul: Try to prevent the CI from timing out on Fedora Rawhide

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -38,7 +38,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 1320
+    timeout: 2700
     files: *system_test_files
     nodeset:
       nodes:


### PR DESCRIPTION
Currently, the CI has been frequently timing out on Fedora Rawhide
nodes, and it's not clear why that is. One possibility is that this is
due to Rawhide using Linux kernels that are built with debugging
enabled, which makes it slower than released Fedoras. So it might be a
matter of just increasing the timeout.

Currently, the timeout for stable Fedoras is 20 minutes, and that for
Rawhide is 22 minutes. Increase the Rawhide timeout to 30 minutes to
see if that makes the CI more stable.