### PR TITLE
build: Enforce all the default 'go vet' checks on all Go  sources

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -72,4 +72,4 @@ endif
 
 test('go fmt', meson_go_fmt_program, args: [meson.current_source_dir()])
 test('go vet', go, args: ['vet', '-c', '3', './...'], workdir: meson.current_source_dir())
-test('go test', go, args: ['test', '-v', '-vet', 'off', './...'], workdir: meson.current_source_dir())
+test('go test', go, args: ['test', '-vet', 'off', './...'], workdir: meson.current_source_dir())

--- a/src/meson.build
+++ b/src/meson.build
@@ -71,4 +71,4 @@ if shellcheck.found()
 endif
 
 test('go fmt', meson_go_fmt_program, args: [meson.current_source_dir()])
-test('toolbox go unit tests', go, args: ['test', '-v', './...'], workdir: meson.current_source_dir())
+test('go test', go, args: ['test', '-v', './...'], workdir: meson.current_source_dir())

--- a/src/meson.build
+++ b/src/meson.build
@@ -71,4 +71,5 @@ if shellcheck.found()
 endif
 
 test('go fmt', meson_go_fmt_program, args: [meson.current_source_dir()])
-test('go test', go, args: ['test', '-v', './...'], workdir: meson.current_source_dir())
+test('go vet', go, args: ['vet', '-c', '3', './...'], workdir: meson.current_source_dir())
+test('go test', go, args: ['test', '-v', '-vet', 'off', './...'], workdir: meson.current_source_dir())


### PR DESCRIPTION
Currently, only a so-called high-confidence subset of the default checks in `go vet` are being run by `go test` [1].  Since `go vet` is part of the core Go tools, it's worth trying to use more of it.  After all, golangci-lint, which is currently being run through a GitHub Action, is running the default `go vet` checks as one of its linters [2].

It's good to have as much of the testing wrapped inside `meson test`, as possible, because it's easier to run locally and on other non-GitHub CI environments like those of downstream distributors.

[1] https://pkg.go.dev/cmd/go/internal/test

[2] https://golangci-lint.run/usage/linters/
    https://golangci-lint.run/usage/linters/#govet