### PR TITLE
README.md: Clarify that Toolbx isn't a security mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,3 @@ database, etc..
 See our guides on
 [installing & getting started](https://containertoolbx.org/install/) with
 Toolbox and [Linux distro support](https://containertoolbx.org/distros/).
-

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@
 [![Arch Linux package](https://img.shields.io/archlinux/v/community/x86_64/toolbox)](https://www.archlinux.org/packages/community/x86_64/toolbox/)
 [![Fedora package](https://img.shields.io/fedora/v/toolbox/rawhide)](https://src.fedoraproject.org/rpms/toolbox/)
 
-[Toolbox](https://containertoolbx.org/) is a tool for Linux operating systems,
-which allows the use of containerized command line environments. It is built
-on top of [Podman](https://podman.io/) and other standard container
-technologies from [OCI](https://opencontainers.org/).
+[Toolbox](https://containertoolbx.org/) is a tool for Linux, which allows the
+use of interactive command line environments for development and
+troubleshooting the host operating system, without having to install software
+on the host. It is built on top of [Podman](https://podman.io/) and other
+standard container technologies from [OCI](https://opencontainers.org/).
+
+Toolbox environments have seamless access to the user's home directory,
+the Wayland and X11 sockets, networking (including Avahi), removable devices
+(like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the
+udev database, etc..
 
 This is particularly useful on
 [OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
@@ -31,11 +37,12 @@ incrementally adopt containerization.
 
 The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
 image. On Fedora this is the `fedora-toolbox` image. This image is used to
-create a toolbox container that seamlessly integrates with the rest of the
-operating system by providing access to the user's home directory, the Wayland
-and X11 sockets, networking (including Avahi), removable devices (like USB
-sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the udev
-database, etc..
+create a toolbox container that offers the interactive command line
+environment.
+
+Note that Toolbox makes no promise about security beyond what's already
+available in the usual command line environment on the host that everybody is
+familiar with.
 
 
 ## Installation & Use

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ This is particularly useful on
 systems is to discourage installation of software on the host, and instead
 install software as (or in) containers — they mostly don't even have package
 managers like DNF or YUM. This makes it difficult to set up a development
-environment or install tools for debugging in the usual way.
+environment or troubleshoot the operating system in the usual way.
 
 Toolbox solves this problem by providing a fully mutable container within
-which one can install their favourite development and debugging tools, editors
-and SDKs. For example, it's possible to do `yum install ansible` without
-affecting the base operating system.
+which one can install their favourite development and troubleshooting tools,
+editors and SDKs. For example, it's possible to do `yum install ansible`
+without affecting the base operating system.
 
 However, this tool doesn't *require* using an OSTree based system. It works
 equally well on Fedora Workstation and Server, and that's a useful way to


### PR DESCRIPTION
Using the word *containerized* gives the false impression of heightened security.  As if it's a mechanism to run untrusted software in a sandboxed environment without access to the user's private data (such as `$HOME`), hardware peripherals (such as cameras and microphones), etc.. That's not what Toolbx is for.

Toolbx aims to offer an interactive command line environment for development and troubleshooting the host operating system, without having to install software on the host.  That's all.  It makes no promise about security beyond what's already available on the usual command line environment on the host that everybody is familiar with.

https://github.com/containers/toolbox/issues/1020