### PR TITLE
pkg/utils: Use new UBI toolbox image

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -104,7 +104,7 @@ var (
 		},
 		"rhel": {
 			"rhel-toolbox",
-			"ubi",
+			"toolbox",
 			parseReleaseRHEL,
 			"registry.access.redhat.com",
 			"ubi8",

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -18,7 +18,7 @@ readonly SKOPEO=$(command -v skopeo)
 # Images
 declare -Ag IMAGES=([busybox]="quay.io/toolbox_tests/busybox" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
-                   [rhel]="registry.access.redhat.com/ubi8")
+                   [rhel]="registry.access.redhat.com/ubi8/toolbox")
 
 
 function cleanup_all() {


### PR DESCRIPTION
Red Hat has published a new UBI image made specificaly for Toolbx.
Make use of it from now on.

Fixes: https://github.com/containers/toolbox/issues/961