### PR TITLE
Fix spelling errors caught by `codespell`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ Here are some ideas of what you could contribute with:
   images. Ultimately there should be a wide variety of supported distro images.
   You can help with testing other people's image definitions or creating your
   own. **Beware**, maintainers still don't have a clear idea of how the image
-  infrustructure should look like.
+  infrastructure should look like.
 - Write documentation - Some functions in Toolbox's code don't have comments and
   it's not very clear what they do. Toolbox has it's [documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/)
   hosted by Fedora. It's not very large and could use some attention.

--- a/doc/toolbox-rm.1.md
+++ b/doc/toolbox-rm.1.md
@@ -20,7 +20,7 @@ The following options are understood:
 
 **--all, -a**
 
-Remove all toolbox containers. It can be used in conjuction with `--force` as
+Remove all toolbox containers. It can be used in conjunction with `--force` as
 well.
 
 **--force, -f**

--- a/doc/toolbox-rmi.1.md
+++ b/doc/toolbox-rmi.1.md
@@ -20,7 +20,7 @@ The following options are understood:
 
 **--all, -a**
 
-Remove all toolbox images. It can be used in conjuction with `--force` as well.
+Remove all toolbox images. It can be used in conjunction with `--force` as well.
 
 **--force, -f**
 

--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -62,7 +62,7 @@ func completionCommands(cmd *cobra.Command, _ []string, _ string) ([]string, cob
 	commandNames := []string{}
 	commands := cmd.Root().Commands()
 	for _, command := range commands {
-		if strings.Contains(command.Name(), "complet") {
+		if strings.Contains(command.Name(), "complete") {
 			continue
 		}
 		commandNames = append(commandNames, command.Name())

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -272,7 +272,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 		if err := ioutil.WriteFile("/etc/krb5.conf.d/kcm_default_ccache",
 			kcmConfigBytes,
 			0644); err != nil {
-			return errors.New("failed to set KCM as the defult Kerberos credential cache")
+			return errors.New("failed to set KCM as the default Kerberos credential cache")
 		}
 	}
 

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -43,7 +43,7 @@ teardown() {
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
-@test "enter: Try to enter a specifc non-existent container with other containers present" {
+@test "enter: Try to enter a specific non-existent container with other containers present" {
   create_container other-container
 
   run $TOOLBOX enter wrong-container

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -70,7 +70,7 @@ function _clean_temporary_storage() {
 # - distro - os-release field ID (e.g., fedora, rhel)
 # - version - os-release field VERSION_ID (e.g., 33, 34, 8.4)
 #
-# Only use during test suite setup for caching all images to be used throught
+# Only use during test suite setup for caching all images to be used throughout
 # tests.
 function _pull_and_cache_distro_image() {
   local num_of_retries=5


### PR DESCRIPTION
See also: #1146