### PR TITLE
playbooks/dependencies: Avoid stale DNF caches on high-churn  RPM repos

### DIFF
--- a/playbooks/dependencies.yaml
+++ b/playbooks/dependencies.yaml
@@ -17,6 +17,7 @@
 - name: Install RPM packages
   become: yes
   package:
+    update_cache: "{{ true if zuul.attempts > 1 else false }}"
     name:
       - ShellCheck
       - bash-completion


### PR DESCRIPTION
Sometimes the RPM dependencies can't be installed because the DNF cache refers to old packages that have been replaced by newer builds on the RPM repositories [1].  This often happens on Fedora Rawhide because it sees a lot more churn than stable Fedoras.

Currently, one has to keep restarting the tests manually by typing 'recheck' until the DNF caches eventually get updated.  This is both very inefficient because it requires manual intervention; and wasteful because it can take several attempts and it doesn't just run the failing Ansible job, but all the other ones too.

It will be good to force the DNF cache to be updated [2] when an Ansible job is being attempted more than once [3].

[1] https://github.com/containers/toolbox/pull/1171
    https://github.com/containers/toolbox/pull/1200

[2] https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#parameter-update_cache

[3] https://zuul-ci.org/docs/zuul/latest/job-content.html#var-zuul.attempts