### PR TITLE
.zuul: Shuffle some code around

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -12,14 +12,14 @@
     run: playbooks/unit-test.yaml
 
 - job:
-    name: system-test-fedora-34
-    description: Run Toolbox's system tests in Fedora 34
-    timeout: 1200
+    name: system-test-fedora-rawhide
+    description: Run Toolbox's system tests in Fedora Rawhide
+    timeout: 2700
     files: &system_test_files ['data/*', 'playbooks/*', 'profile.d/*', 'src/*', 'meson.build', 'meson_options.txt', '.zuul.yaml']
     nodeset:
       nodes:
-        - name: ci-node-34
-          label: cloud-fedora-34-small
+        - name: ci-node-rawhide
+          label: cloud-fedora-rawhide-small
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
 
@@ -36,14 +36,14 @@
     run: playbooks/system-test.yaml
 
 - job:
-    name: system-test-fedora-rawhide
-    description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 2700
+    name: system-test-fedora-34
+    description: Run Toolbox's system tests in Fedora 34
+    timeout: 1200
     files: *system_test_files
     nodeset:
       nodes:
-        - name: ci-node-rawhide
-          label: cloud-fedora-rawhide-small
+        - name: ci-node-34
+          label: cloud-fedora-34-small
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
 

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -50,18 +50,18 @@
 - project:
     periodic:
       jobs:
-        - system-test-fedora-34
-        - system-test-fedora-35
         - system-test-fedora-rawhide
+        - system-test-fedora-35
+        - system-test-fedora-34
     check:
       jobs:
         - unit-test
-        - system-test-fedora-34
-        - system-test-fedora-35
         - system-test-fedora-rawhide
+        - system-test-fedora-35
+        - system-test-fedora-34
     gate:
       jobs:
         - unit-test
-        - system-test-fedora-34
-        - system-test-fedora-35
         - system-test-fedora-rawhide
+        - system-test-fedora-35
+        - system-test-fedora-34


### PR DESCRIPTION
Defining the YAML anchor as part of the Rawhide tests, instead of the
Fedora 34 test, will prevent it from getting lost by mistake when
Fedora 34 reaches its End of Life.