### PR TITLE
.zuul: Try to prevent the CI from timing out on stable Fedoras

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,7 +51,7 @@
 - job:
     name: system-test-fedora-36
     description: Run Toolbx's system tests in Fedora 36
-    timeout: 1200
+    timeout: 2400
     nodeset:
       nodes:
         - name: fedora-36
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-35
     description: Run Toolbox's system tests in Fedora 35
-    timeout: 1200
+    timeout: 2400
     nodeset:
       nodes:
         - name: fedora-35


### PR DESCRIPTION
Currently, the CI has been timing out on Fedora 36 nodes [1].  It's possible that this is due to the recent expansion of the test suite, which already required increasing the timeout for Fedora Rawhide [2].

[1] https://github.com/containers/toolbox/pull/1191
    https://github.com/containers/toolbox/pull/1208

[2] Commit e8f4e9c3671ee31c
    https://github.com/containers/toolbox/pull/1195