### PR TITLE
Allow toolbox containers to be created with a custom hostname

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -5,6 +5,7 @@ toolbox\-create - Create a new toolbox container
 
 ## SYNOPSIS
 **toolbox create** [*--distro DISTRO* | *-d DISTRO*]
+               [*--hostname HOSTNAME*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
                [*CONTAINER*]
@@ -84,6 +85,11 @@ confusion.
 Create a toolbox container for a different operating system DISTRO than the
 host. Cannot be used with `--image`. Has to be coupled with `--release` unless
 the selected DISTRO matches the host.
+
+**--hostname** HOSTNAME
+
+Initializes the netowork hostname of the toolbox container to the specified value.
+If not specified, this will default to **toolbox**.
 
 **--image** NAME, **-i** NAME
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -203,7 +203,7 @@ func runCommand(container string,
 				return nil
 			}
 
-			if err := createContainer(container, image, release, false); err != nil {
+			if err := createContainer(container, image, release, "", false); err != nil {
 				return err
 			}
 		} else if containersCount == 1 && defaultContainer {

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -71,6 +71,25 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+fedora-toolbox-32"
 }
 
+@test "create: Create a container with a custom hostname ('test.host-name.local')" {
+  run $TOOLBOX -y create --hostname test.host-name.local
+
+  assert_success
+  assert_output --partial "Enter with: toolbox enter"
+
+  run $TOOLBOX -y run -- hostname
+
+  assert_success
+  assert_output --partial "test.host-name.local"
+}
+
+@test "create: Create a container with an invalid hostname ('test.host-name.local.')" {
+  run $TOOLBOX -y create --hostname test.host-name.local.
+
+  assert_failure
+  assert_line --index 0 "Error: invalid hostname"
+}
+
 @test "create: Try to create a container based on non-existent image" {
   run $TOOLBOX -y create -i foo.org/bar
 


### PR DESCRIPTION
This feature consists of a new optional flag `--hostname HOSTNAME`, which can be used when invoking `toolbox create` to create a new container with a custom hostname.

This is essentially a re-implementation of #210 from scratch, written in golang.

This may also address many of the concerns brought up in the comments of #771, and could potentially assist in the adoption of a new default hostname, since it allows for more flexibility in that regard.

This PR includes:
- [x] A new feature, which is backwards compatible with all existing use-cases of `toolbox create`
- [x] Associated system tests for the new `--hostname` flag
- [x] Associated updates to the `toolbox create` documentation in the manual.