### PR TITLE
build: add dynamic linker option for riscv64

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -41,6 +41,8 @@ elif cpu_family == 'x86' and endian == 'little'
   dynamic_linker = '/lib/ld-linux.so.2'
 elif cpu_family == 'x86_64' and endian == 'little'
   dynamic_linker = '/lib64/ld-linux-x86-64.so.2'
+elif cpu_family == 'riscv64' and endian == 'little'
+  dynamic_linker = '/lib/ld-linux-riscv64-lp64d.so.1'
 else
   host_machine_description = cpu_family + ' (' + endian + ' endian)'
   error('Please specify dynamic linker for:', host_machine_description)


### PR DESCRIPTION
This commit add dynamic linker for riscv 64 architecture. Tested in Arch Linux rv64gc qemu user image.

###  Addtional notes:

The old go module `golang.org/x/sys` doesn't contains implementation for RISC-V. We need to replace the module with v0.2.0.

```bash
cd src
go mod edit -replace golang.org/x/sys=golang.org/x/sys@v0.2.0
go mod download golang.org/x/sys
```

I don't know if this upgrade will affect the program, so changes are not included in this PR.