### PR TITLE
.github/CODEOWNERS: Clarify ownership of the images for Ubuntu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *    @HarryMichal @debarshiray
 /data/gfx/*.gif    @jimmac
+/images/ubuntu     @Jmennius


### PR DESCRIPTION
This reflects the value of the 'maintainer' LABELs of the images.

https://github.com/containers/toolbox/pull/483