### PR TITLE
.zuul: Use the latest version of the tools for static analysis

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -18,22 +18,22 @@
 - job:
     name: unit-test
     description: Run Toolbox's unit tests declared in Meson
-    timeout: 600
+    timeout: 1200
     nodeset:
       nodes:
-        - name: ci-node-36
-          label: cloud-fedora-36
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
     pre-run: playbooks/setup-env.yaml
     run: playbooks/unit-test.yaml
 
 - job:
     name: unit-test-migration-path-for-coreos-toolbox
     description: Run Toolbox's unit tests declared in Meson when built with -Dmigration_path_for_coreos_toolbox
-    timeout: 600
+    timeout: 1200
     nodeset:
       nodes:
-        - name: ci-node-36
-          label: cloud-fedora-36
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
     pre-run: playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
     run: playbooks/unit-test.yaml
 


### PR DESCRIPTION
The 'unit tests' are no longer just unit tests.  They also run a bunch of static analysis tools like ShellCheck, codespell, gofmt and 'go vet'.  Since newer versions of these tools are generally better at catching problems in the codebase, it will be better to run the 'unit tests' on Fedora Rawhide with the latest versions than older stable Fedoras.

The timeout for the 'unit tests' need to be increased because Fedora Rawhide is slower is than stable Fedoras.