### PR TITLE
fix: bad variable substitution

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -26,8 +26,11 @@ if [ -f /run/ostree-booted ] \
    && [ "${ID}" = "fedora" ] \
    && { [ "${VARIANT_ID}" = "workstation" ] || [ "${VARIANT_ID}" = "silverblue" ] || [ "${VARIANT_ID}" = "kinoite" ]; }; then
     echo ""
-    # shellcheck disable=SC3059
-    echo "Welcome to Fedora ${VARIANT:-$VARIANT_ID}. This terminal is running on the"
+    _pretty='Fedora'
+    if [ -z "${VARIANT}" ] || [ -z "${VARIANT_ID}" ]; then
+      _pretty="${pretty} ${VARIANT_ID:-$VARIANT}"
+    fi
+    echo "Welcome to ${_pretty}. This terminal is running on the"
     echo "host system. You may want to try out the Toolbox for a directly"
     echo "mutable environment that allows package installation with DNF."
     echo ""

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -27,7 +27,7 @@ if [ -f /run/ostree-booted ] \
    && { [ "${VARIANT_ID}" = "workstation" ] || [ "${VARIANT_ID}" = "silverblue" ] || [ "${VARIANT_ID}" = "kinoite" ]; }; then
     echo ""
     # shellcheck disable=SC3059
-    echo "Welcome to Fedora ${VARIANT_ID^}. This terminal is running on the"
+    echo "Welcome to Fedora ${VARIANT:-$VARIANT_ID}. This terminal is running on the"
     echo "host system. You may want to try out the Toolbox for a directly"
     echo "mutable environment that allows package installation with DNF."
     echo ""


### PR DESCRIPTION
Fixes https://github.com/containers/toolbox/issues/1017

Using suggestion https://github.com/containers/toolbox/issues/1017#issuecomment-1095252885:

> I suppose a nicer fix would be to simply use VARIANT, which is already a pretty name, or worst case use sed to perform the uppercasing, which will work in POSIX, bash, and zsh.