### PR TITLE
Set hostname to toolbox.{host_hostname}

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -409,8 +409,13 @@ func createContainer(container, image, release string, showCommandToEnter bool) 
 
 	createArgs = append(createArgs, xdgRuntimeDirEnv...)
 
+    localHostname, err := os.Hostname()
+    if err != nil {
+        localHostname = "localhost"
+    }
+    toolboxHostname := "toolbox." + localHostname
 	createArgs = append(createArgs, []string{
-		"--hostname", "toolbox",
+		"--hostname", toolboxHostname,
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
 	}...)

--- a/toolbox
+++ b/toolbox
@@ -1078,7 +1078,7 @@ create()
     $podman_command create \
             --dns none \
             --env TOOLBOX_PATH="$TOOLBOX_PATH" \
-            --hostname toolbox \
+            --hostname "toolbox.${HOSTNAME:-localhost}" \
             --ipc host \
             --label "com.github.containers.toolbox=true" \
             --label "com.github.debarshiray.toolbox=true" \


### PR DESCRIPTION
Fixes https://github.com/containers/toolbox/issues/1059 when running X11 apps under kwin/Plasma desktop on Fedora Kinoite 37.

The random freezes experienced in #1059 are caused by DNS lookups of the unqualified host name 'toolbox' that the container uses by default, at least on my machine. Distrobox (https://github.com/89luca89/distrobox) uses the same style of container host name as this patch and has never had any issues for me under KDE.

An alternative solution which does not modify the host name is to explicitly add 'toolbox' to the hosts file or DNS, but it is more user friendly to have something that just works without any changes to the host configuration.