### PR TITLE
cmd/list: Remove redundant initializations

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -142,7 +142,7 @@ func getContainers() ([]toolboxContainer, error) {
 
 	for _, container := range containers {
 		var c toolboxContainer
-		var isToolboxContainer bool = false
+		var isToolboxContainer bool
 
 		containerJSON, err := json.Marshal(container)
 		if err != nil {
@@ -205,7 +205,7 @@ func getImages() ([]toolboxImage, error) {
 
 	for _, image := range images {
 		var i toolboxImage
-		var isToolboxImage bool = false
+		var isToolboxImage bool
 
 		imageJSON, err := json.Marshal(image)
 		if err != nil {


### PR DESCRIPTION
Fallout from 2369da5d31830e5cd3e1a13857a686365875ae61