### PR TITLE
test/system: Fix typo

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -62,7 +62,7 @@ teardown() {
 }
 
 @test "run: Try to run a command in a container based on Fedora but with wrong version" {
-  run $TOOLBOX run -d fedora -r foobar
+  run $TOOLBOX run -d fedora -r foobar ls
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"


### PR DESCRIPTION
This isn't causing any problems at the moment.  However, the test can
break if the order in which the command line arguments are validated
changes.  eg., if the presence of a command is checked before the
release, then the error message will be different.

Fallout from 8b6418d8aa6b1573a413e084e83bd1f695475406