### PR TITLE
.github/CODEOWNERS: Clarify ownership of Ubuntu image publication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 *    @HarryMichal @debarshiray
 /.github/workflows/arch-images.yaml       @Foxboron
 /.github/workflows/arch-images-pr.yaml    @Foxboron
+/.github/workflows/ubuntu-images.yaml     @Jmennius
 /data/gfx/*.gif    @jimmac
 /images/arch       @Foxboron
 /images/rhel       @debarshiray @olivergs


### PR DESCRIPTION
This reflects the value of the 'maintainer' LABELs of the images.

/cc @Jmennius 