### PR TITLE
Add corrections to avoid duplicate packages

### DIFF
--- a/images/fedora/f37/Containerfile
+++ b/images/fedora/f37/Containerfile
@@ -13,6 +13,8 @@ COPY README.md /
 
 RUN sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
 RUN dnf -y swap coreutils-single coreutils-full
+RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks
+RUN rm /etc/rpm/macros.image-language.conf
 
 COPY missing-docs /
 RUN dnf -y reinstall $(<missing-docs)

--- a/images/fedora/f37/extra-packages
+++ b/images/fedora/f37/extra-packages
@@ -7,7 +7,6 @@ findutils
 flatpak-spawn
 fpaste
 git
-glibc-all-langpacks
 gnupg
 gnupg2-smime
 gvfs-client

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -13,6 +13,8 @@ COPY README.md /
 
 RUN sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
 RUN dnf -y swap coreutils-single coreutils-full
+RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks
+RUN rm /etc/rpm/macros.image-language.conf
 
 COPY missing-docs /
 RUN dnf -y reinstall $(<missing-docs)

--- a/images/fedora/f38/extra-packages
+++ b/images/fedora/f38/extra-packages
@@ -7,7 +7,6 @@ findutils
 flatpak-spawn
 fpaste
 git
-glibc-all-langpacks
 gnupg
 gnupg2-smime
 gvfs-client


### PR DESCRIPTION
The following lines have been added to the fedora 37 and 38 images: RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks RUN rm /etc/rom/macros.image-language.conf
These two lines avoid redundant packages inside the images.

https://github.com/containers/toolbox/issues/1136
https://github.com/containers/toolbox/issues/1137

Signed-off-by: Nieves Montero <nmontero@redhat.com>