### PR TITLE
build: Don't try to handle exceptions when spawning subprocesses

### DIFF
--- a/completion/generate_completions.py
+++ b/completion/generate_completions.py
@@ -31,11 +31,7 @@ if len(sys.argv) != 3:
 source_dir = sys.argv[1]
 completion_type = sys.argv[2]
 
-try:
-    os.chdir(source_dir)
-    output = subprocess.run(['go', 'run', '.', 'completion', completion_type], check=True)
-except subprocess.CalledProcessError as e:
-    print('{}: go run returned non-zero exit status {}'.format(sys.argv[0], e.returncode), file=sys.stderr)
-    sys.exit(e.returncode)
+os.chdir(source_dir)
+output = subprocess.run(['go', 'run', '.', 'completion', completion_type], check=True)
 
 sys.exit(0)

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -22,7 +22,6 @@ import sys
 destdir = os.environ.get('DESTDIR', '')
 
 if not destdir and not os.path.exists('/run/.containerenv'):
-    print('Calling systemd-tmpfiles --create ...')
     subprocess.run(['systemd-tmpfiles', '--create'], check=True)
 
 sys.exit(0)

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -23,11 +23,6 @@ destdir = os.environ.get('DESTDIR', '')
 
 if not destdir and not os.path.exists('/run/.containerenv'):
     print('Calling systemd-tmpfiles --create ...')
-
-    try:
-        subprocess.run(['systemd-tmpfiles', '--create'], check=True)
-    except subprocess.CalledProcessError as e:
-        print('Returned non-zero exit status', e.returncode)
-        sys.exit(e.returncode)
+    subprocess.run(['systemd-tmpfiles', '--create'], check=True)
 
 sys.exit(0)

--- a/src/meson_go_fmt.py
+++ b/src/meson_go_fmt.py
@@ -25,12 +25,7 @@ if len(sys.argv) != 2:
 
 source_dir = sys.argv[1]
 
-try:
-    gofmt = subprocess.run(['gofmt', '-d', source_dir], capture_output=True, check=True)
-except subprocess.CalledProcessError as e:
-    print('{}: gofmt returned non-zero exit status {}'.format(sys.argv[0], e.returncode), file=sys.stderr)
-    sys.exit(e.returncode)
-
+gofmt = subprocess.run(['gofmt', '-d', source_dir], capture_output=True, check=True)
 if gofmt.stdout:
    diff = gofmt.stdout.decode()
    print(diff)


### PR DESCRIPTION
In short, it's a lot of effort to cover all possible exceptions that can
be thrown, and things work reasonably well even without handling them.
Since this is just part of the build, there's no point in complicating
things for aesthetic reasons.

More details in the commits.