### PR TITLE
man: toolbox-create distro broken

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -82,7 +82,10 @@ confusion.
 **--distro** DISTRO, **-d** DISTRO
 
 Create a toolbox container for a different operating system DISTRO than the
-host. Cannot be used with `--image`.
+host. Cannot be used with `--image`. NOTE: This is currently broken. If an
+invalid DISTRO is passed together with the --release option, then it might
+simply download a different distro, for example Fedora of the corresponding
+release.
 
 **--image** NAME, **-i** NAME
 


### PR DESCRIPTION
Added a note that the --distro option in toolbox create is currently not working as expected.

This is being worked on in #937, but I thought it would be useful to warn users until this is resolved.
Certainly confused me and made me read the man page 3 times to see if I did something wrong.
Remove this note when #937 is solved.