### PR TITLE
cmd/utils: Handle space-separated input when asking for confirmation

### DIFF
--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 – 2022 Red Hat Inc.
+ * Copyright © 2020 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -43,7 +44,12 @@ func askForConfirmation(prompt string) bool {
 
 		var response string
 
-		fmt.Scanf("%s", &response)
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Split(bufio.ScanLines)
+		if scanner.Scan() {
+			response = scanner.Text()
+		}
+
 		if response == "" {
 			response = "n"
 		} else {


### PR DESCRIPTION
fmt.Scanf [1] is fragile when it comes to space-separated input.  It stores successive space-separated values into successive arguments as determined by the format string.  This breaks with untrusted input that can have an unknown number of space-separated values.

Here are some examples:
```
  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]: no no not at all
  $ no not at all
  bash: no: command not found...

  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]: foo bar
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]: Download registry.fedoraproject.org/fedora-toolbox:39
    (294.8MB)? [y/N]:
```

Instead this is what should happen:
```
  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]: no no not at all
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]: foo bar
  Download registry.fedoraproject.org/fedora-toolbox:39 (294.8MB)?
    [y/N]:
```

Fallout from 936f22ff152c424ce89b1454a52f1901de59d328

[1] https://pkg.go.dev/fmt#Scanf