### PR TITLE
test/system: Remove workaround for carriage return without a terminal

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -40,7 +40,7 @@ teardown() {
 @test "run: Run echo 'Hello World' inside of the default container" {
   create_default_container
 
-  run $TOOLBOX --verbose run echo -n "Hello World"
+  run $TOOLBOX --verbose run echo "Hello World"
 
   assert_success
   assert_line --index $((${#lines[@]}-1)) "Hello World"
@@ -52,7 +52,7 @@ teardown() {
   start_container running
   stop_container running
 
-  run $TOOLBOX --verbose run --container running echo -n "Hello World"
+  run $TOOLBOX --verbose run --container running echo "Hello World"
 
   assert_success
   assert_line --index $((${#lines[@]}-1)) "Hello World"


### PR DESCRIPTION
Commit a22d7821cb8cea13 ensured that a nested pseudo-terminal device is only created for the process running inside the container, if the Toolbx binary's standard input and output streams are connected to a terminal.

Therefore, 'echo ...' no longer ends with an unwanted extra carriage return when terminal devices are absent - there's only a line feed for the trailing newline.  Hence, there's no need to use the -n flag to skip the trailing newline.

This reverts parts of commit 16b0c5d88fcc404d52c6e37a7f46bd430b352369.

https://github.com/containers/toolbox/issues/157