### PR TITLE
Re-unify container & image name resolution and ensure that the 'distro' CLI and config file options are valid

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -154,23 +154,17 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	distro, err := utils.ResolveDistro(createFlags.distro)
-	if err != nil {
-		err := createErrorInvalidDistro()
-		return err
-	}
-
-	release := createFlags.release
-	if release != "" {
+	var release string
+	if createFlags.release != "" {
 		var err error
-		release, err = utils.ParseRelease(distro, release)
+		release, err = utils.ParseRelease(createFlags.distro, createFlags.release)
 		if err != nil {
-			err := createErrorInvalidRelease(distro)
+			err := createErrorInvalidRelease()
 			return err
 		}
 	}
 
-	image, release, err := utils.ResolveImageName(distro, createFlags.image, release)
+	image, release, err := utils.ResolveImageName(createFlags.distro, createFlags.image, release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -164,12 +164,10 @@ func create(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	image, release, err := utils.ResolveImageName(createFlags.distro, createFlags.image, release)
-	if err != nil {
-		return err
-	}
-
-	container, err = utils.ResolveContainerName(container, image, release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(container,
+		createFlags.distro,
+		createFlags.image,
+		release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -119,12 +119,7 @@ func enter(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	image, release, err := utils.ResolveImageName(enterFlags.distro, "", release)
-	if err != nil {
-		return err
-	}
-
-	container, err = utils.ResolveContainerName(container, image, release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(container, enterFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -107,25 +107,19 @@ func enter(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	distro, err := utils.ResolveDistro(enterFlags.distro)
-	if err != nil {
-		err := createErrorInvalidDistro()
-		return err
-	}
-
-	release := enterFlags.release
-	if release != "" {
+	var release string
+	if enterFlags.release != "" {
 		defaultContainer = false
 
 		var err error
-		release, err = utils.ParseRelease(distro, release)
+		release, err = utils.ParseRelease(enterFlags.distro, enterFlags.release)
 		if err != nil {
-			err := createErrorInvalidRelease(distro)
+			err := createErrorInvalidRelease()
 			return err
 		}
 	}
 
-	image, release, err := utils.ResolveImageName(distro, "", release)
+	image, release, err := utils.ResolveImageName(enterFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -60,12 +60,7 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	image, release, err := utils.ResolveImageName("", "", "")
-	if err != nil {
-		return err
-	}
-
-	container, err := utils.ResolveContainerName("", image, release)
+	container, image, release, err := utils.ResolveContainerAndImageNames("", "", "", "")
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -107,20 +107,14 @@ func run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	distro, err := utils.ResolveDistro(runFlags.distro)
-	if err != nil {
-		err := createErrorInvalidDistro()
-		return err
-	}
-
-	release := runFlags.release
-	if release != "" {
+	var release string
+	if runFlags.release != "" {
 		defaultContainer = false
 
 		var err error
-		release, err = utils.ParseRelease(distro, release)
+		release, err = utils.ParseRelease(runFlags.distro, runFlags.release)
 		if err != nil {
-			err := createErrorInvalidRelease(distro)
+			err := createErrorInvalidRelease()
 			return err
 		}
 	}
@@ -136,7 +130,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	image, release, err := utils.ResolveImageName(distro, "", release)
+	image, release, err := utils.ResolveImageName(runFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -130,12 +130,7 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	image, release, err := utils.ResolveImageName(runFlags.distro, "", release)
-	if err != nil {
-		return err
-	}
-
-	container, err := utils.ResolveContainerName(runFlags.container, image, release)
+	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, runFlags.distro, "", release)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -81,20 +81,9 @@ func createErrorInvalidContainer(containerArg string) error {
 	return errors.New(errMsg)
 }
 
-func createErrorInvalidDistro() error {
-	var builder strings.Builder
-	fmt.Fprintf(&builder, "invalid argument for '--distro'\n")
-	fmt.Fprintf(&builder, "Supported values are: %s\n", strings.Join(utils.GetSupportedDistros(), " "))
-	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
-
-	errMsg := builder.String()
-	return errors.New(errMsg)
-}
-
-func createErrorInvalidRelease(distro string) error {
+func createErrorInvalidRelease() error {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "invalid argument for '--release'\n")
-	fmt.Fprintf(&builder, "Supported values for distribution %s are in format: %s\n", distro, utils.GetReleaseFormat(distro))
 	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
 
 	errMsg := builder.String()

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -250,10 +250,6 @@ func getDefaultImageForDistro(distro, release string) string {
 		panic("distro not specified")
 	}
 
-	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
-		distro = distroFallback
-	}
-
 	distroObj, supportedDistro := supportedDistros[distro]
 	if !supportedDistro {
 		panicMsg := fmt.Sprintf("failed to find %s in the list of supported distributions", distro)
@@ -715,6 +711,10 @@ func ResolveContainerAndImageNames(container, distroCLI, imageCLI, releaseCLI st
 		if viper.IsSet("general.distro") {
 			distro = viper.GetString("general.distro")
 		}
+	}
+
+	if _, ok := supportedDistros[distro]; !ok {
+		return "", "", "", fmt.Errorf("distribution %s is unsupported", distro)
 	}
 
 	if distro != distroDefault && releaseCLI == "" && !viper.IsSet("general.release") {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -44,7 +44,6 @@ type Distro struct {
 	ContainerNamePrefix    string
 	ImageBasename          string
 	ParseRelease           ParseReleaseFunc
-	ReleaseFormat          string
 	Registry               string
 	Repository             string
 	RepositoryNeedsRelease bool
@@ -59,10 +58,6 @@ const (
 	// Based on the nameRegex value in:
 	// https://github.com/containers/libpod/blob/master/libpod/options.go
 	ContainerNameRegexp = "[a-zA-Z0-9][a-zA-Z0-9_.-]*"
-)
-
-var (
-	ErrUnsupportedDistro = errors.New("linux distribution is not supported")
 )
 
 var (
@@ -103,7 +98,6 @@ var (
 			"fedora-toolbox",
 			"fedora-toolbox",
 			parseReleaseFedora,
-			"<release>/f<release>",
 			"registry.fedoraproject.org",
 			"",
 			false,
@@ -112,7 +106,6 @@ var (
 			"rhel-toolbox",
 			"toolbox",
 			parseReleaseRHEL,
-			"<major.minor>",
 			"registry.access.redhat.com",
 			"ubi8",
 			false,
@@ -253,8 +246,8 @@ func getDefaultImageForDistro(distro, release string) string {
 		panic("distro not specified")
 	}
 
-	if !IsDistroSupported(distro) {
-		distro = distroDefault
+	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
+		distro = "fedora"
 	}
 
 	distroObj, supportedDistro := supportedDistros[distro]
@@ -418,20 +411,6 @@ func GetMountOptions(target string) (string, error) {
 	return mountOptions, nil
 }
 
-// GetReleaseFormat returns the format string signifying supported release
-// version formats.
-//
-// distro should be value found under ID in os-release.
-//
-// If distro is unsupported an empty string is returned.
-func GetReleaseFormat(distro string) string {
-	if !IsDistroSupported(distro) {
-		return ""
-	}
-
-	return supportedDistros[distro].ReleaseFormat
-}
-
 func GetRuntimeDirectory(targetUser *user.User) (string, error) {
 	gid, err := strconv.Atoi(targetUser.Gid)
 	if err != nil {
@@ -486,14 +465,6 @@ func GetSupportedDistros() []string {
 // Examples: "5 minutes ago", "2 hours ago", "3 days ago"
 func HumanDuration(duration int64) string {
 	return units.HumanDuration(time.Since(time.Unix(duration, 0))) + " ago"
-}
-
-// IsDistroSupported signifies if a distribution has a toolbx image for it.
-//
-// distro should be value found under ID in os-release.
-func IsDistroSupported(distro string) bool {
-	_, ok := supportedDistros[distro]
-	return ok
 }
 
 // ImageReferenceCanBeID checks if 'image' might be the ID of an image
@@ -640,18 +611,16 @@ func ShortID(id string) string {
 	return id
 }
 
-// ParseRelease assesses if the requested version of a distribution is in
-// the correct format.
-//
-// If distro is an empty string, a default value (value under the
-// 'general.distro' key in a config file or 'fedora') is assumed.
 func ParseRelease(distro, release string) (string, error) {
 	if distro == "" {
-		distro, _ = ResolveDistro(distro)
+		distro = distroDefault
+		if viper.IsSet("general.distro") {
+			distro = viper.GetString("general.distro")
+		}
 	}
 
-	if !IsDistroSupported(distro) {
-		distro = distroDefault
+	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
+		distro = "fedora"
 	}
 
 	distroObj, supportedDistro := supportedDistros[distro]
@@ -756,33 +725,6 @@ func ResolveContainerName(container, image, release string) (string, error) {
 	return container, nil
 }
 
-// ResolveDistro assess if the requested distribution is supported and provides
-// a default value if none is requested.
-//
-// If distro is empty, and the "general.distro" key in a config file is set,
-// the value is read from the config file. If the key is not set, the default
-// value ('fedora') is used instead.
-func ResolveDistro(distro string) (string, error) {
-	logrus.Debug("Resolving distribution")
-	logrus.Debugf("Distribution: %s", distro)
-
-	if distro == "" {
-		distro = distroDefault
-		if viper.IsSet("general.distro") {
-			distro = viper.GetString("general.distro")
-		}
-	}
-
-	if !IsDistroSupported(distro) {
-		return "", ErrUnsupportedDistro
-	}
-
-	logrus.Debug("Resolved distribution")
-	logrus.Debugf("Distribution: %s", distro)
-
-	return distro, nil
-}
-
 // ResolveImageName standardizes the name of an image.
 //
 // If no image name is specified then the base image will reflect the platform of the host (even the version).
@@ -797,7 +739,10 @@ func ResolveImageName(distroCLI, imageCLI, releaseCLI string) (string, string, e
 	distro, image, release := distroCLI, imageCLI, releaseCLI
 
 	if distroCLI == "" {
-		distro, _ = ResolveDistro(distroCLI)
+		distro = distroDefault
+		if viper.IsSet("general.distro") {
+			distro = viper.GetString("general.distro")
+		}
 	}
 
 	if distro != distroDefault && releaseCLI == "" && !viper.IsSet("general.release") {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -50,8 +50,10 @@ type Distro struct {
 }
 
 const (
-	idTruncLength          = 12
-	releaseDefaultFallback = "34"
+	containerNamePrefixFallback = "fedora-toolbox"
+	distroFallback              = "fedora"
+	idTruncLength               = 12
+	releaseFallback             = "34"
 )
 
 const (
@@ -61,9 +63,9 @@ const (
 )
 
 var (
-	containerNamePrefixDefault = "fedora-toolbox"
+	containerNamePrefixDefault string
 
-	distroDefault = "fedora"
+	distroDefault string
 
 	preservedEnvironmentVariables = []string{
 		"COLORTERM",
@@ -118,7 +120,9 @@ var (
 )
 
 func init() {
-	releaseDefault = releaseDefaultFallback
+	containerNamePrefixDefault = containerNamePrefixFallback
+	distroDefault = distroFallback
+	releaseDefault = releaseFallback
 
 	hostID, err := GetHostID()
 	if err == nil {
@@ -247,7 +251,7 @@ func getDefaultImageForDistro(distro, release string) string {
 	}
 
 	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
-		distro = "fedora"
+		distro = distroFallback
 	}
 
 	distroObj, supportedDistro := supportedDistros[distro]
@@ -614,7 +618,7 @@ func ParseRelease(distro, release string) (string, error) {
 	}
 
 	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
-		distro = "fedora"
+		distro = distroFallback
 	}
 
 	distroObj, supportedDistro := supportedDistros[distro]

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -20,44 +20,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestGetReleaseFormat(t *testing.T) {
-	testCases := []struct {
-		name     string
-		distro   string
-		expected string
-	}{
-		{
-			"Unknown distro",
-			"foobar",
-			"",
-		},
-		{
-			"Known distro (fedora)",
-			"fedora",
-			supportedDistros["fedora"].ReleaseFormat,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			res := GetReleaseFormat(tc.distro)
-			assert.Equal(t, tc.expected, res)
-		})
-	}
-}
-
-func TestGetSupportedDistros(t *testing.T) {
-	refDistros := []string{"fedora", "rhel"}
-
-	distros := GetSupportedDistros()
-	for _, d := range distros {
-		assert.Contains(t, refDistros, d)
-	}
-}
 
 func TestImageReferenceCanBeID(t *testing.T) {
 	testCases := []struct {
@@ -106,92 +70,6 @@ func TestImageReferenceCanBeID(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ok := ImageReferenceCanBeID(tc.ref)
 			assert.Equal(t, tc.ok, ok)
-		})
-	}
-}
-
-func TestIsDistroSupport(t *testing.T) {
-	testCases := []struct {
-		name   string
-		distro string
-		ok     bool
-	}{
-		{
-			"Unsupported distro",
-			"foobar",
-			false,
-		},
-		{
-			"Supported distro (fedora)",
-			"fedora",
-			true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			res := IsDistroSupported(tc.distro)
-			assert.Equal(t, tc.ok, res)
-		})
-	}
-}
-
-func TestResolveDistro(t *testing.T) {
-	testCases := []struct {
-		name        string
-		distro      string
-		expected    string
-		configValue string
-		err         bool
-	}{
-		{
-			"Default - no distro provided; config unset",
-			"",
-			distroDefault,
-			"",
-			false,
-		},
-		{
-			"Default - no distro provided; config set",
-			"",
-			"rhel",
-			"rhel",
-			false,
-		},
-		{
-			"Fedora",
-			"fedora",
-			"fedora",
-			"",
-			false,
-		},
-		{
-			"RHEL",
-			"rhel",
-			"rhel",
-			"",
-			false,
-		},
-		{
-			"FooBar; wrong distro",
-			"foobar",
-			"",
-			"",
-			true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.configValue != "" {
-				viper.Set("general.distro", tc.configValue)
-			}
-
-			res, err := ResolveDistro(tc.distro)
-			assert.Equal(t, tc.expected, res)
-			if tc.err {
-				assert.NotNil(t, err)
-			}
 		})
 	}
 }

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -71,6 +71,16 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+fedora-toolbox-32"
 }
 
+@test "create: Try to create a container based on unsupported distribution" {
+  local distro="foo"
+
+  run $TOOLBOX --assumeyes create --distro "$distro"
+
+  assert_failure
+  assert_line --index 0 "Error: distribution $distro is unsupported"
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
 @test "create: Try to create a container based on non-existent image" {
   run $TOOLBOX -y create -i foo.org/bar
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -80,27 +80,13 @@ teardown() {
   assert_line --index 2 "Use 'toolbox --verbose ...' for further details."
 }
 
-@test "create: Try to create a container based on unsupported distribution" {
-  local distro="foo"
-
-  run $TOOLBOX -y create -d "$distro"
-
-  assert_failure
-  assert_line --index 0 "Error: invalid argument for '--distro'"
-  # Distro names are in a hashtable and thus the order can change
-  assert_line --index 1 --regexp "Supported values are: (.?(fedora|rhel))+"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
-}
-
 @test "create: Try to create a container based on Fedora but with wrong version" {
   run $TOOLBOX -y create -d fedora -r foobar
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
-  assert_line --index 1 "Supported values for distribution fedora are in format: <release>/f<release>"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
+  assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "create: Try to create a container based on non-default distribution without providing version" {

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -48,27 +48,13 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
-@test "run: Try to run a command in a container based on unsupported distribution" {
-  local distro="foo"
-
-  run $TOOLBOX -y run -d "$distro" ls
-
-  assert_failure
-  assert_line --index 0 "Error: invalid argument for '--distro'"
-  # Distro names are in a hashtable and thus the order can change
-  assert_line --index 1 --regexp "Supported values are: (.?(fedora|rhel))+"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
-}
-
 @test "run: Try to run a command in a container based on Fedora but with wrong version" {
   run $TOOLBOX run -d fedora -r foobar ls
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
-  assert_line --index 1 "Supported values for distribution fedora are in format: <release>/f<release>"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
+  assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "run: Try to run a command in a container based on non-default distro without providing a version" {

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -48,6 +48,16 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
+@test "run: Try to run a command in a container based on unsupported distribution" {
+  local distro="foo"
+
+  run $TOOLBOX --assumeyes run --distro "$distro" ls
+
+  assert_failure
+  assert_line --index 0 "Error: distribution $distro is unsupported"
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
 @test "run: Try to run a command in a container based on Fedora but with wrong version" {
   run $TOOLBOX run -d fedora -r foobar ls
 

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -54,6 +54,16 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
+@test "enter: Try to enter a container based on unsupported distribution" {
+  local distro="foo"
+
+  run $TOOLBOX --assumeyes enter --distro "$distro"
+
+  assert_failure
+  assert_line --index 0 "Error: distribution $distro is unsupported"
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
 @test "enter: Try to enter a container based on Fedora but with wrong version" {
   run $TOOLBOX enter -d fedora -r foobar
 

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -54,27 +54,13 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
-@test "enter: Try to enter a container based on unsupported distribution" {
-  local distro="foo"
-
-  run $TOOLBOX -y enter -d "$distro"
-
-  assert_failure
-  assert_line --index 0 "Error: invalid argument for '--distro'"
-  # Distro names are in a hashtable and thus the order can change
-  assert_line --index 1 --regexp "Supported values are: (.?(fedora|rhel))+"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
-}
-
 @test "enter: Try to enter a container based on Fedora but with wrong version" {
   run $TOOLBOX enter -d fedora -r foobar
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
-  assert_line --index 1 "Supported values for distribution fedora are in format: <release>/f<release>"
-  assert_line --index 2 "Run 'toolbox --help' for usage."
-  assert [ ${#lines[@]} -eq 3 ]
+  assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "enter: Try to enter a container based on non-default distro without providing a version" {


### PR DESCRIPTION
This reverts https://github.com/containers/toolbox/pull/977 to address the problems with it with the intention to fix the first part of https://github.com/containers/toolbox/issues/937

https://github.com/containers/toolbox/issues/937 points out several problems.  This pull request only attempts to ensure that Toolbx errors out when the user specifies an invalid `distro`, instead of falling back to Fedora.  It doesn't try to improve the error reporting for a missing or invalid `release`.

