### PR TITLE
build: Silence a WARNING

### DIFF
--- a/completion/meson.build
+++ b/completion/meson.build
@@ -1,14 +1,14 @@
 generate_completions_program = find_program('generate_completions.py')
 
 if bash_completion.found()
-  bash_comp_dir = bash_completion.get_pkgconfig_variable('completionsdir')
+  bash_comp_dir = bash_completion.get_variable(pkgconfig: 'completionsdir')
 else
   bash_comp_dir = get_option('datadir') / 'bash-completion' / 'completions'
   message('bash-completion not found: using', get_option('prefix') / bash_comp_dir, 'as a falback install directory')
 endif
 
 if fish.found()
-  fish_comp_dir = fish.get_pkgconfig_variable('completionsdir')
+  fish_comp_dir = fish.get_variable(pkgconfig: 'completionsdir')
 else
   fish_comp_dir = get_option('datadir') / 'fish' / 'completions'
   message('fish not found: using', get_option('prefix') / fish_comp_dir, 'as a fallback install directory')

--- a/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
+++ b/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
@@ -4,7 +4,7 @@
     - include_tasks: dependencies.yaml
 
     - name: Set up build directory
-      command: meson -Dmigration_path_for_coreos_toolbox=true builddir
+      command: meson -Dmigration_path_for_coreos_toolbox=true --fatal-meson-warnings builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
 

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -4,7 +4,7 @@
     - include_tasks: dependencies.yaml
 
     - name: Set up build directory
-      command: meson builddir
+      command: meson --fatal-meson-warnings builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
 


### PR DESCRIPTION
Otherwise, Meson complains:
  completion/meson.build:4: WARNING: Project targeting '>= 0.58.0' but
    tried to use feature deprecated since '0.56.0':
    dependency.get_pkgconfig_variable. use
    dependency.get_variable(pkgconfig : ...) instead

Fallout from bafbbe81c9220cb3749a19a244e45a61477553a6