### PR TITLE
pkg/utils: Update fallback release to 37 for non-fedora hosts

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -52,7 +52,7 @@ const (
 	containerNamePrefixFallback = "fedora-toolbox"
 	distroFallback              = "fedora"
 	idTruncLength               = 12
-	releaseFallback             = "34"
+	releaseFallback             = "37"
 )
 
 const (


### PR DESCRIPTION
Fedora 34 reached End of Life on 7th June 2022:
https://docs.fedoraproject.org/en-US/releases/eol/