### PR TITLE
cmd/list, cmd/run: Consolidate the dependencies for the IsTerminal() API

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2021 Red Hat Inc.
+ * Copyright © 2019 – 2022 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ import (
 
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 type toolboxImage struct {
@@ -264,9 +264,10 @@ func listOutput(images []toolboxImage, containers []toolboxContainer) {
 		const resetColor = "\033[0m"
 
 		stdoutFd := os.Stdout.Fd()
+		stdoutFdInt := int(stdoutFd)
 		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-		if isatty.IsTerminal(stdoutFd) {
+		if term.IsTerminal(stdoutFdInt) {
 			fmt.Fprintf(writer, "%s", defaultColor)
 		}
 
@@ -278,7 +279,7 @@ func listOutput(images []toolboxImage, containers []toolboxContainer) {
 			"STATUS",
 			"IMAGE NAME")
 
-		if isatty.IsTerminal(stdoutFd) {
+		if term.IsTerminal(stdoutFdInt) {
 			fmt.Fprintf(writer, "%s", resetColor)
 		}
 
@@ -290,7 +291,7 @@ func listOutput(images []toolboxImage, containers []toolboxContainer) {
 				isRunning = container.Status == "running"
 			}
 
-			if isatty.IsTerminal(stdoutFd) {
+			if term.IsTerminal(stdoutFdInt) {
 				var color string
 				if isRunning {
 					color = boldGreenColor
@@ -308,7 +309,7 @@ func listOutput(images []toolboxImage, containers []toolboxContainer) {
 				container.Status,
 				container.Image)
 
-			if isatty.IsTerminal(stdoutFd) {
+			if term.IsTerminal(stdoutFdInt) {
 				fmt.Fprintf(writer, "%s", resetColor)
 			}
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2021 Red Hat Inc.
+ * Copyright © 2019 – 2022 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import (
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/utils"
-	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -441,7 +441,13 @@ func constructExecArgs(container string,
 
 	execArgs = append(execArgs, detachKeys...)
 
-	if isatty.IsTerminal(os.Stdin.Fd()) && isatty.IsTerminal(os.Stdout.Fd()) {
+	stdinFd := os.Stdin.Fd()
+	stdinFdInt := int(stdinFd)
+
+	stdoutFd := os.Stdout.Fd()
+	stdoutFdInt := int(stdoutFd)
+
+	if term.IsTerminal(stdinFdInt) && term.IsTerminal(stdoutFdInt) {
 		execArgs = append(execArgs, "--tty")
 	}
 

--- a/src/go.mod
+++ b/src/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/docker/go-units v0.4.0
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/godbus/dbus/v5 v5.0.6
-	github.com/mattn/go-isatty v0.0.14
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1


### PR DESCRIPTION
It was decided in commit 950f510872404da8 that golang.org/x/* would be used for the IsTerminal() API, not github.com/mattn/go-isatty.  However, github.com/mattn/go-isatty had crept in through commits f49df914f4b64fed and a22d7821cb8cea13.

The size savings seem to have been lost, because with Go 1.18.6, the binary size actually grew from 9410616 bytes to 9410912.  However, it seems better to stick to packages from the golang.org domain, whenever possible.