### PR TITLE
build: Skip a needless failure when running systemd-tmpfiles  as non-root

### DIFF
--- a/completion/meson.build
+++ b/completion/meson.build
@@ -1,28 +1,28 @@
 generate_completions_program = find_program('generate_completions.py')
 
-if bash_completion_dep.found()
-  bashcompletionsdir = bash_completion_dep.get_variable(pkgconfig: 'completionsdir')
-else
-  bashcompletionsdir = get_option('datadir') / 'bash-completion' / 'completions'
-  message('bash-completion not found: using', get_option('prefix') / bashcompletionsdir, 'as a falback install directory')
-endif
-
-if fish_dep.found()
-  fishcompletionsdir = fish_dep.get_variable(pkgconfig: 'completionsdir')
-else
-  fishcompletionsdir = get_option('datadir') / 'fish' / 'completions'
-  message('fish not found: using', get_option('prefix') / fishcompletionsdir, 'as a fallback install directory')
-endif
-
-custom_target(
-  'bash-completion',
-  capture: true,
-  command: [generate_completions_program, meson.global_source_root() / 'src', 'bash'],
-  depends: [toolbox_go],
-  install: true,
-  install_dir: bashcompletionsdir,
-  output: 'toolbox',
+if bashcompletionsdir != ''
+  custom_target(
+    'bash-completion',
+    capture: true,
+    command: [generate_completions_program, meson.global_source_root() / 'src', 'bash'],
+    depends: [toolbox_go],
+    install: true,
+    install_dir: bashcompletionsdir,
+    output: 'toolbox',
 )
+endif
+
+if fishcompletionsdir != ''
+  custom_target(
+    'fish-completion',
+    capture: true,
+    command: [generate_completions_program, meson.global_source_root() / 'src', 'fish'],
+    depends: [toolbox_go],
+    install: true,
+    install_dir: fishcompletionsdir,
+    output: 'toolbox.fish',
+)
+endif
 
 custom_target(
   'zsh-completion',
@@ -30,16 +30,6 @@ custom_target(
   command: [generate_completions_program, meson.global_source_root() / 'src', 'zsh'],
   depends: [toolbox_go],
   install: true,
-  install_dir: get_option('datadir') / 'zsh' / 'site-functions',
+  install_dir: zshcompletionsdir,
   output: '_toolbox',
-)
-
-custom_target(
-  'fish-completion',
-  capture: true,
-  command: [generate_completions_program, meson.global_source_root() / 'src', 'fish'],
-  depends: [toolbox_go],
-  install: true,
-  install_dir: fishcompletionsdir,
-  output: 'toolbox.fish',
 )

--- a/completion/meson.build
+++ b/completion/meson.build
@@ -21,7 +21,7 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: bashcompletionsdir,
-  output: 'toolbox'
+  output: 'toolbox',
 )
 
 custom_target(
@@ -31,7 +31,7 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: get_option('datadir') / 'zsh' / 'site-functions',
-  output: '_toolbox'
+  output: '_toolbox',
 )
 
 custom_target(
@@ -41,5 +41,5 @@ custom_target(
   depends: [toolbox_go],
   install: true,
   install_dir: fishcompletionsdir,
-  output: 'toolbox.fish'
+  output: 'toolbox.fish',
 )

--- a/meson.build
+++ b/meson.build
@@ -18,8 +18,26 @@ go_md2man = find_program('go-md2man')
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 
-bash_completion_dep = dependency('bash-completion', required: false)
-fish_dep = dependency('fish', required: false)
+bashcompletionsdir = get_option('bash_completions_dir')
+if bashcompletionsdir == ''
+  bash_completion_dep = dependency('bash-completion', required: false)
+  if bash_completion_dep.found()
+    bashcompletionsdir = bash_completion_dep.get_variable(pkgconfig: 'completionsdir')
+  endif
+endif
+
+fishcompletionsdir = get_option('fish_completions_dir')
+if fishcompletionsdir == ''
+  fish_completion_dep = dependency('fish', required: false)
+  if fish_completion_dep.found()
+    fishcompletionsdir = fish_completion_dep.get_variable(pkgconfig: 'completionsdir')
+  endif
+endif
+
+zshcompletionsdir = get_option('zsh_completions_dir')
+if zshcompletionsdir == ''
+  zshcompletionsdir = get_option('datadir') / 'zsh' / 'site-functions'
+endif
 
 migration_path_for_coreos_toolbox = get_option('migration_path_for_coreos_toolbox')
 profiledir = get_option('profile_dir')
@@ -70,8 +88,6 @@ subdir('data')
 subdir('doc')
 subdir('profile.d')
 subdir('src')
-if get_option('install_completions')
-  subdir('completion')
-endif
+subdir('completion')
 
 meson.add_install_script('meson_post_install.py')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,22 @@
 option(
+  'bash_completions_dir',
+  description: 'Directory for Bash completion scripts',
+  type: 'string',
+)
+
+option(
+  'fish_completions_dir',
+  description: 'Directory for fish completion scripts',
+  type: 'string',
+)
+
+option(
+  'zsh_completions_dir',
+  description: 'Directory for Z shell completion scripts (default=$datadir/zsh/site-functions)',
+  type: 'string',
+)
+
+option(
   'migration_path_for_coreos_toolbox',
   description: 'Offer a migration path to users of github.com/coreos/toolbox',
   type: 'boolean',
@@ -16,11 +34,4 @@ option(
   'tmpfiles_dir',
   description: 'Directory for system-wide tmpfiles.d(5) files',
   type: 'string',
-)
-
-option(
-  'install_completions',
-  description: 'Install bash, zsh and fish command completions',
-  type: 'boolean',
-  value: true,
 )

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -20,8 +20,9 @@ import subprocess
 import sys
 
 destdir = os.environ.get('DESTDIR', '')
+euid = os.geteuid()
 
-if not destdir and not os.path.exists('/run/.containerenv'):
+if not destdir and not os.path.exists('/run/.containerenv') and euid == 0:
     subprocess.run(['systemd-tmpfiles', '--create'], check=True)
 
 sys.exit(0)


### PR DESCRIPTION
If `systemd-tmpfiles --create` is called as a non-root user, then it causes:
```
  --- stdout ---
  Calling systemd-tmpfiles --create ...

  --- stderr ---
  Failed to open directory 'cryptsetup': Permission denied
  Failed to open directory 'certs': Permission denied
  Failed to create directory or subvolume "/var/spool/cups/tmp":
    Permission denied
  ...
  ...
  ...
  Traceback (most recent call last):
    File "toolbox/meson_post_install.py", line 26, in <module>
      subprocess.run(['systemd-tmpfiles', '--create'], check=True)
    File "/usr/lib64/python3.10/subprocess.py", line 524, in run
      raise CalledProcessError(retcode, process.args,
  subprocess.CalledProcessError: Command '['systemd-tmpfiles',
      '--create']' returned non-zero exit status 73.
```

Since, `systemd-tmpfiles(8)` can't be used like this as a non-root user, there's no point in calling it and needlessly failing the build.

Unfortunately, Meson doesn't seem to offer a way to get the process' effective UID inside its scripts.  Therefore, this leaves a spurious build-time dependency on systemd when building as a non-root user.