### PR TITLE
pkg/utils: Mark a private function as such

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -231,7 +231,7 @@ func GetCgroupsVersion() (int, error) {
 	return version, nil
 }
 
-func GetContainerNamePrefixForImage(image string) (string, error) {
+func getContainerNamePrefixForImage(image string) (string, error) {
 	basename := ImageReferenceGetBasename(image)
 	if basename == "" {
 		return "", fmt.Errorf("failed to get the basename of image %s", image)
@@ -739,7 +739,7 @@ func ResolveContainerName(container, image, release string) (string, error) {
 
 	if container == "" {
 		var err error
-		container, err = GetContainerNamePrefixForImage(image)
+		container, err = getContainerNamePrefixForImage(image)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Figuring out the container name prefix for a given image only needs to
happen as part of resolving the final Toolbox container name from the
given command line and configuration options.

Fallout from c990fb43cad5f1704584f119ba4f57074c1d0bc9