### PR TITLE
playbooks: Require GCC and show its version

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -4,6 +4,7 @@
     name:
       - bash-completion
       - flatpak-session-helper
+      - gcc
       - golang
       - httpd-tools
       - meson
@@ -50,7 +51,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper
 
 - name: Show podman versions
   command: podman version

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -25,6 +25,7 @@
       - codespell
       - fish
       - flatpak-session-helper
+      - gcc
       - golang
       - golang-github-cpuguy83-md2man
       - httpd-tools
@@ -50,7 +51,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper
 
 - name: Show podman versions
   command: podman version


### PR DESCRIPTION
Building Toolbx requires a C compiler [1], which defaults to GCC on Fedora and CentOS Stream.  It's good to explicitly require it, so that it doesn't go missing from the build.

Showing the version of the C compiler is a big help when debugging weird build problems involving the toolchain.  A following commit will use CGO to link to libsubid.so, which will only increase the relevance of the C compiler.

[1] Commit c8aaed52c547e24e
    https://github.com/containers/toolbox/pull/923