### PR TITLE
.github/workflows: Publish the Arch Linux image at quay.io/toolbx/...

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 *    @HarryMichal @debarshiray
+/.github/workflows/arch-images.yaml       @Foxboron
+/.github/workflows/arch-images-pr.yaml    @Foxboron
 /data/gfx/*.gif    @jimmac
 /images/arch       @Foxboron
 /images/rhel       @debarshiray @olivergs

--- a/.github/workflows/arch-images-pr.yaml
+++ b/.github/workflows/arch-images-pr.yaml
@@ -1,0 +1,31 @@
+name: Build the arch-toolbox image for PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - images/arch/**
+      - .github/workflows/arch-images-pr.yaml
+
+jobs:
+  build-and-push-images:
+    name: Build the arch-toolbox image for PRs
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build the arch-toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: images/arch
+          file: images/arch/Containerfile
+          platforms: linux/amd64
+          push: false
+          no-cache: true
+          tags: quay.io/toolbx/arch-toolbox:latest

--- a/.github/workflows/arch-images.yaml
+++ b/.github/workflows/arch-images.yaml
@@ -1,0 +1,43 @@
+name: Build and push the arch-toolbox image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - images/arch/**
+      - .github/workflows/arch-images.yaml
+  schedule:
+    - cron: '0 0 * * MON'
+
+# Prevent multiple workflow runs from racing
+concurrency: ${{ github.workflow }}
+
+jobs:
+  build-and-push-images:
+    name: Build and push the arch-toolbox image
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: 'toolbx+github'
+          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+
+      - name: Build and push the arch-toolbox image
+        uses: docker/build-push-action@v3
+        with:
+          context: images/arch
+          file: images/arch/Containerfile
+          platforms: linux/amd64
+          push: true
+          no-cache: true
+          tags: quay.io/toolbx/arch-toolbox:latest


### PR DESCRIPTION
Until now, the Arch Linux image was being published at quay.io/toolbx-images/archlinux-toolbox:latest.  This renames the image to arch-toolbox [1] to match the os-release(5) ID on Arch, and changes the location to quay.io/toolbx/arch-toolbox:latest.

Build and push when there are changes in the 'images/arch' directory or in the GitHub workflow itself, as well as every other week (7th and 21st days of a month to be precise).

[1] Commit 2568528cb7f52663
    https://github.com/containers/toolbox/pull/861