### PR TITLE
playbooks: Highlight failures from 'meson compile' and 'meson install'

### DIFF
--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -18,6 +18,12 @@
       - systemd
       - udisks2
 
+- name: Download Go modules
+  shell: |
+    go mod download -x
+  args:
+    chdir: '{{ zuul.project.src_dir }}/src'
+
 - name: Setup submodules
   shell: |
     git submodule init

--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -1,4 +1,4 @@
-- name: Install requirements
+- name: Install RPM packages
   become: yes
   package:
     use: dnf
@@ -24,7 +24,7 @@
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Setup submodules
+- name: Setup Git submodules
   shell: |
     git submodule init
     git submodule update

--- a/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
+++ b/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
@@ -7,5 +7,3 @@
       command: meson -Dmigration_path_for_coreos_toolbox=true --fatal-meson-warnings builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
-
-    - include_tasks: build.yaml

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -7,5 +7,3 @@
       command: meson setup --fatal-meson-warnings builddir
       args:
         chdir: '{{ zuul.project.src_dir }}'
-
-    - include_tasks: build.yaml

--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -1,6 +1,8 @@
 ---
 - hosts: all
   tasks:
+    - include_tasks: build.yaml
+
     - name: Run system tests
       command: bats --timing ./test/system
       environment:

--- a/playbooks/unit-test.yaml
+++ b/playbooks/unit-test.yaml
@@ -1,6 +1,8 @@
 ---
 - hosts: all
   tasks:
+    - include_tasks: build.yaml
+
     - name: Test
       command: meson test -C builddir
       args:


### PR DESCRIPTION
Currently, `meson compile` and `meson install` were being invoked from pre-run playbooks.  This meant that a genuine build failure from either of those commands would be shown as a `RETRY_LIMIT` failure by the CI.

This was misleading.  It made it look as if the failure was caused by some transient networking problem or that the CI node was too slow due to momentary heavy load, whereas the failure was actually due to a problem in the Toolbx sources.  A genuine problem in the sources should be reflected as a `FAILURE`, not `RETRY_LIMIT`.

However, it's worth noting that `meson compile` invokes `go build`, which downloads all the Go modules required by the Toolbx sources.  This is worth retaining in the pre-run playbooks since it primarily depends on Internet infrastructure beyond the Toolbx sources.

As a nice side-effect, the CI no longer gets mysteriously stuck like this while the Go modules are being downloaded:
```
TASK [Build Toolbox]
ci-node-36 | ninja: Entering directory `/home/zuul-worker/src/github.com/containers/toolbox/builddir'
...
ci-node-36 | [8/13] Generating doc/toolbox-rmi.1 with a custom command
ci-node-36 | [9/13] Generating doc/toolbox-run.1 with a custom command
ci-node-36 | [10/13] Generating doc/toolbox.conf.5 with a custom command
ci-node-36 | [11/13] Generating src/toolbox with a custom command
```