### PR TITLE
initContainer: Use unix.Mount syscall instead of mount external command

### DIFF
--- a/.codespellexcludefile
+++ b/.codespellexcludefile
@@ -13,3 +13,4 @@
 		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
 		{"/var/lib/systemd/coredump", "/run/host/var/lib/systemd/coredump", "ro"},
 		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
+		"ro":            {false, unix.MS_RDONLY},


### PR DESCRIPTION
Use golang unix syscalls package to perform mount operations instead of invoking in a shell the mount command.
Performing this operation programmatically should provide more observability debugging the code. It also reduces dependencies on external commands that may change or break functionality between versions.