### PR TITLE
Revert "cmd/completion: Add prefix to command to hide it better"

### DIFF
--- a/completion/generate_completions.py
+++ b/completion/generate_completions.py
@@ -22,8 +22,7 @@ import sys
 
 if len(sys.argv) != 3:
     print('{}: wrong arguments'.format(sys.argv[0]), file=sys.stderr)
-    print('Usage: {} [SOURCE DIR] [COMPLETION TYPE]'.format(
-        sys.argv[0]), file=sys.stderr)
+    print('Usage: {} [SOURCE DIR] [COMPLETION TYPE]'.format(sys.argv[0]), file=sys.stderr)
     print()
     print("SOURCE DIR is path to the Toolbox Go source code")
     print("COMPLETION TYPE is either 'bash', 'zsh' or 'fish'")
@@ -34,11 +33,9 @@ completion_type = sys.argv[2]
 
 try:
     os.chdir(source_dir)
-    output = subprocess.run(
-        ['go', 'run', '.', '__completion', completion_type], check=True)
+    output = subprocess.run(['go', 'run', '.', 'completion', completion_type], check=True)
 except subprocess.CalledProcessError as e:
-    print('{}: go run returned non-zero exit status {}'.format(
-        sys.argv[0], e.returncode), file=sys.stderr)
+    print('{}: go run returned non-zero exit status {}'.format(sys.argv[0], e.returncode), file=sys.stderr)
     sys.exit(e.returncode)
 
 sys.exit(0)

--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -26,7 +26,7 @@ import (
 )
 
 var completionCmd = &cobra.Command{
-	Use:                   "__completion",
+	Use:                   "completion",
 	Short:                 "Generate completion script",
 	Hidden:                true,
 	DisableFlagsInUseLine: true,


### PR DESCRIPTION
Cobra provides a default command 'completion' that is always visible. The reverted change caused an additional command 'completion' to show up in the list because the then called command '__completion' didn't override the default one. This became apparent due to d69ce6794b089725 dynamically generating completion arguments for the 'help' command.

This reverts commit 4469774fb1986252aa9660892dba33c9447420ec.

Split from https://github.com/containers/toolbox/pull/1055