### PR TITLE
cmd/create: Fix typo

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -474,7 +474,7 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 		return fmt.Errorf("failed to create container %s", container)
 	}
 
-	// The spinner must be stopped before showing the 'enter' hit below.
+	// The spinner must be stopped before showing the 'enter' hint below.
 	s.Stop()
 
 	if showCommandToEnter {


### PR DESCRIPTION
Fallout from e935ed893d5b72ac9f08987bc2c7ede9f7d506cc