### PR TITLE
test/system: Fix warnings by specifying the minimum needed Bats version

### DIFF
--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Copyright © 2019 – 2022 Red Hat, Inc.
+# Copyright © 2019 – 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
 setup() {
+  bats_require_minimum_version 1.7.0
   _setup_environment
 }
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -20,6 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
 }

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -20,6 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_all
 }
@@ -37,13 +38,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -81,13 +77,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -106,13 +97,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -131,13 +117,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$image"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -159,24 +140,14 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -198,24 +169,14 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -237,13 +198,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image" "$default_image-copy"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
@@ -265,13 +221,8 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy" "$default_image"
 
   assert_success
-  assert_output ""
-  output="$stderr"
-  assert_output ""
-  if check_bats_version 1.7.0; then
-    assert [ ${#lines[@]} -eq 0 ]
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0

--- a/test/system/108-completion.bats
+++ b/test/system/108-completion.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 #
-# Copyright © 2022 Red Hat, Inc.
+# Copyright © 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.7.0
   _setup_environment
 }
 


### PR DESCRIPTION
Bats 1.7.0 emits a warning if a feature that is only available starting
from a certain version of Bats onwards is used without specifying that
version [1]:
```
  BW02: Using flags on `run` requires at least BATS_VERSION=1.5.0. Use
    `bats_require_minimum_version 1.5.0` to fix this message.
        (from function `bats_warn_minimum_guaranteed_version' in file
           /usr/lib/bats-core/warnings.bash, line 32,
         from function `run' in file
           /usr/lib/bats-core/test_functions.bash, line 227,
         in test file test/system/001-version.bats, line 27)
```

Note that `bats_require_minimum_version` itself is only available from
Bats 1.7.0 [2].  Hence, even though the specific feature here (using
flags on 'run') only requires Bats >= 1.5.0, in practice Bats >= 1.7.0
is needed.  Fortunately, commit e22a82fec8e59c5a already added a
dependency on Bats >= 1.7.0.  So, there's nothing to worry about.

[1] Bats commit 82002bb6c1a5c418
    https://github.com/bats-core/bats-core/issues/556
    https://bats-core.readthedocs.io/en/stable/warnings/BW02.html

[2] Bats commit 71d6b71cebc3d32b
    https://github.com/bats-core/bats-core/issues/556
    https://bats-core.readthedocs.io/en/stable/warnings/BW02.html