### PR TITLE
tests: Add an obvious error message

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -22,7 +22,8 @@ Running them won't remove any existing containers or images.
 These tests use a few standard libraries for `bats` which help with clarity
 and consistency. The libraries are [bats-support](https://github.com/bats-core/bats-support)
 and [bats-assert](https://github.com/bats-core/bats-assert). These libraries are
-provided as git submodules in the `libs` directory. Make sure both are present.
+provided as git submodules in the `libs` directory. Make sure both are present
+by running `git submodule init` and `git submodule update`.
 
 ## How to run the tests
 

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -15,11 +15,23 @@
 # limitations under the License.
 #
 
-load 'libs/helpers'
+missing_dependencies=false
+
+if [ -f test/system/libs/bats-assert/load.bash ] && [ -f test/system/libs/bats-support/load.bash ]; then
+  load 'libs/helpers'
+else
+  missing_dependencies=true
+fi
 
 setup_suite() {
   bats_require_minimum_version 1.7.0
   echo "# test suite: Set up" >&3
+
+  if $missing_dependencies; then
+    echo "# Missing dependencies" >&3
+    echo "# Forgot to run 'git submodule init' and 'git submodule update' ?" >&3
+    return 1
+  fi
 
   local os_release="$(find_os_release)"
   local system_id="$(get_system_id)"
@@ -49,6 +61,10 @@ setup_suite() {
 teardown_suite() {
   bats_require_minimum_version 1.7.0
   echo "# test suite: Tear down" >&3
+
+  if $missing_dependencies; then
+    return 0
+  fi
 
   _setup_environment
 


### PR DESCRIPTION
We wasted some time trying to get the tests
running locally, when all we were missing was
git submodules init.

Add some more obvious hints about this possible
stumbling block.