### PR TITLE
pkg/utils: Mark a private function as such

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -140,7 +140,7 @@ func init() {
 	hostID, err := GetHostID()
 	if err == nil {
 		if distroObj, supportedDistro := supportedDistros[hostID]; supportedDistro {
-			release, err := GetHostVersionID()
+			release, err := getHostVersionID()
 			if err == nil {
 				containerNamePrefixDefault = distroObj.ContainerNamePrefix
 				distroDefault = hostID
@@ -399,11 +399,11 @@ func GetHostVariantID() (string, error) {
 	return osRelease["VARIANT_ID"], nil
 }
 
-// GetHostVersionID returns the VERSION_ID from the os-release files
+// getHostVersionID returns the VERSION_ID from the os-release files
 //
 // Examples:
 // - host is Fedora 32, returned string is '32'
-func GetHostVersionID() (string, error) {
+func getHostVersionID() (string, error) {
 	osRelease, err := osrelease.Read()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Reading the VERSION_ID field from the host operating system's os-release(5) only needs to happen when initializing this package.

Fallout from 9e2825524ad61ac71540d2024f31bda39e745efc