### PR TITLE
cmd/utils, test/system: Tweak an error message for consistency

### DIFF
--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -74,7 +74,7 @@ func createErrorContainerNotFound(container string) error {
 func createErrorInvalidContainer(containerArg string) error {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "invalid argument for '%s'\n", containerArg)
-	fmt.Fprintf(&builder, "Container names must match '%s'\n", utils.ContainerNameRegexp)
+	fmt.Fprintf(&builder, "Container names must match '%s'.\n", utils.ContainerNameRegexp)
 	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
 
 	errMsg := builder.String()

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -43,7 +43,7 @@ teardown() {
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for 'CONTAINER'"
-  assert_line --index 1 "Container names must match '[a-zA-Z0-9][a-zA-Z0-9_.-]*'"
+  assert_line --index 1 "Container names must match '[a-zA-Z0-9][a-zA-Z0-9_.-]*'."
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
@@ -52,7 +52,7 @@ teardown() {
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--container'"
-  assert_line --index 1 "Container names must match '[a-zA-Z0-9][a-zA-Z0-9_.-]*'"
+  assert_line --index 1 "Container names must match '[a-zA-Z0-9][a-zA-Z0-9_.-]*'."
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 


### PR DESCRIPTION
Barring the first line, all other lines are terminated with a full stop
elsewhere.
