### PR TITLE
test/system: Ensure that $HOME is used as a fallback working directory

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -58,6 +58,23 @@ teardown() {
   assert_line --index $((${#lines[@]}-1)) "Hello World"
 }
 
+@test "run: Ensure that $HOME is used as a fallback working directory" {
+  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  create_default_container
+
+  pushd /etc/kernel
+  run --separate-stderr $TOOLBOX run pwd
+  popd
+
+  assert_success
+  assert_line --index 0 "$HOME"
+  assert [ ${#lines[@]} -eq 1 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index $((${#stderr_lines[@]}-2)) "Error: directory /etc/kernel not found in container $default_container_name"
+  assert_line --index $((${#stderr_lines[@]}-1)) "Using $HOME instead."
+  assert [ ${#stderr_lines[@]} -gt 2 ]
+}
+
 @test "run: Try to run a command in the default container with no containers created" {
   local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
 


### PR DESCRIPTION
This needs a directory that's going to be present on the host operating system across various configurations of all supported distributions, such as the hosts running the CI, but not inside the Toolbx containers.

It looks like `/etc/kernel` is present on both Debian and Fedora, but absent from the fedora-toolbox images.  On a Debian 10 server, it's owned by several packages:
```
$ dpkg-query --search /etc/kernel
dkms, systemd, grub2-common, initramfs-tools, apt: /etc/kernel
```

... while on Fedora 36 Workstation:
```
$ rpm --file --query /etc/kernel
systemd-udev-250.8-1.fc36.x86_64
```

Currently, there's no way to get `assert_line` to use the `stderr_lines` array [1].  This is worked around by assigning `stderr_lines` to the `lines` array.

[1] https://github.com/bats-core/bats-assert/issues/42