### PR TITLE
Make toolbox list behave in the same way podman images does

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -40,7 +40,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 2700
+    timeout: 3600
     nodeset:
       nodes:
         - name: ci-node-rawhide

--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -128,13 +128,13 @@ func completionImageNames(cmd *cobra.Command, _ []string, _ string) ([]string, c
 	}
 
 	var imageNames []string
-	if images, err := getImages(); err == nil {
+	if images, err := getImages(true); err == nil {
 		for _, image := range images {
-			if len(image.Names) > 0 {
-				imageNames = append(imageNames, image.Names[0])
-			} else {
-				imageNames = append(imageNames, image.ID)
+			if len(image.Names) != 1 {
+				panic("cannot complete unflattened Image")
 			}
+
+			imageNames = append(imageNames, image.Names[0])
 		}
 	}
 
@@ -143,19 +143,16 @@ func completionImageNames(cmd *cobra.Command, _ []string, _ string) ([]string, c
 
 func completionImageNamesFiltered(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	var imageNames []string
-	if images, err := getImages(); err == nil {
+	if images, err := getImages(true); err == nil {
 		for _, image := range images {
 			skip := false
-			var imageName string
 
-			if len(image.Names) > 0 {
-				imageName = image.Names[0]
-			} else {
-				imageName = image.ID
+			if len(image.Names) != 1 {
+				panic("cannot complete unflattened Image")
 			}
 
 			for _, arg := range args {
-				if arg == imageName {
+				if arg == image.Names[0] {
 					skip = true
 					break
 				}
@@ -165,7 +162,7 @@ func completionImageNamesFiltered(_ *cobra.Command, args []string, _ string) ([]
 				continue
 			}
 
-			imageNames = append(imageNames, imageName)
+			imageNames = append(imageNames, image.Names[0])
 		}
 	}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -70,7 +70,7 @@ func rmi(cmd *cobra.Command, args []string) error {
 	}
 
 	if rmiFlags.deleteAll {
-		toolboxImages, err := getImages()
+		toolboxImages, err := getImages(false)
 		if err != nil {
 			return err
 		}

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -76,6 +76,27 @@ teardown() {
   fi
 }
 
+@test "list: Image and its copy" {
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image_and_copy
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 2
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+
+  assert_success
+  assert_line --index 1 --partial "$default_image"
+  assert_line --index 2 --partial "$default_image-copy"
+  assert [ ${#lines[@]} -eq 4 ]
+  if check_bats_version 1.7.0; then
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+}
+
 @test "list: Try to list images and containers (no flag) with 3 containers and 2 images (the list should have 3 images and 2 containers)" {
   # Pull the two images
   pull_default_image

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -90,8 +90,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr $TOOLBOX list --images
 
   assert_success
-  assert_line --index 1 --partial "$(get_system_id)-toolbox:$(get_system_version)"
-  assert_line --index 2 --partial "fedora-toolbox:34"
+  assert_line --index 1 --partial "fedora-toolbox:34"
+  assert_line --index 2 --partial "$(get_system_id)-toolbox:$(get_system_version)"
   assert [ ${#lines[@]} -eq 4 ]
   if check_bats_version 1.7.0; then
     assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -113,8 +113,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr $TOOLBOX list
 
   assert_success
-  assert_line --index 1 --partial "$(get_system_id)-toolbox:$(get_system_version)"
-  assert_line --index 2 --partial "fedora-toolbox:34"
+  assert_line --index 1 --partial "fedora-toolbox:34"
+  assert_line --index 2 --partial "$(get_system_id)-toolbox:$(get_system_version)"
   assert_line --index 5 --partial "$(get_system_id)-toolbox-$(get_system_version)"
   assert_line --index 6 --partial "non-default-one"
   assert_line --index 7 --partial "non-default-two"
@@ -136,8 +136,8 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "<none>"
-  assert_line --index 2 --partial "$default_image"
-  assert_line --index 3 --partial "fedora-toolbox:34"
+  assert_line --index 2 --partial "fedora-toolbox:34"
+  assert_line --index 3 --partial "$default_image"
   assert [ ${#lines[@]} -eq 5 ]
   if check_bats_version 1.7.0; then
     assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -64,7 +64,7 @@ teardown() {
 }
 
 @test "list: List an image without a name" {
-  build_image_without_name
+  build_image_without_name >/dev/null
 
   run --keep-empty-lines --separate-stderr $TOOLBOX list
 
@@ -130,7 +130,7 @@ teardown() {
 
   pull_default_image
   pull_distro_image fedora 34
-  build_image_without_name
+  build_image_without_name >/dev/null
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
 

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -115,6 +115,140 @@ teardown() {
   assert_equal "$num_of_images" 0
 }
 
+@test "rmi: An image and its copy by name, separately" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image_and_copy
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 2
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
+@test "rmi: An image and its copy by name, separately (reverse order)" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image_and_copy
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 2
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
+@test "rmi: An image and its copy by name, together" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image_and_copy
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 2
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image" "$default_image-copy"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
+@test "rmi: An image and its copy by name, together (reverse order)" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image_and_copy
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 2
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy" "$default_image"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
 @test "rmi: Try to remove all images with a container present and running" {
   skip "Bug: Fail in 'toolbox rmi' does not return non-zero value"
   num_of_images=$(list_images)

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -70,12 +70,37 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
 
-  build_image_without_name
+  build_image_without_name >/dev/null
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
+@test "rmi: An image without a name" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  image="$(build_image_without_name)"
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$image"
 
   assert_success
   assert_output ""

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -65,6 +65,34 @@ teardown() {
   assert_equal "$new_num_of_images" "$num_of_images"
 }
 
+@test "rmi: An image by name" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  local default_image
+  default_image="$(get_default_image)"
+
+  pull_default_image
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
 @test "rmi: '--all' with an image without a name" {
   local num_of_images
   num_of_images="$(list_images)"

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -29,6 +29,26 @@ teardown() {
 }
 
 
+@test "rmi: '--all' without any images" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
 @test "rmi: Remove all images with the default image present" {
   num_of_images=$(list_images)
   assert_equal "$num_of_images" 0

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -65,6 +65,31 @@ teardown() {
   assert_equal "$new_num_of_images" "$num_of_images"
 }
 
+@test "rmi: '--all' with an image without a name" {
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+
+  build_image_without_name
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+
+  assert_success
+  assert_output ""
+  output="$stderr"
+  assert_output ""
+  if check_bats_version 1.7.0; then
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 0
+}
+
 @test "rmi: Try to remove all images with a container present and running" {
   skip "Bug: Fail in 'toolbox rmi' does not return non-zero value"
   num_of_images=$(list_images)

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -53,10 +53,11 @@ teardown() {
   create_container foo
   start_container foo
 
-  run --keep-empty-lines $TOOLBOX rmi --all
+  run --keep-empty-lines --separate-stderr $TOOLBOX rmi --all
 
   assert_failure
-  assert_output --regexp "Error: image .* has dependent children"
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 --regexp "Error: image .* has dependent children"
 
   new_num_of_images=$(list_images)
 

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -35,7 +35,7 @@ teardown() {
 
   pull_default_image
 
-  run $TOOLBOX rmi --all
+  run --keep-empty-lines $TOOLBOX rmi --all
 
   assert_success
   assert_output ""
@@ -53,7 +53,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run $TOOLBOX rmi --all
+  run --keep-empty-lines $TOOLBOX rmi --all
 
   assert_failure
   assert_output --regexp "Error: image .* has dependent children"
@@ -70,7 +70,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run $TOOLBOX rmi --all --force
+  run --keep-empty-lines $TOOLBOX rmi --all --force
 
   assert_success
   assert_output ""

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -234,8 +234,12 @@ function build_image_without_name() {
   assert_line --index 1 --partial "LABEL com.github.containers.toolbox=\"true\""
   assert_line --index 2 --partial "COMMIT"
   assert_line --index 3 --regexp "^--> [a-z0-9]*$"
+  last=$((${#lines[@]}-1))
+  assert_line --index "$last" --regexp "^[a-f0-9]{64}$"
 
   rm -f "$BATS_TMPDIR"/Containerfile
+
+  echo "${lines[$last]}"
 }
 
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -327,6 +327,29 @@ function pull_default_image() {
 }
 
 
+function pull_default_image_and_copy() {
+  pull_default_image
+
+  local distro
+  local version
+  local image
+
+  distro="$(get_system_id)"
+  version="$(get_system_version)"
+  image="${IMAGES[$distro]}:$version"
+
+  # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
+  run "$SKOPEO" copy \
+      "containers-storage:[overlay@$ROOTLESS_PODMAN_STORE_DIR+$ROOTLESS_PODMAN_STORE_DIR]$image" \
+      "containers-storage:[overlay@$ROOTLESS_PODMAN_STORE_DIR+$ROOTLESS_PODMAN_STORE_DIR]$image-copy"
+
+  if [ "$status" -ne 0 ]; then
+    echo "Failed to copy image $image to $image-copy"
+    assert_success
+  fi
+}
+
+
 # Creates a container with specific name, distro and version
 #
 # Pulling of an image is taken care of by the function


### PR DESCRIPTION
This PR should fix #1043.

It makes `toolbox list` behave in the same way as `podman images`
```
[test@fedora build]$ podman images 
REPOSITORY                                                       TAG         IMAGE ID      CREATED      SIZE
registry.access.redhat.com/ubi9/toolbox                          latest      c24104d7b237  2 weeks ago  596 MB
<INTERNAL_URL>/toolbox-container                             9.0.0-9     c24104d7b237  2 weeks ago  596 MB
[test@fedora build]$ toolbox list 
IMAGE ID      IMAGE NAME                                                               CREATED
c24104d7b237  registry.access.redhat.com/ubi9/toolbox:latest                           2 weeks ago
c24104d7b237  <INTERNAL_URL>/toolbox-container:9.0.0-9                            2 weeks ago
```

As mentioned in the issue `podman images --format json` returns image twice with multiple `Names`, so my approach is to detect images with the same ID (this comes from the assumption that those image record are really identical), then print image twice with both names. 
