### PR TITLE
cmd/create, cmd/run: Rely on podman >= 1.6.4 always being present

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -254,14 +254,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		devPtsMount = []string{"--mount", "type=devpts,destination=/dev/pts"}
 	}
 
-	logrus.Debug("Checking if 'podman create' supports '--ulimit host'")
-
-	var ulimitHost []string
-
-	if podman.CheckVersion("1.5.0") {
-		logrus.Debug("'podman create' supports '--ulimit host'")
-		ulimitHost = []string{"--ulimit", "host"}
-	}
+	ulimitHost := []string{"--ulimit", "host"}
 
 	var usernsArg string
 	if currentUser.Uid == "0" {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -604,24 +604,6 @@ func startContainer(container string) error {
 		return fmt.Errorf("failed to start container %s", container)
 	}
 
-	logrus.Debug("Checking if 'podman system migrate' supports '--new-runtime'")
-
-	if !podman.CheckVersion("1.6.2") {
-		var builder strings.Builder
-
-		fmt.Fprintf(&builder,
-			"container %s doesn't support cgroups v%d\n",
-			container,
-			cgroupsVersion)
-
-		fmt.Fprintf(&builder, "Update Podman to version 1.6.2 or newer.\n")
-
-		errMsg := builder.String()
-		return errors.New(errMsg)
-	}
-
-	logrus.Debug("'podman system migrate' supports '--new-runtime'")
-
 	ociRuntimeRequired := "runc"
 	if cgroupsVersion == 2 {
 		ociRuntimeRequired = "crun"


### PR DESCRIPTION
So far the minimum required Podman version was 1.4.0, based on what used to be available in RHEL 7.  These days, Podman 1.6.4 is old enough to be in RHEL 7.9.  Hence it's time to bump the baseline.