### PR TITLE
images: add `findutils` and `sudo` to missing docs for f36+

### DIFF
--- a/images/fedora/f36/missing-docs
+++ b/images/fedora/f36/missing-docs
@@ -1,6 +1,7 @@
 acl
 bash
 curl
+findutils
 gawk
 grep
 gzip
@@ -11,5 +12,6 @@ pam
 python3
 rpm
 sed
+sudo
 systemd
 tar

--- a/images/fedora/f37/missing-docs
+++ b/images/fedora/f37/missing-docs
@@ -1,6 +1,7 @@
 acl
 bash
 curl
+findutils
 gawk
 grep
 gzip
@@ -11,5 +12,6 @@ pam
 python3
 rpm
 sed
+sudo
 systemd
 tar


### PR DESCRIPTION
Noticed today that `man xargs` was returning the POSIX manpage instead
of the one shipped by `findutils`.