### PR TITLE
images: Ensure that the kill(1), mount(8), etc. manuals are available

### DIFF
--- a/images/fedora/f36/ensure-files
+++ b/images/fedora/f36/ensure-files
@@ -9,3 +9,6 @@
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*
+
+/usr/share/man/man1/kill.1*
+/usr/share/man/man8/mount.8*

--- a/images/fedora/f36/missing-docs
+++ b/images/fedora/f36/missing-docs
@@ -16,3 +16,4 @@ sed
 sudo
 systemd
 tar
+util-linux-core

--- a/images/fedora/f37/ensure-files
+++ b/images/fedora/f37/ensure-files
@@ -9,3 +9,6 @@
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*
+
+/usr/share/man/man1/kill.1*
+/usr/share/man/man8/mount.8*

--- a/images/fedora/f37/missing-docs
+++ b/images/fedora/f37/missing-docs
@@ -16,3 +16,4 @@ sed
 sudo
 systemd
 tar
+util-linux-core

--- a/images/fedora/f38/ensure-files
+++ b/images/fedora/f38/ensure-files
@@ -9,3 +9,6 @@
 /usr/share/man/fr/man8/rpm.8*
 /usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*
+
+/usr/share/man/man1/kill.1*
+/usr/share/man/man8/mount.8*

--- a/images/fedora/f38/missing-docs
+++ b/images/fedora/f38/missing-docs
@@ -16,3 +16,4 @@ sed
 sudo
 systemd
 tar
+util-linux-core


### PR DESCRIPTION
Note that in the past, it was observed that the util-linux package was no longer part of the fedora base images starting from Fedora 35 [1], and indeed it wasn't [2].  However, later the util-linux-core subset was restored from Fedora 36 onwards [3].  Hence, the need to restore the util-linux-core documentation that was stripped out in the base image.

Only the images for currently maintained Fedoras (ie., 36, 37 and 38) were updated.

Original patch from Jens Petersen for Fedora [4].

[1] Commit df05e276b219aef4
    https://github.com/containers/toolbox/issues/929

[2] fedora-kickstarts commit 1f3645b72d46a0a7
    https://pagure.io/fedora-kickstarts/c/1f3645b72d46a0a7
    https://bugzilla.redhat.com/show_bug.cgi?id=1951111

[3] fedora-kickstarts commit 4477181faf75e105
    https://pagure.io/fedora-kickstarts/c/4477181faf75e105

[4] Fedora fedora-toolbox commit 805dc32c280b10f3
    https://src.fedoraproject.org/container/fedora-toolbox/c/805dc32c280b10f3