### PR TITLE
Add two bind mounts needed by display servers

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -56,6 +56,7 @@ var (
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},
+		{"/run/systemd/sessions", "/run/host/run/systemd/sessions", ""},
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
 		{"/tmp", "/run/host/tmp", "rslave"},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -58,6 +58,7 @@ var (
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},
 		{"/run/systemd/sessions", "/run/host/run/systemd/sessions", ""},
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
+		{"/run/udev/tags", "/run/host/run/udev/tags", ""},
 		{"/tmp", "/run/host/tmp", "rslave"},
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/lib/libvirt", "/run/host/var/lib/libvirt", ""},


### PR DESCRIPTION
These two commits adds two new bind mounts to newly created toolboxes.

The first one binds `/run/systemd/sessions`, so that systemd calls such as `sd_session_get_seat()` works.

The second one binds `/run/udev/tags`. This makes it possible to run device enumerators that matches against some tag. Here is an example that would now work:

```c
/* gcc -o udev-enumerate `pkg-config --cflags libudev --libs libudev` udev-enumerate.c */

#include <libudev.h>
#include <stdio.h>

int
main(int argc, char **argv)
{
	struct udev *udev;
	struct udev_enumerate *e;
	struct udev_list_entry *entry;

	udev = udev_new();
	e = udev_enumerate_new(udev);
	udev_enumerate_add_match_subsystem(e, "drm");
	udev_enumerate_add_match_tag(e, "seat");
	udev_enumerate_scan_devices(e);
	udev_list_entry_foreach(entry, udev_enumerate_get_list_entry(e)) {
		const char *path;

		path = udev_list_entry_get_name(entry);
		printf("path: %s\n", path);
	}
	return 0;
}
```