### PR TITLE
cmd: Don't use Logrus to call panic

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -100,10 +100,13 @@ func init() {
 	createCmd.SetHelpFunc(createHelp)
 
 	if err := createCmd.RegisterFlagCompletionFunc("distro", completionDistroNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
+
 	if err := createCmd.RegisterFlagCompletionFunc("image", completionImageNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 
 	rootCmd.AddCommand(createCmd)

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/containers/toolbox/pkg/utils"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -63,10 +62,12 @@ func init() {
 		"Enter a toolbox container for a different operating system release than the host")
 
 	if err := enterCmd.RegisterFlagCompletionFunc("container", completionContainerNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 	if err := enterCmd.RegisterFlagCompletionFunc("distro", completionDistroNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 
 	enterCmd.SetHelpFunc(enterHelp)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -117,7 +117,8 @@ func init() {
 	persistentFlags.CountVarP(&rootFlags.verbose, "verbose", "v", "Set log-level to 'debug'")
 
 	if err := rootCmd.RegisterFlagCompletionFunc("log-level", completionLogLevels); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 
 	rootCmd.SetHelpFunc(rootHelp)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -74,10 +74,12 @@ func init() {
 	runCmd.SetHelpFunc(runHelp)
 
 	if err := runCmd.RegisterFlagCompletionFunc("container", completionContainerNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 	if err := runCmd.RegisterFlagCompletionFunc("distro", completionDistroNames); err != nil {
-		logrus.Panicf("failed to register flag completion function: %v", err)
+		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
+		panic(panicMsg)
 	}
 
 	rootCmd.AddCommand(runCmd)


### PR DESCRIPTION
While the use of Logrus is convenient, it causes unneeded fluff to be printed during a panic which distracts from finding the cause of the panic in the first place.

Fallout from d69ce6794b08972592b8528613e0dcbcbda6d5f8

Split out from https://github.com/containers/toolbox/pull/1055