### PR TITLE
build: Enable changing the completion paths & drop install_completions

### DIFF
--- a/completion/meson.build
+++ b/completion/meson.build
@@ -1,28 +1,28 @@
 generate_completions_program = find_program('generate_completions.py')
 
-if bash_completion_dep.found()
-  bashcompletionsdir = bash_completion_dep.get_variable(pkgconfig: 'completionsdir')
-else
-  bashcompletionsdir = get_option('datadir') / 'bash-completion' / 'completions'
-  message('bash-completion not found: using', get_option('prefix') / bashcompletionsdir, 'as a falback install directory')
-endif
-
-if fish_dep.found()
-  fishcompletionsdir = fish_dep.get_variable(pkgconfig: 'completionsdir')
-else
-  fishcompletionsdir = get_option('datadir') / 'fish' / 'completions'
-  message('fish not found: using', get_option('prefix') / fishcompletionsdir, 'as a fallback install directory')
-endif
-
-custom_target(
-  'bash-completion',
-  capture: true,
-  command: [generate_completions_program, meson.global_source_root() / 'src', 'bash'],
-  depends: [toolbox_go],
-  install: true,
-  install_dir: bashcompletionsdir,
-  output: 'toolbox',
+if bashcompletionsdir != ''
+  custom_target(
+    'bash-completion',
+    capture: true,
+    command: [generate_completions_program, meson.global_source_root() / 'src', 'bash'],
+    depends: [toolbox_go],
+    install: true,
+    install_dir: bashcompletionsdir,
+    output: 'toolbox',
 )
+endif
+
+if fishcompletionsdir != ''
+  custom_target(
+    'fish-completion',
+    capture: true,
+    command: [generate_completions_program, meson.global_source_root() / 'src', 'fish'],
+    depends: [toolbox_go],
+    install: true,
+    install_dir: fishcompletionsdir,
+    output: 'toolbox.fish',
+)
+endif
 
 custom_target(
   'zsh-completion',
@@ -30,16 +30,6 @@ custom_target(
   command: [generate_completions_program, meson.global_source_root() / 'src', 'zsh'],
   depends: [toolbox_go],
   install: true,
-  install_dir: get_option('datadir') / 'zsh' / 'site-functions',
+  install_dir: zshcompletionsdir,
   output: '_toolbox',
-)
-
-custom_target(
-  'fish-completion',
-  capture: true,
-  command: [generate_completions_program, meson.global_source_root() / 'src', 'fish'],
-  depends: [toolbox_go],
-  install: true,
-  install_dir: fishcompletionsdir,
-  output: 'toolbox.fish',
 )

--- a/completion/meson.build
+++ b/completion/meson.build
@@ -21,7 +21,7 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: bashcompletionsdir,
-  output: 'toolbox'
+  output: 'toolbox',
 )
 
 custom_target(
@@ -31,7 +31,7 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: get_option('datadir') / 'zsh' / 'site-functions',
-  output: '_toolbox'
+  output: '_toolbox',
 )
 
 custom_target(
@@ -41,5 +41,5 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: fishcompletionsdir,
-  output: 'toolbox.fish'
+  output: 'toolbox.fish',
 )

--- a/meson.build
+++ b/meson.build
@@ -18,8 +18,26 @@ go_md2man = find_program('go-md2man')
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 
-bash_completion_dep = dependency('bash-completion', required: false)
-fish_dep = dependency('fish', required: false)
+bashcompletionsdir = get_option('bash_completions_dir')
+if bashcompletionsdir == ''
+  bash_completion_dep = dependency('bash-completion', required: false)
+  if bash_completion_dep.found()
+    bashcompletionsdir = bash_completion_dep.get_variable(pkgconfig: 'completionsdir')
+  endif
+endif
+
+fishcompletionsdir = get_option('fish_completions_dir')
+if fishcompletionsdir == ''
+  fish_completion_dep = dependency('fish', required: false)
+  if fish_completion_dep.found()
+    fishcompletionsdir = fish_completion_dep.get_variable(pkgconfig: 'completionsdir')
+  endif
+endif
+
+zshcompletionsdir = get_option('zsh_completions_dir')
+if zshcompletionsdir == ''
+  zshcompletionsdir = get_option('datadir') / 'zsh' / 'site-functions'
+endif
 
 migration_path_for_coreos_toolbox = get_option('migration_path_for_coreos_toolbox')
 profiledir = get_option('profile_dir')
@@ -70,8 +88,6 @@ subdir('data')
 subdir('doc')
 subdir('profile.d')
 subdir('src')
-if get_option('install_completions')
-  subdir('completion')
-endif
+subdir('completion')
 
 meson.add_install_script('meson_post_install.py')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,22 @@
 option(
+  'bash_completions_dir',
+  description: 'Directory for Bash completion scripts',
+  type: 'string',
+)
+
+option(
+  'fish_completions_dir',
+  description: 'Directory for fish completion scripts',
+  type: 'string',
+)
+
+option(
+  'zsh_completions_dir',
+  description: 'Directory for Z shell completion scripts (default=$datadir/zsh/site-functions)',
+  type: 'string',
+)
+
+option(
   'migration_path_for_coreos_toolbox',
   description: 'Offer a migration path to users of github.com/coreos/toolbox',
   type: 'boolean',
@@ -16,11 +34,4 @@ option(
   'tmpfiles_dir',
   description: 'Directory for system-wide tmpfiles.d(5) files',
   type: 'string',
-)
-
-option(
-  'install_completions',
-  description: 'Install bash, zsh and fish command completions',
-  type: 'boolean',
-  value: true,
 )


### PR DESCRIPTION
The `bash-completion` and `fish` dependencies were already optional - the shell completions for Bash and fish won't be generated and installed if they are absent; and there's no dependency required for Z shell.  So the `install_completions` build option wasn't reducing the dependency burden.

The build option was a way to disable the generation and installation of the shell completions, regardless of whether the necessary dependencies are present or not.  The only use-case for this is when installing to a non-system-wide prefix while hacking on Toolbox as a non-root user, because the locations for the completions advertised by the shells' APIs might not be accessible.  Being able to disable the completions prevents the installation from failing.

A different way of ensuring a smooth developer experience for a Toolbx hacker is to offer a way to change the locations where the shell completions are installed, which is necessary and beneficial for other use-cases.

Z shell, unlike Bash's `bash-completion.pc` and fish's `fish.pc`, doesn't offer an API to detect the location for the shell completions.  This means that Debian and Fedora use different locations [1, 2].  Namely, `/usr/share/zsh/vendor-completions` and `/usr/share/zsh/site-functions`.

An option to specify the locations for the shell completions can optimize the build, if there's an alternate API for the location that
doesn't involve using `bash-completion.pc` and `fish.pc` as build dependencies.  eg., Fedora provides the `_tmpfilesdir` RPM macro to specify the location for vendor-supplied `tmpfiles.d(5)` files, which makes it possible to avoid having `systemd.pc` as a build dependency [3].

Fallout from bafbbe81c9220cb3749a19a244e45a61477553a6

[1] Debian zsh commit bf0a44a8744469b5
    https://salsa.debian.org/debian/zsh/-/commit/bf0a44a8744469b5
    https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=620452

[2] https://src.fedoraproject.org/rpms/zsh/blob/f37/f/zsh.spec

[3] Fedora toolbox commit 9bebde5bb60f36e3
    https://src.fedoraproject.org/rpms/toolbox/c/9bebde5bb60f36e3

https://github.com/containers/toolbox/pull/840