### PR TITLE
profile.d: Don't leak ID and VARIANT_ID into the shell

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -96,6 +96,8 @@ if [ -f /run/.containerenv ] \
     fi
 fi
 
+unset ID
+unset VARIANT_ID
 unset toolbox_config
 unset host_welcome_stub
 unset toolbox_welcome_stub

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -8,8 +8,8 @@ toolbox_config="$HOME/.config/toolbox"
 host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 
-# shellcheck disable=2046
 # shellcheck disable=SC1091
+# shellcheck disable=SC2046
 eval $(
           if [ -f /etc/os-release ]; then
               . /etc/os-release


### PR DESCRIPTION
Commit dcdfa3a1f5a34213 ensured that the rest of the `os-release(5)` fields don't get injected into the shell as environment variables, but missed ID and VARIANT_ID.

Fallout from c6e37cdef37e2276207b34a42919f1e0ac4a04dc