### PR TITLE
cmd/run: Remove unused code

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -546,8 +546,6 @@ func getEntryPointAndPID(container string) (string, int, error) {
 	switch entryPointPID := entryPointPID.(type) {
 	case float64:
 		entryPointPIDInt = int(entryPointPID)
-	case int:
-		entryPointPIDInt = entryPointPID
 	default:
 		return "", 0, fmt.Errorf("failed to inspect entry point PID of container %s", container)
 	}


### PR DESCRIPTION
Go's encoding/json package parses all JSON numbers as float64 [1].  This oddity was noticed when this code was first written [2], and was later confirmed.

[1] https://pkg.go.dev/encoding/json#Unmarshal

[2] Commit cf5c58ab00223cee
    https://github.com/containers/podman/issues/6105