### PR TITLE
Offer built-in support for Ubuntu and ubuntu-toolbox image definitions

### DIFF
--- a/images/ubuntu/16.04/Containerfile
+++ b/images/ubuntu/16.04/Containerfile
@@ -1,0 +1,37 @@
+FROM docker.io/library/ubuntu:16.04
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="16.04" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Install ubuntu-minimal & ubuntu-standard
+# Ask resolvconf maintainer script not to touch resolve.conf file
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN apt-get update && \
+    echo "resolvconf resolvconf/linkify-resolvconf boolean false" | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Allow authentication with empty password, promptless
+RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam.d/common-auth
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty

--- a/images/ubuntu/16.04/extra-packages
+++ b/images/ubuntu/16.04/extra-packages
@@ -1,0 +1,8 @@
+curl
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh

--- a/images/ubuntu/18.04/Containerfile
+++ b/images/ubuntu/18.04/Containerfile
@@ -1,0 +1,37 @@
+FROM docker.io/library/ubuntu:18.04
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="18.04" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Restore documentation but do not upgrade all packages
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
+    apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Allow authentication with empty password, promptless
+RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam.d/common-auth
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty

--- a/images/ubuntu/18.04/extra-packages
+++ b/images/ubuntu/18.04/extra-packages
@@ -1,0 +1,8 @@
+curl
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh

--- a/images/ubuntu/20.04/Containerfile
+++ b/images/ubuntu/20.04/Containerfile
@@ -1,0 +1,41 @@
+FROM docker.io/library/ubuntu:20.04
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="20.04" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Restore documentation but do not upgrade all packages
+# Install ubuntu-minimal & ubuntu-standard
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
+    apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Allow authentication with empty password, promptless
+RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam.d/common-auth
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/

--- a/images/ubuntu/20.04/extra-packages
+++ b/images/ubuntu/20.04/extra-packages
@@ -1,0 +1,9 @@
+curl
+flatpak-xdg-utils
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh

--- a/images/ubuntu/22.04/Containerfile
+++ b/images/ubuntu/22.04/Containerfile
@@ -1,0 +1,38 @@
+FROM docker.io/library/ubuntu:22.04
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="22.04" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Restore documentation but do not upgrade all packages
+# Install ubuntu-minimal & ubuntu-standard
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
+    apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/

--- a/images/ubuntu/22.04/extra-packages
+++ b/images/ubuntu/22.04/extra-packages
@@ -1,0 +1,9 @@
+curl
+flatpak-xdg-utils
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh

--- a/images/ubuntu/22.10/Containerfile
+++ b/images/ubuntu/22.10/Containerfile
@@ -1,0 +1,38 @@
+FROM docker.io/library/ubuntu:22.10
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="22.10" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Restore documentation but do not upgrade all packages
+# Install ubuntu-minimal & ubuntu-standard
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
+    apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/

--- a/images/ubuntu/22.10/extra-packages
+++ b/images/ubuntu/22.10/extra-packages
@@ -1,0 +1,9 @@
+curl
+flatpak-xdg-utils
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -205,6 +205,121 @@ func TestParseRelease(t *testing.T) {
 			inputRelease: "2.-1",
 			errMsg:       "The release must be in the '<major>.<minor>' format.",
 		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.10",
+			output:       "4.10",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "5.04",
+			output:       "5.04",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20.04",
+			output:       "20.04",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20.10",
+			output:       "20.10",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20.04.0",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20.04.1",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "foo",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20foo",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "foo.bar",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "foo.bar.baz",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "3.10",
+			errMsg:       "The release year must be 4 or more.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "202.4",
+			errMsg:       "The release year cannot have more than two digits.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "202.04",
+			errMsg:       "The release year cannot have more than two digits.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "2020.4",
+			errMsg:       "The release year cannot have more than two digits.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "2020.04",
+			errMsg:       "The release year cannot have more than two digits.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "04.10",
+			errMsg:       "The release year cannot have a leading zero.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.bar",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.bar.baz",
+			errMsg:       "The release must be in the 'YY.MM' format.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.0",
+			errMsg:       "The release month must be between 01 and 12.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.00",
+			errMsg:       "The release month must be between 01 and 12.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "4.13",
+			errMsg:       "The release month must be between 01 and 12.",
+		},
+		{
+			inputDistro:  "ubuntu",
+			inputRelease: "20.4",
+			errMsg:       "The release month must have two digits.",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -28,6 +28,9 @@ load 'libs/helpers'
     # Cache all images that will be needed during the tests
     _pull_and_cache_distro_image fedora 34 || false
     _pull_and_cache_distro_image rhel 8.7 || false
+    _pull_and_cache_distro_image ubuntu 16.04 || false
+    _pull_and_cache_distro_image ubuntu 18.04 || false
+    _pull_and_cache_distro_image ubuntu 20.04 || false
     _pull_and_cache_distro_image busybox || false
     # If run on Fedora Rawhide, cache 2 extra images (previous Fedora versions)
     local rawhide_res="$(awk '/rawhide/' $os_release)"

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -112,6 +112,51 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.7"
 }
 
