### PR TITLE
.github/CODEOWNERS: Clarify the location of the data/gfx directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *    @HarryMichal @debarshiray
-data/gfx/*.gif    @jimmac
+/data/gfx/*.gif    @jimmac


### PR DESCRIPTION
... to be at the root of the repository.  Without the leading slash, the documentation suggests that it could be a data/gfx directory anywhere in the repository [1].

[1] https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Fallout from 3773ceb0c557b59415a92828839b477cbf35ca97