### PR TITLE
build: Make it build on riscv64

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/toolbox
 
-go 1.13
+go 1.14
 
 require (
 	github.com/HarryMichal/go-version v1.0.1

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,6 +45,8 @@ elif cpu_family == 'x86' and endian == 'little'
   dynamic_linker = '/lib/ld-linux.so.2'
 elif cpu_family == 'x86_64' and endian == 'little'
   dynamic_linker = '/lib64/ld-linux-x86-64.so.2'
+elif cpu_family == 'riscv64' and endian == 'little'
+  dynamic_linker = '/lib/ld-linux-riscv64-lp64d.so.1'
 else
   host_machine_description = cpu_family + ' (' + endian + ' endian)'
   error('Please specify dynamic linker for:', host_machine_description)


### PR DESCRIPTION
Go 1.14 added experimental support for 64-bit RISC-V on Linux (GOOS=linux, GOARCH=riscv64) [1], and the path of the dynamic linker (ie., PT_INTERP) was taken from the ABI specification [2].

Tested in Arch Linux rv64gc qemu user image.

[1] https://tip.golang.org/doc/go1.14#riscv

[2] https://sourceware.org/glibc/wiki/ABIList

https://github.com/containers/toolbox/pull/1159