### PR TITLE
pkg/utils: Support host operating systems without VERSION_ID

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -829,7 +829,7 @@ func ResolveContainerAndImageNames(container, distroCLI, imageCLI, releaseCLI st
 		}
 	}
 
-	if _, ok := supportedDistros[distro]; !ok {
+	if _, supportedDistro := supportedDistros[distro]; !supportedDistro {
 		return "", "", "", &DistroError{distro, ErrDistroUnsupported}
 	}
 


### PR DESCRIPTION
The VERSION_ID field in os-release(5) is optional [1].  It's absent on Arch Linux, which follows a rolling-release model and uses the BUILD_ID field instead:
  BUILD_ID=rolling

A subsequent commit will add built-in support for Arch Linux.  Hence, the code to get the default release from the host operating system can no longer assume the presence of the VERSION_ID field in os-release(5).

[1] https://www.freedesktop.org/software/systemd/man/os-release.html