### PR TITLE
src: Run 'go test' unit tests with LC_ALL=C

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -70,4 +70,10 @@ if shellcheck.found()
 endif
 
 test('go fmt', meson_go_fmt_program, args: [meson.current_source_dir()])
-test('toolbox go unit tests', go, args: ['test', '-v', './...'], workdir: meson.current_source_dir())
+test(
+  'toolbox go unit tests',
+  go,
+  args: ['test', '-v', './...'],
+  env: 'LC_ALL=C',
+  workdir: meson.current_source_dir()
+)


### PR DESCRIPTION
The system language interferes with some of the tests. And while
language specific code-paths may need to be tested, we don't have any at
the moment.