### PR TITLE
cmd/root: Don't validate subordinate IDs when generating the completions

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -38,6 +38,17 @@
     run: playbooks/unit-test.yaml
 
 - job:
+    name: unit-test-restricted
+    description: Run Toolbox's unit tests declared in Meson in a restricted build environment
+    timeout: 1800
+    nodeset:
+      nodes:
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
+    pre-run: playbooks/setup-env-restricted.yaml
+    run: playbooks/unit-test.yaml
+
+- job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
     timeout: 3600
@@ -80,6 +91,7 @@
       jobs:
         - unit-test
         - unit-test-migration-path-for-coreos-toolbox
+        - unit-test-restricted
         - system-test-fedora-rawhide
         - system-test-fedora-37
         - system-test-fedora-36
@@ -87,6 +99,7 @@
       jobs:
         - unit-test
         - unit-test-migration-path-for-coreos-toolbox
+        - unit-test-restricted
         - system-test-fedora-rawhide
         - system-test-fedora-37
         - system-test-fedora-36

--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -1,0 +1,71 @@
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Ensure that subordinate group ID ranges are absent
+  become: yes
+  file:
+    path: /etc/subgid
+    state: absent
+
+- name: Ensure that subordinate user ID ranges are absent
+  become: yes
+  file:
+    path: /etc/subuid
+    state: absent
+
+- name: Install RPM packages
+  become: yes
+  package:
+    name:
+      - ShellCheck
+      - bash-completion
+      - codespell
+      - fish
+      - flatpak-session-helper
+      - gcc
+      - golang
+      - golang-github-cpuguy83-md2man
+      - meson
+      - ninja-build
+      - shadow-utils-subid-devel
+      - systemd
+      - udisks2
+    state: present
+    update_cache: "{{ true if zuul.attempts > 1 else false }}"
+
+- name: Ensure that podman(1) is absent
+  become: yes
+  package:
+    name:
+      - podman
+    state: absent
+    update_cache: "{{ true if zuul.attempts > 1 else false }}"
+
+- name: Download Go modules
+  shell: |
+    go mod download -x
+  args:
+    chdir: '{{ zuul.project.src_dir }}/src'
+
+- name: Set up Git submodules
+  shell: |
+    git submodule init
+    git submodule update
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+
+- name: Check versions of crucial packages
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang flatpak-session-helper

--- a/playbooks/setup-env-restricted.yaml
+++ b/playbooks/setup-env-restricted.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  tasks:
+    - include_tasks: dependencies-fedora-restricted.yaml
+
+    - name: Set up build directory
+      command: meson setup --fatal-meson-warnings builddir
+      args:
+        chdir: '{{ zuul.project.src_dir }}'

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -401,6 +401,11 @@ func validateSubIDRanges(cmd *cobra.Command, args []string, user *user.User) (bo
 		return true, nil
 	}
 
+	if cmdName, completionCmdName := cmd.Name(), completionCmd.Name(); cmdName == completionCmdName {
+		logrus.Debugf("Look-up not needed: command %s doesn't need them", cmdName)
+		return true, nil
+	}
+
 	if _, err := utils.ValidateSubIDRanges(user); err != nil {
 		logrus.Debugf("Looking for sub-GID and sub-UID ranges: %s", err)
 		return false, newSubIDError()


### PR DESCRIPTION
Ever since commit bafbbe81c9220cb3, the shell completions are generated
while building Toolbx using the 'completion' command.  This involves
running toolbox(1) itself, and hence validating the subordinate user and
group ID ranges.

Unfortunately, some build environments don't have subordinate ID ranges
set up.  Therefore, it's better to avoid validating them when generating
the shell completions, especially, since they are generated by Cobra
itself and subordinate ID ranges are not involved at all.

Note that subordinate ID ranges may be needed when the generated shell
completions are actually used in interactive command line environments.
The shell completions invoke the hidden '__complete' command to get the
results that are presented to the user, and, if needed, the subordinate
ID ranges will continue to be used by podman(1) as part of that.

https://github.com/containers/toolbox/issues/1246