### PR TITLE
Add builds with -Dmigration_path_for_coreos_toolbox to the CI

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -12,6 +12,18 @@
     run: playbooks/unit-test.yaml
 
 - job:
+    name: unit-test-migration-path-for-coreos-toolbox
+    description: Run Toolbox's unit tests declared in Meson when built with -Dmigration_path_for_coreos_toolbox
+    timeout: 600
+    files: ['playbooks/*', 'src/*', 'meson.build', 'meson_options.txt', 'meson_post_install.py', '.zuul.yaml']
+    nodeset:
+      nodes:
+        - name: ci-node-36
+          label: cloud-fedora-36
+    pre-run: playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
+    run: playbooks/unit-test.yaml
+
+- job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 2700
@@ -66,12 +78,14 @@
     check:
       jobs:
         - unit-test
+        - unit-test-migration-path-for-coreos-toolbox
         - system-test-fedora-rawhide
         - system-test-fedora-36
         - system-test-fedora-35
     gate:
       jobs:
         - unit-test
+        - unit-test-migration-path-for-coreos-toolbox
         - system-test-fedora-rawhide
         - system-test-fedora-36
         - system-test-fedora-35

--- a/playbooks/build.yaml
+++ b/playbooks/build.yaml
@@ -1,0 +1,12 @@
+- name: Build Toolbox
+  command: ninja -C builddir
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+    creates: builddir/src/toolbox
+
+- name: Install Toolbox
+  become: yes
+  command: ninja -C builddir install
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+    creates: /usr/local/bin/toolbox

--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -1,0 +1,35 @@
+- name: Install requirements
+  become: yes
+  package:
+    use: dnf
+    name:
+      - ShellCheck
+      - bash-completion
+      - bats
+      - flatpak-session-helper
+      - golang
+      - golang-github-cpuguy83-md2man
+      - httpd-tools
+      - meson
+      - ninja-build
+      - openssl
+      - podman
+      - skopeo
+      - systemd
+      - udisks2
+
+- name: Setup submodules
+  shell: |
+    git submodule init
+    git submodule update
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+
+- name: Check versions of crucial packages
+  command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
+
+- name: Show podman versions
+  command: podman version
+
+- name: Show podman debug information
+  command: podman info --debug

--- a/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
+++ b/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
@@ -1,0 +1,11 @@
+---
+- hosts: all
+  tasks:
+    - include_tasks: dependencies.yaml
+
+    - name: Set up build directory
+      command: meson -Dmigration_path_for_coreos_toolbox=true builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'
+
+    - include_tasks: build.yaml

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -8,15 +8,4 @@
       args:
         chdir: '{{ zuul.project.src_dir }}'
 
-    - name: Build Toolbox
-      command: ninja -C builddir
-      args:
-        chdir: '{{ zuul.project.src_dir }}'
-        creates: builddir/src/toolbox
-
-    - name: Install Toolbox
-      become: yes
-      command: ninja -C builddir install
-      args:
-        chdir: '{{ zuul.project.src_dir }}'
-        creates: /usr/local/bin/toolbox
+    - include_tasks: build.yaml

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -1,41 +1,7 @@
 ---
 - hosts: all
   tasks:
-    - name: Install requirements
-      become: yes
-      package:
-        use: dnf
-        name:
-          - ShellCheck
-          - bash-completion
-          - bats
-          - flatpak-session-helper
-          - golang
-          - golang-github-cpuguy83-md2man
-          - httpd-tools
-          - meson
-          - ninja-build
-          - openssl
-          - podman
-          - skopeo
-          - systemd
-          - udisks2
-
-    - name: Setup submodules
-      shell: |
-        git submodule init
-        git submodule update
-      args:
-        chdir: '{{ zuul.project.src_dir }}'
-
-    - name: Check versions of crucial packages
-      command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
-
-    - name: Show podman versions
-      command: podman version
-
-    - name: Show podman debug information
-      command: podman info --debug
+    - include_tasks: dependencies.yaml
 
     - name: Set up build directory
       command: meson builddir


### PR DESCRIPTION
The `-Dmigration_path_for_coreos_toolbox` option enables a different code
path that's currently not tested by the CI at all.  In fact, since it's
a build-time option, the corresponding code path is not even built by
the CI.

To properly support the `-Dmigration_path_for_coreos_toolbox` option, it
needs to be covered by the CI.  This is a step in that direction by
running the unit tests on it.