### PR TITLE
Add findutils and sudo to missing docs for images f36, f37 and f38

### DIFF
--- a/images/fedora/f36/missing-docs
+++ b/images/fedora/f36/missing-docs
@@ -1,6 +1,7 @@
 acl
 bash
 curl
+findutils
 gawk
 grep
 gzip
@@ -11,5 +12,6 @@ pam
 python3
 rpm
 sed
+sudo
 systemd
 tar

--- a/images/fedora/f37/missing-docs
+++ b/images/fedora/f37/missing-docs
@@ -1,6 +1,7 @@
 acl
 bash
 curl
+findutils
 gawk
 grep
 gzip
@@ -11,5 +12,6 @@ pam
 python3
 rpm
 sed
+sudo
 systemd
 tar

--- a/images/fedora/f38/missing-docs
+++ b/images/fedora/f38/missing-docs
@@ -1,6 +1,7 @@
 acl
 bash
 curl
+findutils
 gawk
 grep
 gzip
@@ -11,5 +12,6 @@ pam
 python3
 rpm
 sed
+sudo
 systemd
 tar


### PR DESCRIPTION
This pull request is based on the following one https://github.com/containers/toolbox/pull/1068