### PR TITLE
Add new packages to Fedora 38

### DIFF
--- a/images/fedora/f38/extra-packages
+++ b/images/fedora/f38/extra-packages
@@ -20,6 +20,8 @@ less
 lsof
 man-db
 man-pages
+mesa-dri-drivers
+mesa-vulkan-drivers
 mtr
 nano-default-editor
 nss-mdns
@@ -37,6 +39,7 @@ tree
 unzip
 util-linux
 vte-profile
+vulkan-loader
 wget
 which
 words


### PR DESCRIPTION
The following packages have also been added to Fedora 38 image: mesa-dri-drivers
mesa-vulkan-drivers
vulkan-loader
Fixing up fedora 38 image to match the changes made earlier on fedora 37.

Signed-off-by: Nieves Montero <nmontero@redhat.com>