### PR TITLE
build: Remove redundant build_by_default

### DIFF
--- a/completion/meson.build
+++ b/completion/meson.build
@@ -17,6 +17,7 @@ endif
 completion_bash = custom_target('bash-completion',
   capture: true,
   command: [generate_completions_program, meson.global_source_root() / 'src', 'bash'],
+  depends: [toolbox],
   install: true,
   install_dir: bash_comp_dir,
   output: 'toolbox')
@@ -24,6 +25,7 @@ completion_bash = custom_target('bash-completion',
 completion_zsh = custom_target('zsh-completion',
   capture: true,
   command: [generate_completions_program, meson.global_source_root() / 'src', 'zsh'],
+  depends: [toolbox],
   install: true,
   install_dir: get_option('datadir') / 'zsh' / 'site_functions',
   output: '_toolbox')
@@ -31,6 +33,7 @@ completion_zsh = custom_target('zsh-completion',
 completion_fish = custom_target('fish-completion',
   capture: true,
   command: [generate_completions_program, meson.global_source_root() / 'src', 'fish'],
+  depends: [toolbox],
   install: true,
   install_dir: fish_comp_dir,
   output: 'toolbox.fish')

--- a/src/meson.build
+++ b/src/meson.build
@@ -48,7 +48,7 @@ endif
 
 message('Host machine dynamic linker:', dynamic_linker)
 
-custom_target(
+toolbox = custom_target(
   'toolbox',
   build_by_default: true,
   command: [

--- a/src/meson.build
+++ b/src/meson.build
@@ -50,7 +50,6 @@ message('Host machine dynamic linker:', dynamic_linker)
 
 toolbox = custom_target(
   'toolbox',
-  build_by_default: true,
   command: [
     go_build_wrapper_program,
     meson.current_source_dir(),


### PR DESCRIPTION
By default, the value of the `build_by_default` argument is determined
by the value of the `install` argument, which has been set to `true`
ever since the Go implementation was considered stable enough for end
users.

Fallout from 0b3c66434e8e4bf138d902d115b87d0dbfac16df