### PR TITLE
build: Fix typo in install dir for ZSH completions

### DIFF
--- a/completion/meson.build
+++ b/completion/meson.build
@@ -27,7 +27,7 @@ completion_zsh = custom_target('zsh-completion',
   command: [generate_completions_program, meson.global_source_root() / 'src', 'zsh'],
   depends: [toolbox],
   install: true,
-  install_dir: get_option('datadir') / 'zsh' / 'site_functions',
+  install_dir: get_option('datadir') / 'zsh' / 'site-functions',
   output: '_toolbox')
 
 completion_fish = custom_target('fish-completion',


### PR DESCRIPTION
Fallout from bafbbe81c9220cb3749a19a244e45a61477553a6

Split from https://github.com/containers/toolbox/pull/1055