### PR TITLE
cmd/run: Suppress errors from Podman when interactive and not verbose

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -459,12 +459,6 @@ func constructExecArgs(container string,
 	fallbackToBash bool,
 	ttyNeeded bool,
 	workDir string) []string {
-	var detachKeys []string
-
-	if detachKeysSupported {
-		detachKeys = []string{"--detach-keys", ""}
-	}
-
 	logLevelString := podman.LogLevel.String()
 
 	execArgs := []string{
@@ -472,19 +466,28 @@ func constructExecArgs(container string,
 		"exec",
 	}
 
-	execArgs = append(execArgs, detachKeys...)
-
-	if ttyNeeded {
-		execArgs = append(execArgs, "--tty")
+	if detachKeysSupported {
+		execArgs = append(execArgs, []string{
+			"--detach-keys", "",
+		}...)
 	}
+
+	execArgs = append(execArgs, envOptions...)
 
 	execArgs = append(execArgs, []string{
 		"--interactive",
+	}...)
+
+	if ttyNeeded {
+		execArgs = append(execArgs, []string{
+			"--tty",
+		}...)
+	}
+
+	execArgs = append(execArgs, []string{
 		"--user", currentUser.Username,
 		"--workdir", workDir,
 	}...)
-
-	execArgs = append(execArgs, envOptions...)
 
 	execArgs = append(execArgs, []string{
 		container,


### PR DESCRIPTION
Here's some historical context to understand what's going on.

In the past, before commit a22d7821cb8cea13, Podman's standard error stream was only revealed when `--verbose` was used.

During that time, the standard error and output streams of the process running inside the Toolbx container, but not `podman exec ...` itself, were merged into the standard output stream read and revealed by the Toolbx binary.

Then commit a22d7821cb8cea13 ensured that a nested pseudo-terminal device is only created for the process running inside the container, if the Toolbx binary's standard input and output streams are connected to a terminal.  This meant that the standard error stream of the container process stayed separate from the standard output stream received by the Toolbx binary, when terminal devices were absent.  The errors from `podman exec ...` itself continued to be separate as before.

However, Toolbx only read and revealed the standard error stream of the spawned `podman exec ...` process when `--verbose` was used.  This meant that all the errors from the container process got lost in the absence of `--verbose`.  This was an unintended change in behaviour caused by commit a22d7821cb8cea13 that got addressed in the subsequent commit 7cba807e450a1ab8, but with yet another unintended change in behaviour.

Commit 7cba807e450a1ab8 started reading and revealing the standard error stream of the spawned `podman exec ...` process unconditionally.  This caused the errors from both Podman and the container process to be revealed unconditionally, which is a problem.

Podman is an implementation detail of Toolbx.  Therefore, Toolbx users shouldn't be directly exposed to errors from Podman, unless they are using `--verbose` to debug a problem.  On the other hand, the container process is the outcome of a command specified by the user.  So, the user does expect to see what's going on with it.

That's the unintended change in behaviour this commit tries to fix.

Unfortunately, when Toolbx is being used non-interactively (ie., no terminal devices), the errors from the process running inside the Toolbx container and the errors from `podman exec ...` itself are part of the same standard error stream received by Toolbx.  It's impossible to distinguish between the two without deeper changes.

Hence, this commit only focuses on interactive use (ie., terminals are present), which is where the visual appearance and presentation of error messages really matter.  Non-interactive use is programmatic use, so the visuals don't matter so much.

Fallout from 7cba807e450a1ab8b34b42cba25c4fac69ae2e6c