### PR TITLE
Revert ".zuul: Run tests only for relevant files"

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,7 +3,6 @@
     name: unit-test
     description: Run Toolbox's unit tests declared in Meson
     timeout: 600
-    files: ['playbooks/*', 'profile.d/*', 'src/*', 'meson.build', 'meson_options.txt', 'meson_post_install.py', '.zuul.yaml']
     nodeset:
       nodes:
         - name: ci-node-36
@@ -15,7 +14,6 @@
     name: unit-test-migration-path-for-coreos-toolbox
     description: Run Toolbox's unit tests declared in Meson when built with -Dmigration_path_for_coreos_toolbox
     timeout: 600
-    files: ['playbooks/*', 'profile.d/*', 'src/*', 'meson.build', 'meson_options.txt', 'meson_post_install.py', '.zuul.yaml']
     nodeset:
       nodes:
         - name: ci-node-36
@@ -27,17 +25,6 @@
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 2700
-    files: &system_test_files [
-      'data/*',
-      'playbooks/*',
-      'profile.d/*',
-      'src/*',
-      'test/*',
-      'meson.build',
-      'meson_options.txt',
-      'meson_post_install.py',
-      '.zuul.yaml',
-    ]
     nodeset:
       nodes:
         - name: ci-node-rawhide
@@ -49,7 +36,6 @@
     name: system-test-fedora-36
     description: Run Toolbx's system tests in Fedora 36
     timeout: 1200
-    files: *system_test_files
     nodeset:
       nodes:
         - name: ci-node-36
@@ -61,7 +47,6 @@
     name: system-test-fedora-35
     description: Run Toolbox's system tests in Fedora 35
     timeout: 1200
-    files: *system_test_files
     nodeset:
       nodes:
         - name: ci-node-35


### PR DESCRIPTION
On a couple of occasions the relevant tests didn't get triggered because some files weren't listed [1], and on another a commit forgot to update the list of files.

The objective of the CI is to reduce stress for the maintainers, and make it easy for contributors to find out if their changes work or not. Missing tests don't help with that, and there's no need to optimize the tests like this unless there's a real problem to be solved.

[1] Commit deca452b273378e5
    Commit 5c27d730212312d6

[2] Commit b1743c492708826c

This reverts commit c28d902089467884a31de276ec9c8dbb0ef76fa8.