### PR TITLE
test/system: Group the test cases somewhat logically

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -58,6 +58,21 @@ teardown() {
   assert_line --index $((${#lines[@]}-1)) "Hello World"
 }
 
+@test "run: Run sudo id inside of the default container" {
+  create_default_container
+
+  output="$($TOOLBOX --verbose run sudo id 2>$BATS_TMPDIR/stderr)"
+  status="$?"
+
+  echo "# stderr"
+  cat $BATS_TMPDIR/stderr
+  echo "# stdout"
+  echo $output
+
+  assert_success
+  assert_output --partial "uid=0(root)"
+}
+
 @test "run: Ensure that $HOME is used as a fallback working directory" {
   local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
   create_default_container
@@ -181,21 +196,6 @@ teardown() {
   assert_line --index 1 "Distribution $distro doesn't match the host."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#lines[@]} -eq 3 ]
-}
-
-@test "run: Run sudo id inside of the default container" {
-  create_default_container
-
-  output="$($TOOLBOX --verbose run sudo id 2>$BATS_TMPDIR/stderr)"
-  status="$?"
-
-  echo "# stderr"
-  cat $BATS_TMPDIR/stderr
-  echo "# stdout"
-  echo $output
-
-  assert_success
-  assert_output --partial "uid=0(root)"
 }
 
 @test "run: Run command exiting with non-zero code in the default container" {


### PR DESCRIPTION
It seems that as new test cases got developed they got appended towards the end of the file.  Now that there are a non-trivial number of test cases, it's difficult to look at the file and get a gist of all the scenarios being tested.

It will be better to have some logical grouping -- starting with the most basic functionality, then moving on to more advanced features, and then finally the errors.

This is a step towards that.