+@test "create: Ubuntu 16.04" {
+  pull_distro_image ubuntu 16.04
+
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 16.04
+
+  assert_success
+  assert_output --partial "Created container: ubuntu-toolbox-16.04"
+  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-16.04"
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-16.04"
+}
+
+@test "create: Ubuntu 18.04" {
+  pull_distro_image ubuntu 18.04
+
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 18.04
+
+  assert_success
+  assert_output --partial "Created container: ubuntu-toolbox-18.04"
+  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-18.04"
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-18.04"
+}
+
+@test "create: Ubuntu 20.04" {
+  pull_distro_image ubuntu 20.04
+
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20.04
+
+  assert_success
+  assert_output --partial "Created container: ubuntu-toolbox-20.04"
+  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-20.04"
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-20.04"
+}
+
 @test "create: Try an unsupported distribution" {
   local distro="foo"
 
@@ -329,6 +374,196 @@ teardown() {
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
   assert_line --index 1 "The release must be in the '<major>.<minor>' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 20')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 20.04.0')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20.04.0
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 20.04.1')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20.04.1
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release foo')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release foo
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 20foo')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20foo
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release foo.bar')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release foo.bar
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release foo.bar.baz')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release foo.bar.baz
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 3.10')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 3.10
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year must be 4 or more."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 202.4')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 202.4
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year cannot have more than two digits."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 202.04')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 202.04
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year cannot have more than two digits."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 2020.4')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 2020.4
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year cannot have more than two digits."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 2020.04')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 2020.04
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year cannot have more than two digits."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 04.10')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 04.10
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release year cannot have a leading zero."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 4.bar')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 4.bar
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 4.bar.baz')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 4.bar.baz
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be in the 'YY.MM' format."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 4.0')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 4.0
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release month must be between 01 and 12."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 4.00')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 4.00
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release month must be between 01 and 12."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 4.13')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 4.13
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release month must be between 01 and 12."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
+}
+
+@test "create: Try Ubuntu with an invalid release ('--release 20.4')" {
+  run $TOOLBOX --assumeyes create --distro ubuntu --release 20.4
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release month must have two digits."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#lines[@]} -eq 3 ]
 }

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -178,6 +178,96 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "list: Ubuntu 16.04 image" {
+  pull_distro_image ubuntu 16.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:16.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 16.04 image (using --images)" {
+  pull_distro_image ubuntu 16.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:16.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 18.04 image" {
+  pull_distro_image ubuntu 18.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:18.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 18.04 image (using --images)" {
+  pull_distro_image ubuntu 18.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:18.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 20.04 image" {
+  pull_distro_image ubuntu 20.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:20.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 20.04 image (using --images)" {
+  pull_distro_image ubuntu 20.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx-images/ubuntu-toolbox:20.04"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "list: An image without a name" {
   build_image_without_name >/dev/null
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -66,6 +66,36 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "run: Smoke test with Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  run --separate-stderr $TOOLBOX run --distro ubuntu --release 16.04 true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  run --separate-stderr $TOOLBOX run --distro ubuntu --release 18.04 true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  run --separate-stderr $TOOLBOX run --distro ubuntu --release 20.04 true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "run: Ensure that a login shell is used to invoke the command" {
   create_default_container
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -26,7 +26,8 @@ readonly SKOPEO=${SKOPEO:-$(command -v skopeo)}
 declare -Ag IMAGES=([busybox]="quay.io/toolbox_tests/busybox" \
                    [docker-reg]="quay.io/toolbox_tests/registry" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
-                   [rhel]="registry.access.redhat.com/ubi8/toolbox")
+                   [rhel]="registry.access.redhat.com/ubi8/toolbox" \
+                   [ubuntu]="quay.io/toolbx-images/ubuntu-toolbox")
 
 
 function cleanup_all() {


### PR DESCRIPTION
For the full discussion, see: https://github.com/containers/toolbox/pull/483

This is meant to land the first two patches from the [original](https://github.com/containers/toolbox/pull/483) pull request that:
* Allows using the `--distro` and `--release` options to create and enter Ubuntu containers
* Adds the ubuntu-toolbox image definitions

This doesn't include the details of publishing the images to `quay.io/toolbx-images`.  Follow the [original](https://github.com/containers/toolbox/pull/483) pull request for further updates on that.