### PR TITLE
images: ubuntu: Add 23.04 Lunar image

### DIFF
--- a/images/ubuntu/23.04/Containerfile
+++ b/images/ubuntu/23.04/Containerfile
@@ -1,0 +1,46 @@
+FROM docker.io/library/ubuntu:23.04
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="23.04" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu toolbox containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Enable myhostname nss plugin for clean hostname resolution without patching
+# hosts (at least for sudo), add it right after 'files' entry. We expect that
+# this entry is not present yet. Do this early so that package postinst (which
+# adds it too late in the order) skips this step
+RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.conf
+
+# Restore documentation but do not upgrade all packages
+# Install ubuntu-minimal & ubuntu-standard
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
+    apt-get update && \
+    yes | /usr/local/sbin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        flatpak-xdg-utils \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/
+
+# Having anything in /home prevents toolbox from symlinking /var/home there,
+# and 'ubuntu' user with UID 1000 will most likely conflict with host user as well
+RUN userdel --remove ubuntu
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/23.04/extra-packages
+++ b/images/ubuntu/23.04/extra-packages
@@ -1,0 +1,8 @@
+curl
+git
+gnupg2
+keyutils
+tree
+unzip
+zip
+zsh


### PR DESCRIPTION
Which is the next non-LTS to be released on Apr 20th 2023 (and supported for 9 months).