### PR TITLE
cmd/completion: Remove unneeded documentation

### DIFF
--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -10,40 +10,8 @@ import (
 )
 
 var completionCmd = &cobra.Command{
-	Use:   "__completion [bash|zsh|fish|powershell]",
-	Short: "Generate completion script",
-	Long: `To load completions:
-
-Bash:
-
-  $ source <(toolbox completion bash)
-
-  # To load completions for each session, execute once:
-  # Linux:
-  $ toolbox completion bash > /etc/bash_completion.d/toolbox
-  # macOS:
-  $ toolbox completion bash > /usr/local/etc/bash_completion.d/toolbox
-
-Zsh:
-
-  # If shell completion is not already enabled in your environment,
-  # you will need to enable it.  You can execute the following once:
-
-  $ echo "autoload -U compinit; compinit" >> ~/.zshrc
-
-  # To load completions for each session, execute once:
-  $ toolbox completion zsh > "${fpath[1]}/_toolbox"
-
-  # You will need to start a new shell for this setup to take effect.
-
-fish:
-
-  $ toolbox completion fish | source
-
-  # To load completions for each session, execute once:
-  $ toolbox completion fish > ~/.config/fish/completions/toolbox.fish
-
-`,
+	Use:                   "__completion",
+	Short:                 "Generate completion script",
 	Hidden:                true,
 	DisableFlagsInUseLine: true,
 	ValidArgs:             []string{"bash", "zsh", "fish"},


### PR DESCRIPTION
We don't provide completion for PowerShell, we support only Linux and instructions for loading completion files are redundant in Toolbx.

Fallout from d69ce6794b08972592b8528613e0dcbcbda6d5f8

Split out from https://github.com/containers/toolbox/pull/1055