### PR TITLE
playbooks: Don't worry about runc(8)

### DIFF
--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -6,6 +6,7 @@
       - ShellCheck
       - bash-completion
       - bats
+      - fish
       - flatpak-session-helper
       - golang
       - golang-github-cpuguy83-md2man

--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -33,7 +33,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun runc fuse-overlayfs flatpak-session-helper
+  command: rpm -qa *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper
 
 - name: Show podman versions
   command: podman version


### PR DESCRIPTION
... because it was replaced by `crun(1)` as Podman's default OCI runtime
during the migration to cgroups v2 in Fedora 31 [1].  eg., on Fedora 36:
```
  # repoquery --whatrequires runc
  ...
  containerd-0:1.6.1-1.fc36.x86_64
  containerd-0:1.6.9-3.fc36.x86_64
  containers-common-4:1-53.fc36.noarch
  containers-common-extra-4:1-62.fc36.noarch
  moby-engine-0:20.10.12-3.fc36.x86_64
  moby-engine-0:20.10.20-1.fc36.x86_64
```

... and it doesn't get installed on Fedora 35 either:
```
  TASK [Check versions of crucial packages]
  ci-node-35 | glibc-gconv-extra-2.34-43.fc35.x86_64
  ci-node-35 | glibc-2.34-43.fc35.x86_64
  ci-node-35 | glibc-common-2.34-43.fc35.x86_64
  ci-node-35 | glibc-langpack-en-2.34-43.fc35.x86_64
  ci-node-35 | kernel-core-6.0.5-100.fc35.x86_64
  ci-node-35 | kernel-core-6.0.7-100.fc35.x86_64
  ci-node-35 | kernel-core-6.0.8-100.fc35.x86_64
  ci-node-35 | kernel-headers-6.0.5-100.fc35.x86_64
  ci-node-35 | glibc-headers-x86-2.34-43.fc35.noarch
  ci-node-35 | glibc-devel-2.34-43.fc35.x86_64
  ci-node-35 | kernel-srpm-macros-1.0-6.fc35.noarch
  ci-node-35 | containernetworking-plugins-1.1.0-1.fc35.x86_64
  ci-node-35 | container-selinux-2.189.0-1.fc35.noarch
  ci-node-35 | conmon-2.1.0-2.fc35.x86_64
  ci-node-35 | golang-1.16.15-3.fc35.x86_64
  ci-node-35 | crun-1.6-2.fc35.x86_64
  ci-node-35 | fuse-overlayfs-1.9-1.fc35.x86_64
  ci-node-35 | containers-common-1-45.fc35.noarch
  ci-node-35 | podman-3.4.7-2.fc35.x86_64
  ci-node-35 | flatpak-session-helper-1.12.7-2.fc35.x86_64
  ci-node-35 | ok: Runtime: 0:00:00.139573
```

[1] https://fedoraproject.org/wiki/Changes/CGroupsV2