### PR TITLE
playbooks: Remove unnecessary parameter

### DIFF
--- a/.codespellexcludefile
+++ b/.codespellexcludefile
@@ -1,0 +1,1 @@
+		if strings.Contains(command.Name(), "complet") {

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ endif
 
 go = find_program('go')
 go_md2man = find_program('go-md2man')
+
+codespell = find_program('codespell', required: false)
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 
@@ -52,6 +54,24 @@ if tmpfilesdir == '' or not fs.exists('/run/.containerenv')
 endif
 
 toolbox_sh = files('toolbox')
+
+if codespell.found()
+  test(
+    'codespell',
+    codespell,
+    args: [
+      '--check-filenames',
+      '--check-hidden',
+      '--context', '3',
+      '--exclude-file', meson.project_source_root() / '.codespellexcludefile',
+      '--skip', meson.project_build_root(),
+      '--skip', meson.project_source_root() / '.git',
+      '--skip', meson.project_source_root() / 'test/system/libs/bats-assert',
+      '--skip', meson.project_source_root() / 'test/system/libs/bats-support',
+      meson.project_source_root(),
+    ],
+  )
+endif
 
 if shellcheck.found()
   test('shellcheck toolbox (deprecated)', shellcheck, args: [toolbox_sh])

--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -6,6 +6,7 @@
       - ShellCheck
       - bash-completion
       - bats
+      - codespell
       - fish
       - flatpak-session-helper
       - golang

--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -1,7 +1,6 @@
 - name: Install RPM packages
   become: yes
   package:
-    use: dnf
     name:
       - ShellCheck
       - bash-completion


### PR DESCRIPTION
The [documentation](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html) for Ansible's built-in 'package' module says this about the `use` parameter:
```
You should only use this field if the automatic selection is not
working for some reason.
```

