### PR TITLE
Ubuntu image improvements

### DIFF
--- a/images/ubuntu/16.04/Containerfile
+++ b/images/ubuntu/16.04/Containerfile
@@ -35,3 +35,6 @@ RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam
 
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/18.04/Containerfile
+++ b/images/ubuntu/18.04/Containerfile
@@ -35,3 +35,6 @@ RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam
 
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/20.04/Containerfile
+++ b/images/ubuntu/20.04/Containerfile
@@ -40,3 +40,6 @@ RUN mkdir /usr/share/empty
 
 # Add flatpak-spawn to /usr/bin
 RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/20.04/Containerfile
+++ b/images/ubuntu/20.04/Containerfile
@@ -27,6 +27,7 @@ RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         ubuntu-minimal ubuntu-standard \
         libnss-myhostname \
+        flatpak-xdg-utils \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages

--- a/images/ubuntu/20.04/extra-packages
+++ b/images/ubuntu/20.04/extra-packages
@@ -1,5 +1,4 @@
 curl
-flatpak-xdg-utils
 git
 gnupg2
 keyutils

--- a/images/ubuntu/22.04/Containerfile
+++ b/images/ubuntu/22.04/Containerfile
@@ -27,6 +27,7 @@ RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         ubuntu-minimal ubuntu-standard \
         libnss-myhostname \
+        flatpak-xdg-utils \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages

--- a/images/ubuntu/22.04/Containerfile
+++ b/images/ubuntu/22.04/Containerfile
@@ -37,3 +37,6 @@ RUN mkdir /usr/share/empty
 
 # Add flatpak-spawn to /usr/bin
 RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/22.04/extra-packages
+++ b/images/ubuntu/22.04/extra-packages
@@ -1,5 +1,4 @@
 curl
-flatpak-xdg-utils
 git
 gnupg2
 keyutils

--- a/images/ubuntu/22.10/Containerfile
+++ b/images/ubuntu/22.10/Containerfile
@@ -27,6 +27,7 @@ RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         ubuntu-minimal ubuntu-standard \
         libnss-myhostname \
+        flatpak-xdg-utils \
         $(cat extra-packages | xargs) && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages

--- a/images/ubuntu/22.10/Containerfile
+++ b/images/ubuntu/22.10/Containerfile
@@ -37,3 +37,6 @@ RUN mkdir /usr/share/empty
 
 # Add flatpak-spawn to /usr/bin
 RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/22.10/extra-packages
+++ b/images/ubuntu/22.10/extra-packages
@@ -1,5 +1,4 @@
 curl
-flatpak-xdg-utils
 git
 gnupg2
 keyutils


### PR DESCRIPTION
* images: ubuntu: Move flatpak-xdg-utils installation to Containerfile
  Since `flatpak-xdg-utils` is essential to images, not 'extra'.
* images: ubuntu: Remove APT ESM hook
  This was recently introduced with `ubuntu-advantage-tools` and it tries to poke at some system services introducing annoying delay and messages.
  Even if the services are present (on Ubuntu host) and systemd is accessible (rootful container) - that wouldn't be appropriate still.