### PR TITLE
Extend toolbox command to accept custom hostnames.

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -45,6 +45,7 @@ var (
 		authFile  string
 		container string
 		distro    string
+		hostname  string
 		image     string
 		release   string
 	}
@@ -84,6 +85,12 @@ func init() {
 		"d",
 		"",
 		"Create a toolbox container for a different operating system distribution than the host")
+
+	flags.StringVar(&createFlags.hostname,
+		"hostname",
+		"h",
+		"toolbox",
+		"Assign a custom hostname to the toolbox container")
 
 	flags.StringVarP(&createFlags.image,
 		"image",
@@ -419,7 +426,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 	createArgs = append(createArgs, xdgRuntimeDirEnv...)
 
 	createArgs = append(createArgs, []string{
-		"--hostname", "toolbox",
+		"--hostname", hostname,
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
 	}...)


### PR DESCRIPTION
The Default behavior of toolbox does not support the dynamic setting of hostnames. 
The current behavior automatically sets the hostname of all podman containers to the hostname "toolbox"

Ideally like podman an operator might want the container name to be set at create time, so the prompt says something like....  `$username@testing` if the container was named `testing`.  This PR should continue the default behavior, but also allow the default hostname to be overwritten with the argument`--hostname foo` at toolbox create time.