### PR TITLE
images: Don't leak NAME and VERSION into the Toolbx container

### DIFF
--- a/images/fedora/f36/Containerfile
+++ b/images/fedora/f36/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:36
 
-ENV NAME=fedora-toolbox VERSION=36
+ARG NAME=fedora-toolbox
+ARG VERSION=36
 LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \

--- a/images/fedora/f37/Containerfile
+++ b/images/fedora/f37/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:37
 
-ENV NAME=fedora-toolbox VERSION=37
+ARG NAME=fedora-toolbox
+ARG VERSION=37
 LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:38
 
-ENV NAME=fedora-toolbox VERSION=38
+ARG NAME=fedora-toolbox
+ARG VERSION=38
 LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \

--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -1,6 +1,7 @@
 FROM registry.fedoraproject.org/fedora:39
 
-ENV NAME=fedora-toolbox VERSION=39
+ARG NAME=fedora-toolbox
+ARG VERSION=39
 LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \


### PR DESCRIPTION
Note that there can be only one ARG per line.  Otherwise, the build may fail with some build systems.  eg., Fedora's [1], which uses Docker, not Podman.

Only the images for currently maintained Fedoras (ie., 36, 37, 38 & 39) were updated.

[1] https://koji.fedoraproject.org/koji/taskinfo?taskID=98150241

https://github.com/containers/toolbox/issues/188