### PR TITLE
playbooks: Use the same commands as mentioned in the documentation

### DIFF
--- a/data/config/meson.build
+++ b/data/config/meson.build
@@ -1,4 +1,4 @@
 install_data(
   'toolbox.conf',
-  install_dir: join_paths(get_option('sysconfdir'), 'containers'),
+  install_dir: get_option('sysconfdir') / 'containers',
 )

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -32,7 +32,7 @@ foreach section, pages: manuals
       command: go_md2man_command,
       input: input,
       install: true,
-      install_dir: join_paths(get_option('mandir'), sectiondir),
+      install_dir: get_option('mandir') / sectiondir,
       output: output,
     )
   endforeach

--- a/meson.build
+++ b/meson.build
@@ -63,7 +63,7 @@ endif
 
 install_subdir(
   'test',
-  install_dir: join_paths(get_option('datadir'), meson.project_name()),
+  install_dir: get_option('datadir') / meson.project_name(),
   exclude_files: [
     'system/libs/bats-assert/.git',
     'system/libs/bats-assert/.gitignore',

--- a/playbooks/build.yaml
+++ b/playbooks/build.yaml
@@ -1,12 +1,12 @@
 - name: Build Toolbox
-  command: ninja -C builddir
+  command: meson compile -C builddir
   args:
     chdir: '{{ zuul.project.src_dir }}'
     creates: builddir/src/toolbox
 
 - name: Install Toolbox
   become: yes
-  command: ninja -C builddir install
+  command: meson install -C builddir
   args:
     chdir: '{{ zuul.project.src_dir }}'
     creates: /usr/local/bin/toolbox

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -4,7 +4,7 @@
     - include_tasks: dependencies.yaml
 
     - name: Set up build directory
-      command: meson --fatal-meson-warnings builddir
+      command: meson setup --fatal-meson-warnings builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
 

--- a/playbooks/unit-test.yaml
+++ b/playbooks/unit-test.yaml
@@ -2,6 +2,6 @@
 - hosts: all
   tasks:
     - name: Test
-      command: ninja -C builddir test
+      command: meson test -C builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'


### PR DESCRIPTION
... at https://containertoolbx.org/install/

There are some minor benefits to always invoking `meson(1)`, as opposed to directly invoking the underlying build backend, like `ninja`.

It's one less command to be aware of.  Secondly, in theory, Meson can be used with backends other than Ninja (see `meson configure`), even though Ninja is the most likely option for building Toolbx because it's only supported on Linux.