### PR TITLE
cmd/completion: Use Cobra's Bash completion v2

### DIFF
--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -35,7 +35,7 @@ var completionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		switch args[0] {
 		case "bash":
-			if err := cmd.Root().GenBashCompletion(os.Stdout); err != nil {
+			if err := cmd.Root().GenBashCompletionV2(os.Stdout, true); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v", err)
 			}
 		case "zsh":


### PR DESCRIPTION
Bash completion v2 was introduced in Cobra v1.2.0 and v1 will be deprecated in the future:
https://github.com/spf13/cobra/releases/tag/v1.2.0

Since Toolbox already requires Cobra >= v1.3.0, it's better to use the new Bash completion.

Fallout from d69ce6794b08972592b8528613e0dcbcbda6d5f8

Split from https://github.com/containers/toolbox/pull/1055