### PR TITLE
pkg/utils: Offer built-in support for Arch Linux

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -108,6 +108,14 @@ var (
 	releaseDefault string
 
 	supportedDistros = map[string]Distro{
+		"arch": {
+			"arch-toolbox",
+			"arch-toolbox",
+			false,
+			getDefaultReleaseArch,
+			getFullyQualifiedImageArch,
+			parseReleaseArch,
+		},
 		"fedora": {
 			"fedora-toolbox",
 			"fedora-toolbox",
@@ -309,6 +317,10 @@ func getDefaultReleaseForDistro(distro string) (string, error) {
 	return release, nil
 }
 
+func getDefaultReleaseArch() (string, error) {
+	return "latest", nil
+}
+
 func getDefaultReleaseFedora() (string, error) {
 	release, err := getHostVersionID()
 	if err != nil {
@@ -394,6 +406,11 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to resolve image %s", image)
+}
+
+func getFullyQualifiedImageArch(image, release string) string {
+	imageFull := "quay.io/toolbx/" + image
+	return imageFull
 }
 
 func getFullyQualifiedImageFedora(image, release string) string {
@@ -709,6 +726,14 @@ func parseRelease(distro, release string) (string, error) {
 	parseReleaseImpl := distroObj.ParseRelease
 	release, err := parseReleaseImpl(release)
 	return release, err
+}
+
+func parseReleaseArch(release string) (string, error) {
+	if release != "latest" && release != "rolling" && release != "" {
+		return "", &ParseReleaseError{"The release must be 'latest'."}
+	}
+
+	return "latest", nil
 }
 
 func parseReleaseFedora(release string) (string, error) {

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -81,6 +81,26 @@ func TestParseRelease(t *testing.T) {
 		errMsg       string
 	}{
 		{
+			inputDistro:  "arch",
+			inputRelease: "",
+			output:       "latest",
+		},
+		{
+			inputDistro:  "arch",
+			inputRelease: "latest",
+			output:       "latest",
+		},
+		{
+			inputDistro:  "arch",
+			inputRelease: "rolling",
+			output:       "latest",
+		},
+		{
+			inputDistro:  "arch",
+			inputRelease: "foo",
+			errMsg:       "The release must be 'latest'.",
+		},
+		{
 			inputDistro:  "fedora",
 			inputRelease: "f34",
 			output:       "34",

--- a/test/system/000-setup.bats
+++ b/test/system/000-setup.bats
@@ -26,6 +26,7 @@ load 'libs/helpers'
     # Cache the default image for the system
     _pull_and_cache_distro_image "$system_id" "$system_version" || false
     # Cache all images that will be needed during the tests
+    _pull_and_cache_distro_image arch latest || false
     _pull_and_cache_distro_image fedora 34 || false
     _pull_and_cache_distro_image rhel 8.7 || false
     _pull_and_cache_distro_image ubuntu 16.04 || false

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -84,6 +84,48 @@ teardown() {
   assert [ ${#lines[@]} -eq 4 ]
 }
 
+@test "create: Arch Linux" {
+  pull_distro_image arch latest
+
+  run $TOOLBOX --assumeyes create --distro arch
+
+  assert_success
+  assert_output --partial "Created container: arch-toolbox-latest"
+  assert_output --partial "Enter with: toolbox enter arch-toolbox-latest"
+
+  run podman ps -a
+
+  assert_output --regexp "Created[[:blank:]]+arch-toolbox-latest"
+}
+
+@test "create: Arch Linux ('--release latest')" {
+  pull_distro_image arch latest
+
+  run $TOOLBOX --assumeyes create --distro arch --release latest
+
+  assert_success
+  assert_output --partial "Created container: arch-toolbox-latest"
+  assert_output --partial "Enter with: toolbox enter arch-toolbox-latest"
+
+  run podman ps -a
+
+  assert_output --regexp "Created[[:blank:]]+arch-toolbox-latest"
+}
+
+@test "create: Arch Linux ('--release rolling')" {
+  pull_distro_image arch latest
+
+  run $TOOLBOX --assumeyes create --distro arch --release rolling
+
+  assert_success
+  assert_output --partial "Created container: arch-toolbox-latest"
+  assert_output --partial "Enter with: toolbox enter arch-toolbox-latest"
+
+  run podman ps -a
+
+  assert_output --regexp "Created[[:blank:]]+arch-toolbox-latest"
+}
+
 @test "create: Fedora 34" {
   pull_distro_image fedora 34
 
@@ -176,6 +218,16 @@ teardown() {
   assert_line --index 0 "Error: failed to pull image foo.org/bar"
   assert_line --index 1 "If it was a private image, log in with: podman login foo.org"
   assert_line --index 2 "Use 'toolbox --verbose ...' for further details."
+}
+
+@test "create: Try Arch Linux with an invalid release ('--release foo')" {
+  run $TOOLBOX --assumeyes create --distro arch --release foo
+
+  assert_failure
+  assert_line --index 0 "Error: invalid argument for '--release'"
+  assert_line --index 1 "The release must be 'latest'."
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#lines[@]} -eq 3 ]
 }
 
 @test "create: Try Fedora with an invalid release ('--release -3')" {

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -118,6 +118,36 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "list: Arch Linux image" {
+  pull_distro_image arch latest
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Arch Linux image (using --images)" {
+  pull_distro_image arch latest
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
+  assert [ ${#lines[@]} -eq 3 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "list: Fedora 34 image" {
   pull_distro_image fedora 34
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -46,6 +46,36 @@ teardown() {
   assert_output ""
 }
 
+@test "run: Smoke test with Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  run --separate-stderr $TOOLBOX run --distro arch true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Arch Linux ('--release latest')" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  run --separate-stderr $TOOLBOX run --distro arch --release latest true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Arch Linux ('--release rolling')" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  run --separate-stderr $TOOLBOX run --distro arch --release rolling true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "run: Smoke test with Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -23,7 +23,8 @@ readonly TOOLBOX=${TOOLBOX:-$(command -v toolbox)}
 readonly SKOPEO=${SKOPEO:-$(command -v skopeo)}
 
 # Images
-declare -Ag IMAGES=([busybox]="quay.io/toolbox_tests/busybox" \
+declare -Ag IMAGES=([arch]="quay.io/toolbx/arch-toolbox" \
+                   [busybox]="quay.io/toolbox_tests/busybox" \
                    [docker-reg]="quay.io/toolbox_tests/registry" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
                    [rhel]="registry.access.redhat.com/ubi8/toolbox" \


### PR DESCRIPTION
This allows using the --distro option to create and enter Arch Linux
containers.  Due to Arch's rolling-release model, the --release option
isn't required.  If --release is used, the accepted values are 'latest'
and 'rolling'.