### PR TITLE
profile.d: Restore compatibility with Z shell

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -18,6 +18,7 @@ eval $(
           fi
 
           echo ID="$ID"
+          echo PRETTY_NAME="\"$PRETTY_NAME\""
           echo VARIANT_ID="$VARIANT_ID"
       )
 
@@ -26,10 +27,11 @@ if [ -f /run/ostree-booted ] \
    && [ "${ID}" = "fedora" ] \
    && { [ "${VARIANT_ID}" = "workstation" ] || [ "${VARIANT_ID}" = "silverblue" ] || [ "${VARIANT_ID}" = "kinoite" ]; }; then
     echo ""
-    # shellcheck disable=SC3059
-    echo "Welcome to Fedora ${VARIANT_ID^}. This terminal is running on the"
-    echo "host system. You may want to try out the Toolbox for a directly"
-    echo "mutable environment that allows package installation with DNF."
+    echo "Welcome to ${PRETTY_NAME:-Linux}."
+    echo ""
+    echo "This terminal is running on the host system. You may want to try"
+    echo "out the Toolbox for a directly mutable environment that allows "
+    echo "package installation with DNF."
     echo ""
     printf "For more information, see the "
     # shellcheck disable=SC1003
@@ -97,6 +99,7 @@ if [ -f /run/.containerenv ] \
 fi
 
 unset ID
+unset PRETTY_NAME
 unset VARIANT_ID
 unset toolbox_config
 unset host_welcome_stub


### PR DESCRIPTION
Otherwise, every zsh instance on Fedora Kinoite and Silverblue was running into:
```
/etc/profile.d/toolbox.sh:30: bad substitution
```

... because case modification with `"${VARIANT_ID^}"` is undefined in POSIX shell [1], and doesn't work with Z shell.

Fedora Silverblue got its own `PRETTY_NAME` (and `VARIANT` and `VARIANT_ID`) starting from Fedora 32 [2].  Therefore, it's better to use `PRETTY_NAME` and let the downstream distributor of the host operating system decide how it should be presented to the user, instead of coming up with a custom string.   eg., `PRETTY_NAME` isn't the same as `"Fedora $VARIANT"` on Fedora Silverblue.

One nice side-effect of this is that while `VARIANT` and `VARIANT_ID` are optional fields, `PRETTY_NAME` has a well-defined fallback value of 'Linux' [3].  This makes this a little less specific to Fedora Kinoite and Silverblue.

The rest of the welcome text was reformatted to prevent it from getting too wide depending on the contents of `PRETTY_NAME`.

Fallout from 3641a0032fff04ed50874de52416a75d1ab63597

[1] https://www.shellcheck.net/wiki/SC3059

[2] https://pagure.io/workstation-ostree-config/c/c18ef957d11862d32f362722931dbfdf1f5beb0d

[3] https://www.freedesktop.org/software/systemd/man/os-release.html

https://github.com/containers/toolbox/issues/1017