### PR TITLE
cmd/initContainer: Bind mount locations regardless of /run/host/etc

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -206,18 +206,6 @@ func initContainer(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		}
-
-		for _, mount := range initContainerMounts {
-			if err := mountBind(mount.containerPath, mount.source, mount.flags); err != nil {
-				return err
-			}
-		}
-
-		if utils.PathExists("/sys/fs/selinux") {
-			if err := mountBind("/sys/fs/selinux", "/usr/share/empty", ""); err != nil {
-				return err
-			}
-		}
 	}
 
 	if initContainerFlags.mediaLink {
@@ -233,6 +221,18 @@ func initContainer(cmd *cobra.Command, args []string) error {
 			if err := redirectPath("/mnt", "/var/mnt", true); err != nil {
 				return err
 			}
+		}
+	}
+
+	for _, mount := range initContainerMounts {
+		if err := mountBind(mount.containerPath, mount.source, mount.flags); err != nil {
+			return err
+		}
+	}
+
+	if utils.PathExists("/sys/fs/selinux") {
+		if err := mountBind("/sys/fs/selinux", "/usr/share/empty", ""); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
Bind mounting the locations at runtime doesn't really have anything to do with whether /run/host/etc is present inside the Toolbx container.

The only possible exception could have been /etc/machine-id, but it isn't, because the bind mount is only performed if the source at /run/host/etc/machine-id is present.

This is a historical mistake that has persisted for a long time, since, in practice, /run/host/etc will almost always exist inside the Toolbx container.  It's time to finally correct it.

Fallout from 9436bbece01d7aa4dc91b4013ed9f80d0b8d34f4