### PR TITLE
cmd/run, root: Exit with exit code of invoked command

### DIFF
--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -42,6 +42,41 @@ matches the host system.
 Run command inside a toolbox container for a different operating system
 RELEASE than the host.
 
+## EXIT STATUS
+
+The exit code gives information about why the command within the container
+failed to run or why it exited.
+
+**1** There was an internal error in Toolbox
+
+**125** There was an internal error in Podman
+
+**126** The run command could not be invoked
+
+```
+$ toolbox run /etc; echo $?
+/bin/sh: line 1: /etc: Is a directory
+/bin/sh: line 1: exec: /etc: cannot execute: Is a directory
+Error: failed to invoke command /etc in container fedora-toolbox-35
+126
+```
+
+**127** The run command cannot be found or the working directory does not exist
+
+```
+$ toolbox run foo; echo $?
+/bin/sh: line 1: exec: foo: not found
+Error: command foo not found in container fedora-toolbox-35
+127
+```
+
+**Exit code** The run command exit code
+
+```
+$ toolbox run false; echo $?
+1
+```
+
 ## EXAMPLES
 
 ### Run ls inside a toolbox container using the default image matching the host OS

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -61,8 +61,29 @@ var (
 	workingDirectory string
 )
 
+type exitError struct {
+	Code int
+	err  error
+}
+
+func (e *exitError) Error() string {
+	if e.err != nil {
+		return e.err.Error()
+	} else {
+		return ""
+	}
+}
+
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		var errExit *exitError
+		if errors.As(err, &errExit) {
+			if errExit.err != nil {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", errExit)
+			}
+			os.Exit(errExit.Code)
+		}
+
 		os.Exit(1)
 	}
 

--- a/src/cmd/root_test.go
+++ b/src/cmd/root_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2022 Ondřej Míchal
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getExitError(err error, rc int) error {
+	return &exitError{rc, err}
+}
+
+func TestExitError(t *testing.T) {
+	t.Run("correct error interface implementation", func(t *testing.T) {
+		var err error = &exitError{0, nil}
+		assert.Implements(t, (*error)(nil), err)
+	})
+
+	testCases := []struct {
+		name string
+		err  error
+		rc   int
+	}{
+		{
+			"errmsg empty; return code 0; casting from Error",
+			nil,
+			0,
+		},
+		{
+			"errmsg empty; return code > 0; casting from Error",
+			nil,
+			42,
+		},
+		{
+			"errmsg full; return code 0; casting from Error",
+			errors.New("this is an error message"),
+			0,
+		},
+		{
+			"errmsg full; return code > 0; casting from Error",
+			errors.New("this is an error message"),
+			42,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := getExitError(tc.err, tc.rc)
+			var errExit *exitError
+
+			assert.ErrorAs(t, err, &errExit)
+			assert.Equal(t, tc.rc, errExit.Code)
+			if tc.err != nil {
+				assert.Equal(t, tc.err.Error(), errExit.Error())
+			}
+		})
+	}
+}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -325,7 +325,7 @@ func runCommandWithFallbacks(container string, command []string, emitEscapeSeque
 			logrus.Debugf("%s", arg)
 		}
 
-		exitCode, err := shell.RunWithExitCode("podman", os.Stdin, os.Stdout, nil, execArgs...)
+		exitCode, err := shell.RunWithExitCode("podman", os.Stdin, os.Stdout, os.Stderr, execArgs...)
 
 		if emitEscapeSequence {
 			fmt.Printf("\033]777;container;pop;;;%s\033\\", currentUser.Uid)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -26,6 +26,7 @@ import (
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/utils"
+	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -453,9 +454,12 @@ func constructExecArgs(container string,
 
 	execArgs = append(execArgs, detachKeys...)
 
+	if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) {
+		execArgs = append(execArgs, "--tty")
+	}
+
 	execArgs = append(execArgs, []string{
 		"--interactive",
-		"--tty",
 		"--user", currentUser.Username,
 		"--workdir", workDir,
 	}...)

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -391,6 +391,12 @@ function stop_container() {
 }
 
 
+# Returns the name of the latest created container
+function get_latest_container_name() {
+  $PODMAN ps -l --format "{{ .Names }}"
+}
+
+
 function list_images() {
   $PODMAN images --all --quiet | wc -l
 }


### PR DESCRIPTION
When a command is executed with toolbox run and it returns a non-zero
exit code, it is just ignored if that exit code is not handled. This
prevents users to identify errors when executing commands in toolbox.

With this fix, the exit codes of the invoked command are propagated
and returned by 'toolbox run'. This includes even exit codes returned
by Podman on error.

Supersedes https://github.com/containers/toolbox/pull/867