### PR TITLE
.github/CODEOWNERS: Clarify ownership of the images for RHEL

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 *    @HarryMichal @debarshiray
 /data/gfx/*.gif    @jimmac
+/images/rhel       @debarshiray @olivergs


### PR DESCRIPTION
This partly reflects the value of the 'maintainer' LABELs of the current images.  Oliver is the original author, but he has lots of other duties these days, and wanted me to help him co-maintain the images.

Note that the toolbox image definitions for RHEL do need a maintainer who is a Red Hat employee.  Otherwise they won't be able to actually build and publish the images at registry.access.redhat.com.