### PR TITLE
Increase the validation coverage for the container & release options

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -147,28 +147,12 @@ func create(cmd *cobra.Command, args []string) error {
 		containerArg = "--container"
 	}
 
-	if container != "" {
-		if !utils.IsContainerNameValid(container) {
-			err := createErrorInvalidContainer(containerArg)
-			return err
-		}
-	}
-
-	var release string
-	if createFlags.release != "" {
-		var err error
-		release, err = utils.ParseRelease(createFlags.distro, createFlags.release)
-		if err != nil {
-			hint := err.Error()
-			err := createErrorInvalidRelease(hint)
-			return err
-		}
-	}
-
-	container, image, release, err := utils.ResolveContainerAndImageNames(container,
+	container, image, release, err := resolveContainerAndImageNames(container,
+		containerArg,
 		createFlags.distro,
 		createFlags.image,
-		release)
+		createFlags.release)
+
 	if err != nil {
 		return err
 	}

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -100,27 +100,18 @@ func enter(cmd *cobra.Command, args []string) error {
 
 	if container != "" {
 		defaultContainer = false
-
-		if !utils.IsContainerNameValid(container) {
-			err := createErrorInvalidContainer(containerArg)
-			return err
-		}
 	}
 
-	var release string
 	if enterFlags.release != "" {
 		defaultContainer = false
-
-		var err error
-		release, err = utils.ParseRelease(enterFlags.distro, enterFlags.release)
-		if err != nil {
-			hint := err.Error()
-			err := createErrorInvalidRelease(hint)
-			return err
-		}
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(container, enterFlags.distro, "", release)
+	container, image, release, err := resolveContainerAndImageNames(container,
+		containerArg,
+		enterFlags.distro,
+		"",
+		enterFlags.release)
+
 	if err != nil {
 		return err
 	}

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -60,7 +60,7 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	container, image, release, err := utils.ResolveContainerAndImageNames("", "", "", "")
+	container, image, release, err := resolveContainerAndImageNames("", "", "", "", "")
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -100,24 +100,10 @@ func run(cmd *cobra.Command, args []string) error {
 
 	if runFlags.container != "" {
 		defaultContainer = false
-
-		if !utils.IsContainerNameValid(runFlags.container) {
-			err := createErrorInvalidContainer("--container")
-			return err
-		}
 	}
 
-	var release string
 	if runFlags.release != "" {
 		defaultContainer = false
-
-		var err error
-		release, err = utils.ParseRelease(runFlags.distro, runFlags.release)
-		if err != nil {
-			hint := err.Error()
-			err := createErrorInvalidRelease(hint)
-			return err
-		}
 	}
 
 	if len(args) == 0 {
@@ -131,7 +117,12 @@ func run(cmd *cobra.Command, args []string) error {
 
 	command := args
 
-	container, image, release, err := utils.ResolveContainerAndImageNames(runFlags.container, runFlags.distro, "", release)
+	container, image, release, err := resolveContainerAndImageNames(runFlags.container,
+		"--container",
+		runFlags.distro,
+		"",
+		runFlags.release)
+
 	if err != nil {
 		return err
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ sources = files(
   'cmd/utils.go',
   'pkg/podman/podman.go',
   'pkg/shell/shell.go',
+  'pkg/utils/errors.go',
   'pkg/utils/utils.go',
   'pkg/version/version.go',
 )

--- a/src/pkg/utils/errors.go
+++ b/src/pkg/utils/errors.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2022 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+)
+
+type ContainerError struct {
+	Container string
+	Image     string
+	Err       error
+}
+
+type ParseReleaseError struct {
+	Hint string
+}
+
+func (err *ContainerError) Error() string {
+	errMsg := fmt.Sprintf("%s: %s", err.Container, err.Err)
+	return errMsg
+}
+
+func (err *ContainerError) Unwrap() error {
+	return err.Err
+}
+
+func (err *ParseReleaseError) Error() string {
+	return err.Hint
+}

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -150,7 +150,7 @@ func TestParseRelease(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			release, err := ParseRelease(tc.inputDistro, tc.inputRelease)
+			release, err := parseRelease(tc.inputDistro, tc.inputRelease)
 
 			if tc.ok {
 				assert.NoError(t, err)

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -56,6 +56,19 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
+@test "create: Try to create a container with invalid custom image ('ßpeci@l.Nam€')" {
+  local image="ßpeci@l.Nam€"
+
+  run $TOOLBOX create --image "$image"
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--image'"
+  assert_line --index 1 "Container name $image generated from image is invalid."
+  assert_line --index 2 "Container names must match '[a-zA-Z0-9][a-zA-Z0-9_.-]*'."
+  assert_line --index 3 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 4 ]
+}
+
 @test "create: Create a container with a distro and release options ('fedora'; f32)" {
   pull_distro_image fedora 32
 


### PR DESCRIPTION
Currently, the container name and release are only validated if they
were specified as command line options.  Neither the value of release
in the configuration file nor the container name generated from an
image are validated.

There's also a lot of repeated code in the command front-ends to
validate the container name and release.  This opens the door for
mistakes.  Any adjustment to the code must be repeated elsewhere, and
there are subtle interactions and overlaps between the validation code
and the code to resolve container and image names.

It's worth noting that the container and image name resolution happens
for both the command line and configuration file options, and generates
the container name from the image when necessary.

Therefore, validating everything while resolving cleans up the command
front-ends and increases the coverage of the validation.

This introduces the use of sentinel error values and custom error
implementations to identify the different errors that can occur while
resolving the container and images, so that they can be appropriately
shown to the user.