### PR TITLE
.zuul: Try to prevent the CI from timing out running the unit tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -2,7 +2,7 @@
 - job:
     name: unit-test
     description: Run Toolbox's unit tests declared in Meson
-    timeout: 300
+    timeout: 600
     files: ['playbooks/*', 'src/*', 'meson.build', 'meson_options.txt', '.zuul.yaml']
     nodeset:
       nodes:


### PR DESCRIPTION
Currently, the CI has been frequently timing out when running the unit
tests. It's possible that the current 5 minute timeout isn't enough,
because it's significantly lower than the 20 minute timeout on stable
Fedoras for the system tests.

Increase the timeout to 10 minutes to see if that makes the CI more
stable.