### PR TITLE
profile.d: Avoid a TOCTOU race

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -11,9 +11,7 @@ toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 # shellcheck disable=2046
 # shellcheck disable=SC1091
 eval $(
-          if [ -f /etc/os-release ]; then
-              . /etc/os-release
-          else
+          if ! . /etc/os-release 2>/dev/null; then
               . /usr/lib/os-release
           fi
 


### PR DESCRIPTION
The availability of `/etc/os-release` might change between the check and the actual attempt to source it.  Due to this inherent race in file I/O, it's better to try to source it first, and then handle the error.

The standard error stream from the attempt to source /etc/os-release is silenced because it's not mandatory for the file to be present [1].  Otherwise, users would see a spurious error message in the very valid scenario that there's no `/etc/os-release`:
```
bash: /etc/os-release: No such file or directory
```

A valid `os-release(5)` file is not expected to have any commands in it.  Hence, there's no chance of a non-zero exit code from the last command inside `/etc/os-release` getting forwarded as the exit code of the attempt to source it [2], and getting misinterpreted as the file being absent.  So, it's more important to avoid the spurious error message.

Note that this change isn't about defending against malicious actors trying to exploit this race for nefarious purposes.  The `/etc/os-release` file is owned by `root`.  If the `root` user is compromised on the host operating system then it's going to have such far-reaching consequences that the problem of an invalid `/etc/os-release` is nothing in comparison.  It's assumed that the root user knows what they are doing and has put in place a sane `/etc/os-release`.

This change is about avoiding the race condition during valid changes to `/etc/os-release`.  eg., a system administrator or a developer or a live update to the operating system changing the file.

Fallout from 34505fd4757721fdc26c8a5e82c6bdc27c1cda2e

[1] https://www.freedesktop.org/software/systemd/man/os-release.html

[2] https://www.gnu.org/software/bash/manual/html_node/Bourne-Shell-Builtins.html