### PR TITLE
cmd/initContainer: Give access to /run/systemd/users from the host

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ var (
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},
 		{"/run/systemd/sessions", "/run/host/run/systemd/sessions", ""},
 		{"/run/systemd/system", "/run/host/run/systemd/system", ""},
+		{"/run/systemd/users", "/run/host/run/systemd/users", ""},
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
 		{"/run/udev/tags", "/run/host/run/udev/tags", ""},
 		{"/tmp", "/run/host/tmp", "rslave"},


### PR DESCRIPTION
Just like /run/systemd/sessions makes it possible to get the seat for a session ID, /run/systemd/users can make it possible to get the seat and the session ID for a user's UID.

The absence of /run/systemd/users inside Toolbx containers isn't currently causing problems for any use-case, but it seems very close to the sort of things that were necessary to run a non-nested display server from within a Toolbx container on a virtual terminal.  It's not impossible that in future some implementation details of the display server stack may make /run/systemd/users necessary.

https://github.com/containers/toolbox/issues/992