### PR TITLE
doc/toolbox-create: Tweak an example for consistency

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -129,7 +129,7 @@ $ toolbox create --distro fedora --release f36
 $ toolbox create --image bar foo
 ```
 
-### Create a toolbox container from a custom image needing authentication
+### Create a custom toolbox container from a custom image that's private
 
 ```
 $ toolbox create --authfile ~/auth.json --image registry.example.com/bar


### PR DESCRIPTION
When describing the --authfile option, the word "private" is used to refer to images needing authentication.  Using the same word shortens the text so that the word "custom" can be used in the same way as in the other examples.