### PR TITLE
ci: Build & Publish Fedora Toolbx images with GitHub Packages

### DIFF
--- a/.github/workflows/image-factory.yaml
+++ b/.github/workflows/image-factory.yaml
@@ -1,0 +1,58 @@
+name: Image Factory
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+env:
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
+  REGISTRY_USER: ${{ github.actor }}
+  REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build-push-images:
+    name: Build & Push Toolbx images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        pool:
+          - image: fedora-toolbox-36
+            version: 36
+            dir: fedora/f36
+
+          - image: fedora-toolbox-35
+            version: 35
+            dir: fedora/f35
+
+          - image: fedora-toolbox-34
+            version: 34
+            dir: fedora/f34
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Login to Registry
+        uses: redhat-actions/podman-login@v1
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          containerfiles: ./Containerfile
+          context: ./images/${{ matrix.pool.dir }}
+          image: ${{ matrix.pool.image }}
+          oci: true
+          tags: ${{ matrix.pool.version }}
+
+      # TODO: Testing of newly-created images
+
+      - name: Push Image
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+


### PR DESCRIPTION
For the sake of greater control over the testing of images and for having an
infrustructure for hosting images that are not endorsed by the distirbutions.