### PR TITLE
Set the HOME env variable to be consistent with the used home directory

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -426,6 +426,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		"--volume", homeDirMountArg,
 		"--volume", toolboxPathMountArg,
 		"--volume", runtimeDirectoryMountArg,
+		"--env", fmt.Sprintf("HOME=%s", currentUser.HomeDir),
 	}...)
 
 	createArgs = append(createArgs, avahiSocketMount...)


### PR DESCRIPTION
As per https://github.com/containers/podman/pull/18492 , in podman the HOME environment variable defaults to the home of the caller on first container start. Upon a restart, it defaults to the home of the user specified with `--user` which is root in the case of toolbox. If the linked PR is merged, the default will be defined by `--user` and will be used unless  the HOME env variable is explicitly defined. 

This PR explicitly sets the HOME env variable to be consistent with the home directory used by toolbox. Certain tools such as VSCode Dev Containers extract information about the home directory via this variable.