### PR TITLE
.mailmap: Canonicalize my email

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,1 +1,2 @@
+<rishi@fedoraproject.org> <debarshir@gnome.org>
 Ondřej Míchal <harrymichal@seznam.cz>


### PR DESCRIPTION
From now on, Debarshi Ray <debarshir@gnome.org> will show up as
Debarshi Ray <rishi@fedoraproject.org>.

Toolbox isn't quite a GNOME project (it doesn't use elements from the
GNOME platform, like GLib), even though it's part of the same
ecosystem and many Toolbox contributors are also GNOME contributors.

Toolbox was conceived to improve the developer experience on Fedora
Silverblue, and expanded over time to cover other use-cases (eg.,
troubleshooting the operating system) and Fedora editions (eg., CoreOS
and Workstation).  Even though there's a growing number of users on
other distributions, they are not the primary reason for Toolbox to
exist.

Toolbox heavily depends on Podman, and as a result is more aligned with
the Containers organization on GitHub than anything else, which is
driven, to a large degree, by Fedora contributors.

Hence, my desire to use my Fedora identity.