### PR TITLE
build: Call 'systemd-tmpfiles --create' when installing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,8 @@ project(
   meson_version: '>= 0.58.0',
 )
 
+fs = import('fs')
+
 cc = meson.get_compiler('c')
 if not cc.has_argument('-print-file-name=libc.so')
   error('C compiler does not support the -print-file-name argument.')
@@ -22,9 +24,12 @@ migration_path_for_coreos_toolbox = get_option('migration_path_for_coreos_toolbo
 profiledir = get_option('profile_dir')
 
 tmpfilesdir = get_option('tmpfiles_dir')
-if tmpfilesdir == ''
+if tmpfilesdir == '' or not fs.exists('/run/.containerenv')
   systemd_dep = dependency('systemd')
-  tmpfilesdir = systemd_dep.get_variable(pkgconfig: 'tmpfilesdir')
+
+  if tmpfilesdir == ''
+    tmpfilesdir = systemd_dep.get_variable(pkgconfig: 'tmpfilesdir')
+  endif
 endif
 
 if bash_completion.found()
@@ -65,3 +70,5 @@ subdir('data')
 subdir('doc')
 subdir('profile.d')
 subdir('src')
+
+meson.add_install_script('meson_post_install.py')

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import sys
+
+destdir = os.environ.get('DESTDIR', '')
+
+if not destdir and not os.path.exists('/run/.containerenv'):
+    print('Calling systemd-tmpfiles --create ...')
+
+    try:
+        subprocess.run(['systemd-tmpfiles', '--create'], check=True)
+    except subprocess.CalledProcessError as e:
+        print('Returned non-zero exit status', e.returncode)
+        sys.exit(e.returncode)
+
+sys.exit(0)

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -52,10 +52,3 @@
       args:
         chdir: '{{ zuul.project.src_dir }}'
         creates: /usr/local/bin/toolbox
-
-    - name: Setup environment
-      become: yes
-      command:
-        cmd: systemd-tmpfiles --create
-        creates: /run/media
-        creates: /run/host


### PR DESCRIPTION
It's only necessary to call 'systemd-tmpfiles --create' when building
and installing from source, and not when using a downstream package,
because:

  * When 'meson install' is called as part of building the package,
    that's not when the temporary files need to be created. They need
    to be created when the package is later downloaded and installed
    by the user.

  * Downstream tools can sometimes handle it automatically. eg., on
    Fedora, the systemd RPM installs a trigger that tells RPM to call
    'systemd-tmpfiles --create' automatically when a tmpfiles.d snippet
    is installed.

https://github.com/containers/toolbox/issues/955