### PR TITLE
cmd/run, pkg/podman: Stop container once the last session finishes

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -284,6 +284,8 @@ func runCommand(container string,
 	}
 
 	logrus.Debugf("Container %s is initialized", container)
+
+	defer stopContainer(container)
 
 	if err := runCommandWithFallbacks(container,
 		preserveFDs,
@@ -650,4 +652,11 @@ func startContainer(container string) error {
 	}
 
 	return nil
+}
+
+func stopContainer(container string) {
+	logrus.Debugf("Stopping container %s", container)
+	if err := podman.Stop(container); err != nil {
+		logrus.Debugf("Stopping container %s failed: %s", container, err)
+	}
 }

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -408,6 +408,19 @@ func Start(container string, stderr io.Writer) error {
 	args := []string{"--log-level", logLevelString, "start", container}
 
 	if err := shell.Run("podman", nil, nil, stderr, args...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func Stop(container string) error {
+	logrus.Debugf("Stopping container %s", container)
+
+	logLevelString := LogLevel.String()
+	args := []string{"--log-level", logLevelString, "stop", container}
+
+	if err := shell.Run("podman", nil, nil, nil, args...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently, once a toolbox container gets started with 'podman start', as part of the 'toolbox enter' command, it doesn't stop unless the host is shut down or someone explicitly calls 'podman stop'. This becomes annoying if someone tries to remove the container because commands like 'podman rm' and such don't work without the '--force' flag, even if all active 'toolbox enter' and 'toolbox run' sessions have terminated.

A crude form of reference counting has been set up that depends on 'podman stop' failing as long there's any active 'podman exec' session left.  Every invocation of 'podman exec' in 'enter' and 'run' is followed by 'podman stop', so that the container gets stopped once the last session finishes.

While this approach looks very crude at first glance, it does have the advantage of being ridiculously simple to implement.  Thus, it's a lot more robust and easier to verify than setting up some custom reference counting or synchronization using other means like POSIX signals or file locks.

Based on the implementation in github.com/coreos/toolbox.

https://github.com/containers/toolbox/issues/114