### PR TITLE
ci: Remove only-new-issues option from linter run

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -22,4 +22,3 @@ jobs:
         with:
           version: latest
           working-directory: ./src
-          only-new-issues: true


### PR DESCRIPTION
The option is mutually exclusive with the working-directory option that
we need to use due to Toolbx code residing in a subdirectory. The tool
itself does not work recursively.

Fallout from https://github.com/containers/toolbox/pull/974

https://github.com/containers/toolbox/pull/978