### PR TITLE
Fix spelling mistakes

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -44,7 +44,7 @@
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Setup Git submodules
+- name: Set up Git submodules
   shell: |
     git submodule init
     git submodule update

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -44,7 +44,7 @@
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Setup Git submodules
+- name: Set up Git submodules
   shell: |
     git submodule init
     git submodule update

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -319,7 +319,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	uidString := strconv.Itoa(initContainerFlags.uid)
 	targetUser, err := user.LookupId(uidString)
 	if err != nil {
-		return fmt.Errorf("failed to lookup user ID %s: %w", uidString, err)
+		return fmt.Errorf("failed to look up user ID %s: %w", uidString, err)
 	}
 
 	toolboxRuntimeDirectory, err := utils.GetRuntimeDirectory(targetUser)

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -219,7 +219,7 @@ func showManual(manual string) error {
 			return nil
 		}
 
-		return errors.New("failed to lookup man(1)")
+		return errors.New("failed to look up man(1)")
 	}
 
 	manualArgs := []string{"man", manual}

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -17,7 +17,7 @@
 
 load 'libs/helpers'
 
-@test "test suite: Setup" {
+@test "test suite: Set up" {
     local os_release="$(find_os_release)"
     local system_id="$(get_system_id)"
     local system_version="$(get_system_version)"

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -47,7 +47,7 @@ function _setup_environment() {
 
 function _setup_containers_storage() {
   mkdir -p ${TEMP_STORAGE_DIR}
-  # Setup a storage config file for PODMAN
+  # Set up a storage config file for PODMAN
   echo -e "[storage]\n  driver = \"overlay\"\n  rootless_storage_path = \"${ROOTLESS_PODMAN_STORE_DIR}\"\n  runroot = \"${ROOTLESS_PODMAN_RUNROOT_DIR}\"\n" > ${PODMAN_STORE_CONFIG_FILE}
   export CONTAINERS_STORAGE_CONF=${PODMAN_STORE_CONFIG_FILE}
 }
@@ -513,7 +513,7 @@ function get_system_version() {
 }
 
 
-# Setup the XDG_RUNTIME_DIR variable if not set
+# Set up the XDG_RUNTIME_DIR variable if not set
 function check_xdg_runtime_dir() {
   if [[ -z "${XDG_RUNTIME_DIR}" ]]; then
     export XDG_RUNTIME_DIR="/run/user/${UID}"


### PR DESCRIPTION
The noun is 'setup' and the verb is 'set up'.  Similarly 'lookup' and 'look up'.

Original patch from Erik Sjölund for Podman [1,2].

[1] Podman commit aa4279ae151fa9df
    https://github.com/containers/podman/commit/aa4279ae151fa9df
    https://github.com/containers/podman/pull/14658

[2] Podman commit 2827140907255ed0
    https://github.com/containers/podman/commit/2827140907255ed0
    https://github.com/containers/podman/pull/14659