### PR TITLE
.zuul: Use the latest version of the tools for static analysis

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -18,11 +18,11 @@
 - job:
     name: unit-test
     description: Run Toolbox's unit tests declared in Meson
-    timeout: 600
+    timeout: 1800
     nodeset:
       nodes:
-        - name: ci-node-36
-          label: cloud-fedora-36
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
     pre-run: playbooks/setup-env.yaml
     run: playbooks/unit-test.yaml
 

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -43,7 +43,7 @@
     timeout: 3600
     nodeset:
       nodes:
-        - name: ci-node-rawhide
+        - name: fedora-rawhide
           label: cloud-fedora-rawhide
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
@@ -54,7 +54,7 @@
     timeout: 1200
     nodeset:
       nodes:
-        - name: ci-node-36
+        - name: fedora-36
           label: cloud-fedora-36
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
@@ -65,7 +65,7 @@
     timeout: 1200
     nodeset:
       nodes:
-        - name: ci-node-35
+        - name: fedora-35
           label: cloud-fedora-35
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml


### PR DESCRIPTION
The 'unit tests' are no longer just unit tests.  They also run a bunch of static analysis tools like ShellCheck, codespell, gofmt and 'go vet'. Since newer versions of these tools are generally better at catching problems in the codebase, it will be better to run the 'unit tests' on Fedora Rawhide with the latest versions than older stable Fedoras.

The timeout for the 'unit tests' need to be increased because Fedora Rawhide is slower than stable Fedoras.  Currently, the timeout for the 'unit tests' running on Fedora 36 is 10 minutes.  Increasing it to 20 minutes when running on Fedora Rawhide wasn't enough, so maybe 30 will be sufficient.

Note that this is only feasible because the Fedora Rawhide builds are now more robust against stale DNF caches [1].  Otherwise, it wouldn't have been wise to use Fedora Rawhide to test anything which isn't also being tested elsewhere, because the Fedora Rawhide builds might have stayed broken for extended periods of time due to reasons completely unrelated to Toolbx.

[1] Commit 995c6d175ec5f790
    https://github.com/containers/toolbox/pull/1201