### PR TITLE
images: Ensure that the desired manuals are indeed present

### DIFF
--- a/images/fedora/f36/Containerfile
+++ b/images/fedora/f36/Containerfile
@@ -26,4 +26,18 @@ COPY extra-packages /
 RUN dnf -y install $(<extra-packages)
 RUN rm /extra-packages
 
+COPY ensure-files /
+RUN ret_val=0; \
+  while read file; do \
+    if ! compgen -G "$file" >/dev/null; then \
+      echo "$file: No such file or directory" >&2; \
+      ret_val=1; \
+      break; \
+    fi; \
+  done <ensure-files; \
+  if [ "$ret_val" -ne 0 ]; then \
+    false; \
+  fi
+RUN rm /ensure-files
+
 RUN dnf clean all

--- a/images/fedora/f36/Containerfile
+++ b/images/fedora/f36/Containerfile
@@ -14,6 +14,7 @@ COPY README.md /
 RUN rm /etc/rpm/macros.image-language-conf
 RUN sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
 
+RUN dnf -y upgrade
 RUN dnf -y swap coreutils-single coreutils-full
 RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks
 

--- a/images/fedora/f36/ensure-files
+++ b/images/fedora/f36/ensure-files
@@ -2,6 +2,10 @@
 /usr/share/man/man1/cd.1*
 /usr/share/man/man1/export.1*
 
+/usr/share/man/man1/cat.1*
+/usr/share/man/man1/cp.1*
+/usr/share/man/man1/ls.1*
+
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*

--- a/images/fedora/f36/ensure-files
+++ b/images/fedora/f36/ensure-files
@@ -1,0 +1,7 @@
+/usr/share/man/man1/bash.1*
+/usr/share/man/man1/cd.1*
+/usr/share/man/man1/export.1*
+
+/usr/share/man/fr/man8/rpm.8*
+/usr/share/man/ja/man8/rpm.8*
+/usr/share/man/man8/rpm.8*

--- a/images/fedora/f36/missing-docs
+++ b/images/fedora/f36/missing-docs
@@ -1,5 +1,6 @@
 acl
 bash
+coreutils-common
 curl
 findutils
 gawk

--- a/images/fedora/f37/Containerfile
+++ b/images/fedora/f37/Containerfile
@@ -26,4 +26,18 @@ COPY extra-packages /
 RUN dnf -y install $(<extra-packages)
 RUN rm /extra-packages
 
+COPY ensure-files /
+RUN ret_val=0; \
+  while read file; do \
+    if ! compgen -G "$file" >/dev/null; then \
+      echo "$file: No such file or directory" >&2; \
+      ret_val=1; \
+      break; \
+    fi; \
+  done <ensure-files; \
+  if [ "$ret_val" -ne 0 ]; then \
+    false; \
+  fi
+RUN rm /ensure-files
+
 RUN dnf clean all

--- a/images/fedora/f37/Containerfile
+++ b/images/fedora/f37/Containerfile
@@ -14,6 +14,7 @@ COPY README.md /
 RUN rm /etc/rpm/macros.image-language-conf
 RUN sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
 
+RUN dnf -y upgrade
 RUN dnf -y swap coreutils-single coreutils-full
 RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks
 

--- a/images/fedora/f37/ensure-files
+++ b/images/fedora/f37/ensure-files
@@ -2,6 +2,10 @@
 /usr/share/man/man1/cd.1*
 /usr/share/man/man1/export.1*
 
+/usr/share/man/man1/cat.1*
+/usr/share/man/man1/cp.1*
+/usr/share/man/man1/ls.1*
+
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*

--- a/images/fedora/f37/ensure-files
+++ b/images/fedora/f37/ensure-files
@@ -1,0 +1,7 @@
+/usr/share/man/man1/bash.1*
+/usr/share/man/man1/cd.1*
+/usr/share/man/man1/export.1*
+
+/usr/share/man/fr/man8/rpm.8*
+/usr/share/man/ja/man8/rpm.8*
+/usr/share/man/man8/rpm.8*

--- a/images/fedora/f37/missing-docs
+++ b/images/fedora/f37/missing-docs
@@ -1,5 +1,6 @@
 acl
 bash
+coreutils-common
 curl
 findutils
 gawk

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -26,4 +26,18 @@ COPY extra-packages /
 RUN dnf -y install $(<extra-packages)
 RUN rm /extra-packages
 
+COPY ensure-files /
+RUN ret_val=0; \
+  while read file; do \
+    if ! compgen -G "$file" >/dev/null; then \
+      echo "$file: No such file or directory" >&2; \
+      ret_val=1; \
+      break; \
+    fi; \
+  done <ensure-files; \
+  if [ "$ret_val" -ne 0 ]; then \
+    false; \
+  fi
+RUN rm /ensure-files
+
 RUN dnf clean all

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -14,6 +14,7 @@ COPY README.md /
 RUN rm /etc/rpm/macros.image-language-conf
 RUN sed -i '/tsflags=nodocs/d' /etc/dnf/dnf.conf
 
+RUN dnf -y upgrade
 RUN dnf -y swap coreutils-single coreutils-full
 RUN dnf -y swap glibc-minimal-langpack glibc-all-langpacks
 

--- a/images/fedora/f38/ensure-files
+++ b/images/fedora/f38/ensure-files
@@ -2,6 +2,10 @@
 /usr/share/man/man1/cd.1*
 /usr/share/man/man1/export.1*
 
+/usr/share/man/man1/cat.1*
+/usr/share/man/man1/cp.1*
+/usr/share/man/man1/ls.1*
+
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*

--- a/images/fedora/f38/ensure-files
+++ b/images/fedora/f38/ensure-files
@@ -1,0 +1,7 @@
+/usr/share/man/man1/bash.1*
+/usr/share/man/man1/cd.1*
+/usr/share/man/man1/export.1*
+
+/usr/share/man/fr/man8/rpm.8*
+/usr/share/man/ja/man8/rpm.8*
+/usr/share/man/man8/rpm.8*

--- a/images/fedora/f38/missing-docs
+++ b/images/fedora/f38/missing-docs
@@ -1,5 +1,6 @@
 acl
 bash
+coreutils-common
 curl
 findutils
 gawk


### PR DESCRIPTION
... and add the manuals for `cat(1)`, `cp(1)`, `ls(1)`, etc. to the list.

Only the images for currently maintained Fedoras (ie., 36, 37 and 38) were updated.