### PR TITLE
cmd/run: Fix the name of the shell for running commands in containers

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -461,7 +461,7 @@ func constructExecArgs(container string,
 
 	execArgs = append(execArgs, []string{
 		container,
-		"capsh", "--caps=", "--", "-c", "exec \"$@\"", "/bin/sh",
+		"capsh", "--caps=", "--", "-c", "exec \"$@\"", "bash",
 	}...)
 
 	execArgs = append(execArgs, command...)

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -184,7 +184,7 @@ teardown() {
 
   assert_failure
   assert [ $status -eq 127 ]
-  assert_line --index 0 "/bin/sh: line 1: exec: $cmd: not found"
+  assert_line --index 0 "bash: line 1: exec: $cmd: not found"
   assert_line --index 1 "Error: command $cmd not found in container $(get_latest_container_name)"
   assert [ ${#lines[@]} -eq 2 ]
 }
@@ -196,8 +196,8 @@ teardown() {
 
   assert_failure
   assert [ $status -eq 126 ]
-  assert_line --index 0 "/bin/sh: line 1: /etc: Is a directory"
-  assert_line --index 1 "/bin/sh: line 1: exec: /etc: cannot execute: Is a directory"
+  assert_line --index 0 "bash: line 1: /etc: Is a directory"
+  assert_line --index 1 "bash: line 1: exec: /etc: cannot execute: Is a directory"
   assert_line --index 2 "Error: failed to invoke command /etc in container $(get_latest_container_name)"
   assert [ ${#lines[@]} -eq 3 ]
 }


### PR DESCRIPTION
For the most part, this fixes a minor cosmetic issue for users, but it does make the code less misleading to read for those hacking on Toolbx. Further details below.

Commands are invoked inside a Toolbx from a helper shell invoked by `capsh(1)`.  Unless `capsh(1)` is built with custom options, the helper shell is always `bash`, not `/bin/sh`:
```
$ capsh --caps="" -- -c 'echo "$(readlink /proc/$$/exe)"'
/usr/bin/bash
```

( The possibility of capsh(1) using a different shell, other than Bash,
  through a custom build option is ignored for the time being.  If there
  really are downstream distributors who do that, then this can be
  addressed one way or another. )

Secondly, the name assigned to the embedded command string's `$0` should only be the basename of the helper shell's binary, not the full path, to match the usual behaviour:
```
$ bash -c 'exec foo'
bash: line 1: exec: foo: not found
```

With 'toolbox run' it was:
```
$ toolbox run foo
/bin/sh: line 1: exec: foo: not found
Error: command foo not found in container fedora-toolbox-36
```