### PR TITLE
test/system: Silence warning with Bats >= 1.7.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -6,8 +6,8 @@
     files: ['playbooks/*', 'src/*', 'meson.build', 'meson_options.txt', 'meson_post_install.py', '.zuul.yaml']
     nodeset:
       nodes:
-        - name: ci-node-34
-          label: cloud-fedora-34
+        - name: ci-node-36
+          label: cloud-fedora-36
     pre-run: playbooks/setup-env.yaml
     run: playbooks/unit-test.yaml
 
@@ -57,36 +57,21 @@
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
 
-- job:
-    name: system-test-fedora-34
-    description: Run Toolbox's system tests in Fedora 34
-    timeout: 1200
-    files: *system_test_files
-    nodeset:
-      nodes:
-        - name: ci-node-34
-          label: cloud-fedora-34
-    pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
-
 - project:
     periodic:
       jobs:
         - system-test-fedora-rawhide
         - system-test-fedora-36
         - system-test-fedora-35
-        - system-test-fedora-34
     check:
       jobs:
         - unit-test
         - system-test-fedora-rawhide
         - system-test-fedora-36
         - system-test-fedora-35
-        - system-test-fedora-34
     gate:
       jobs:
         - unit-test
         - system-test-fedora-rawhide
         - system-test-fedora-36
         - system-test-fedora-35
-        - system-test-fedora-34

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -145,7 +145,7 @@ teardown() {
 
   create_default_container
 
-  run $TOOLBOX run $cmd
+  run -127 $TOOLBOX run $cmd
 
   assert_failure
   assert [ $status -eq 127 ]


### PR DESCRIPTION
Bats 1.7.0 emits a warning if a command passed to 'run' returns with an
exit code of 127 [1].

This requires Bats >= 1.5.0, which is present in Fedora >=35, and
supports specifying the exit code as an argument to Bats' 'run'
command [2].

However, bats_require_minimum_version can't be used, because it's
only available from Bats 1.7.0, which is new enough that it's absent in
Fedora 35.

[1] Bats commit c6dc2f88361a4f5b
    https://github.com/bats-core/bats-core/pull/586
    https://bats-core.readthedocs.io/en/stable/warnings/BW01.html

[2] https://github.com/bats-core/bats-core/pull/367
    https://github.com/bats-core/bats-core/pull/507
    https://bats-core.readthedocs.io/en/stable/writing-tests.html

[3] Bats commit 71d6b71cebc3d32b
    https://github.com/bats-core/bats-core/issues/556
    https://bats-core.readthedocs.io/en/stable/warnings/BW02.html