### PR TITLE
cmd/utils, pkg/utils: Improve the error messages for the distro option

### DIFF
--- a/src/pkg/utils/errors.go
+++ b/src/pkg/utils/errors.go
@@ -26,6 +26,11 @@ type ContainerError struct {
 	Err       error
 }
 
+type DistroError struct {
+	Distro string
+	Err    error
+}
+
 type ParseReleaseError struct {
 	Hint string
 }
@@ -36,6 +41,15 @@ func (err *ContainerError) Error() string {
 }
 
 func (err *ContainerError) Unwrap() error {
+	return err.Err
+}
+
+func (err *DistroError) Error() string {
+	errMsg := fmt.Sprintf("%s: %s", err.Distro, err.Err)
+	return errMsg
+}
+
+func (err *DistroError) Unwrap() error {
 	return err.Err
 }
 

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -121,6 +121,10 @@ var (
 	ErrContainerNameFromImageInvalid = errors.New("container name generated from image is invalid")
 
 	ErrContainerNameInvalid = errors.New("container name is invalid")
+
+	ErrDistroUnsupported = errors.New("distribution is unsupported")
+
+	ErrDistroWithoutRelease = errors.New("non-default distribution must specify release")
 )
 
 func init() {
@@ -713,11 +717,11 @@ func ResolveContainerAndImageNames(container, distroCLI, imageCLI, releaseCLI st
 	}
 
 	if _, ok := supportedDistros[distro]; !ok {
-		return "", "", "", fmt.Errorf("distribution %s is unsupported", distro)
+		return "", "", "", &DistroError{distro, ErrDistroUnsupported}
 	}
 
 	if distro != distroDefault && releaseCLI == "" && !viper.IsSet("general.release") {
-		return "", "", "", fmt.Errorf("release not found for non-default distribution %s", distro)
+		return "", "", "", &DistroError{distro, ErrDistroWithoutRelease}
 	}
 
 	if releaseCLI == "" {

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -90,8 +90,10 @@ teardown() {
   run $TOOLBOX --assumeyes create --distro "$distro"
 
   assert_failure
-  assert_line --index 0 "Error: distribution $distro is unsupported"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: invalid argument for '--distro'"
+  assert_line --index 1 "Distribution $distro is unsupported."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "create: Try to create a container based on non-existent image" {
@@ -158,8 +160,10 @@ teardown() {
   run $TOOLBOX -y create -d "$distro"
 
   assert_failure
-  assert_line --index 0 "Error: release not found for non-default distribution $distro"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: option '--release' is needed"
+  assert_line --index 1 "Distribution $distro doesn't match the host."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "create: Try to create a container and pass a non-existent file to the --authfile option" {

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -54,8 +54,10 @@ teardown() {
   run $TOOLBOX --assumeyes run --distro "$distro" ls
 
   assert_failure
-  assert_line --index 0 "Error: distribution $distro is unsupported"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: invalid argument for '--distro'"
+  assert_line --index 1 "Distribution $distro is unsupported."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "run: Try to run a command in a container based on Fedora but with wrong version" {
@@ -113,8 +115,10 @@ teardown() {
   run $TOOLBOX run -d "$distro" ls
 
   assert_failure
-  assert_line --index 0 "Error: release not found for non-default distribution $distro"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: option '--release' is needed"
+  assert_line --index 1 "Distribution $distro doesn't match the host."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "run: Run echo 'Hello World' inside of the default container" {

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -60,8 +60,10 @@ teardown() {
   run $TOOLBOX --assumeyes enter --distro "$distro"
 
   assert_failure
-  assert_line --index 0 "Error: distribution $distro is unsupported"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: invalid argument for '--distro'"
+  assert_line --index 1 "Distribution $distro is unsupported."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "enter: Try to enter a container based on Fedora but with wrong version" {
@@ -119,8 +121,10 @@ teardown() {
   run $TOOLBOX enter -d "$distro"
 
   assert_failure
-  assert_line --index 0 "Error: release not found for non-default distribution $distro"
-  assert [ ${#lines[@]} -eq 1 ]
+  assert_line --index 0 "Error: option '--release' is needed"
+  assert_line --index 1 "Distribution $distro doesn't match the host."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 # TODO: Write the test


### PR DESCRIPTION
This improves the error messages related to `--distro` to address the second point of https://github.com/containers/toolbox/issues/937