### PR TITLE
.github: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*    @HarryMichal @debarshiray


### PR DESCRIPTION
Toolbx was conceived to address the needs of Fedora Linux.  Even though it works on host operating systems outside the Fedora family, it hasn't treated them with the same importance as Fedora Linux and derivatives like Red Hat Enterprise Linux.  Subsequent commits will change that by adding first-class support for host operating systems beyond the Fedora universe.  eg., Arch Linux and Ubuntu.

The current Toolbx maintainers, Ondřej Míchal and myself, are Fedora developers and don't have the bandwidth to drive changes and track down bugs in OSes outside the Fedora family.  Therefore, maintenance of some parts of the code base will be delegated to contributors from those other OS communities.

This is a step in that direction by clearly specifying which part of the code base is maintained by whom.