### PR TITLE
test/system: Remove stray (possibly for debugging) 'podman images'

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -267,8 +267,6 @@ function pull_distro_image() {
     echo "Failed to load image ${image} from cache ${IMAGE_CACHE_DIR}/${image_archive}"
     assert_success
   fi
-
-  $PODMAN images
 }
 
 


### PR DESCRIPTION
This was making it difficult to read the Bats assertions on test failures, by polluting it with unexpected and irrelevant output from `podman images`.  For example [1]:
```
  not ok 39 list: Images with and without names in 12332ms
  # (from function `assert' in file test/system/libs/bats-assert/src/assert.bash, line 46,
  #  in test file test/system/102-list.bats, line 126)
  #   `assert [ ${#stderr_lines[@]} -eq 0 ]' failed
  # REPOSITORY                                 TAG         IMAGE ID      CREATED      SIZE
  # registry.fedoraproject.org/fedora-toolbox  35          862705390e8b  4 weeks ago  332 MB
  # REPOSITORY                                 TAG         IMAGE ID      CREATED       SIZE
  # registry.fedoraproject.org/fedora-toolbox  35          862705390e8b  4 weeks ago   332 MB
  # registry.fedoraproject.org/fedora-toolbox  34          70cbe2ce60ca  7 months ago  354 MB
  #
  # -- assertion failed --
  # expression : [ 1 -eq 0 ]
  # --
  #
```

Fallout from 7973181136494a4ba147808c9ad51ace9aa4305f

[1] https://github.com/containers/toolbox/pull/1192