### PR TITLE
cmd/root: Don't use podman(1) when generating the completions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,12 +18,12 @@ subid_dep = cc.find_library('subid', has_headers: ['shadow/subid.h'])
 
 go = find_program('go')
 go_md2man = find_program('go-md2man')
-podman = find_program('podman')
 
 bats = find_program('bats', required: false)
 codespell = find_program('codespell', required: false)
 htpasswd = find_program('htpasswd', required: false)
 openssl = find_program('openssl', required: false)
+podman = find_program('podman', required: false)
 shellcheck = find_program('shellcheck', required: false)
 skopeo = find_program('skopeo', required: false)
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -166,7 +166,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 
 	logrus.Debugf("TOOLBOX_PATH is %s", toolboxPath)
 
-	if err := migrate(); err != nil {
+	if err := migrate(cmd, args); err != nil {
 		return err
 	}
 
@@ -211,10 +211,15 @@ func rootRun(cmd *cobra.Command, args []string) error {
 	return rootRunImpl(cmd, args)
 }
 
-func migrate() error {
+func migrate(cmd *cobra.Command, args []string) error {
 	logrus.Debug("Migrating to newer Podman")
 
 	if utils.IsInsideContainer() {
+		return nil
+	}
+
+	if cmdName, completionCmdName := cmd.Name(), completionCmd.Name(); cmdName == completionCmdName {
+		logrus.Debugf("Migration not needed: command %s doesn't need it", cmdName)
 		return nil
 	}
 


### PR DESCRIPTION
Ever since commit bafbbe81c9220cb3, the shell completions are generated while building Toolbx using the 'completion' command.  This involves running toolbox(1) itself, and hence invoking 'podman version' to decide if 'podman system migrate' is needed or not.

Unfortunately, some build environments, like Fedora's, are set up inside a chroot(2) or systemd-nspawn(1) or similar, where 'podman version' may not work because it does various things with namespaces(7) and clone(2) that can, under certain circumstances, encounter an EPERM.

Therefore, it's better to avoid using podman(1) when generating the shell completions, especially, since they are generated by Cobra itself and podman(1) is not involved at all.

Note that podman(1) is needed when the generated shell completions are actually used in interactive command line environments.  The shell completions invoke the hidden '__complete' command to get the results that are presented to the user, and, if needed, 'podman system migrate' will continue to be run as part of that.

This reverts commit f3e005d0142d7ec76d5ac8f0a2f331a52fd46011.

https://github.com/containers/podman/issues/17657