### PR TITLE
doc: Fix the titles of the manuals

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -1,4 +1,4 @@
-% toolbox-create(1)
+% toolbox-create 1
 
 ## NAME
 toolbox\-create - Create a new toolbox container

--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -1,4 +1,4 @@
-% toolbox-enter(1)
+% toolbox-enter 1
 
 ## NAME
 toolbox\-enter - Enter a toolbox container for interactive use

--- a/doc/toolbox-help.1.md
+++ b/doc/toolbox-help.1.md
@@ -1,4 +1,4 @@
-% toolbox-help(1)
+% toolbox-help 1
 
 ## NAME
 toolbox\-help - Display help information about Toolbox

--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -1,4 +1,4 @@
-% toolbox-init-container(1)
+% toolbox-init-container 1
 
 ## NAME
 toolbox\-init\-container - Initialize a running container

--- a/doc/toolbox-list.1.md
+++ b/doc/toolbox-list.1.md
@@ -1,4 +1,4 @@
-% toolbox-list(1)
+% toolbox-list 1
 
 ## NAME
 toolbox\-list - List existing toolbox containers and images

--- a/doc/toolbox-rm.1.md
+++ b/doc/toolbox-rm.1.md
@@ -1,4 +1,4 @@
-% toolbox-rm(1)
+% toolbox-rm 1
 
 ## NAME
 toolbox\-rm - Remove one or more toolbox containers

--- a/doc/toolbox-rmi.1.md
+++ b/doc/toolbox-rmi.1.md
@@ -1,4 +1,4 @@
-% toolbox-rmi(1)
+% toolbox-rmi 1
 
 ## NAME
 toolbox\-rmi - Remove one or more toolbox images

--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -1,4 +1,4 @@
-% toolbox-run(1)
+% toolbox-run 1
 
 ## NAME
 toolbox\-run - Run a command in an existing toolbox container

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -1,4 +1,4 @@
-% toolbox(1)
+% toolbox 1
 
 ## NAME
 toolbox - Tool for containerized command line environments on Linux

--- a/doc/toolbox.conf.5.md
+++ b/doc/toolbox.conf.5.md
@@ -1,4 +1,4 @@
-% toolbox.conf(5)
+% toolbox.conf 5
 
 ## NAME
 toolbox.conf - Toolbox configuration file

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -42,7 +42,8 @@ setup() {
   run $TOOLBOX help
 
   assert_success
-  assert_line --index 0 --partial "toolbox(1)()"
+  assert_line --index 0 --partial "toolbox(1)"
+  assert_line --index 0 --partial "General Commands Manual"
 }
 
 @test "help: Run command 'help' with no man present" {


### PR DESCRIPTION
Currently, the titles of the manuals are rendered with a pair of empty parentheses and no section title:
```
  toolbox(1)()                                              toolbox(1)()

  NAME
         toolbox - Tool for containerized command line environments...
```

However, they should be:
```
  toolbox(1)             General Commands Manual              toolbox(1)

  NAME
         toolbox - Tool for containerized command line environments...
```

This is because the troff generated by go-md2man from Markdown has a faulty invocation of the `.TH` macro [1]:
```
  .nh
  .TH toolbox(1)
  .SH NAME
  .PP
  toolbox - Tool for containerized command line environments on Linux
```

It should be:
```
  .nh
  .TH toolbox 1
  .SH NAME
  .PP
  toolbox - Tool for containerized command line environments on Linux
```

Original patch from Andrew Denton for Podman [2].

[1] https://www.gnu.org/software/groff/manual/groff.html

[2] Podman commit 63c779a857b55b00
    https://github.com/containers/podman/pull/15621