### PR TITLE
profile.d: Add "istoolbx" alias

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -1,5 +1,7 @@
 # shellcheck shell=sh
 
+alias istoolbx='[ -f "/run/.toolboxenv" ] && grep -oP "(?<=name=\")[^\";]+" /run/.containerenv'
+
 # shellcheck disable=SC2153
 [ "${BASH_VERSION:-}" != "" ] || [ "${ZSH_VERSION:-}" != "" ] || return 0
 [ "$PS1" != "" ] || return 0


### PR DESCRIPTION
Adds a short command alias that can be run both from the host as well as
the toolbx container. If it is executed from the host, no output is
printed and an error code 1 is returned. If run from a toolbx, prints
out the name of the current toolbx and returns 0 instead.

This may help to alleviate e.g. https://github.com/containers/toolbox/pull/771 (and possibly others). I'm suggesting it here because many people seem to lose track of which environment they are currenty working in. If requested, I could also either make a more elaborate shell script out of this or turn it into an entirely separate project as well. I just thought it would fit here nicely.

Comment/Suggestions are welcome!