### PR TITLE
playbooks: Use Ansible's 'command' module, instead of 'shell'

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -39,15 +39,17 @@
       - fish
 
 - name: Download Go modules
-  shell: |
-    go mod download -x
+  command: go mod download -x
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Set up Git submodules
-  shell: |
-    git submodule init
-    git submodule update
+- name: Initialize Git submodules
+  command: git submodule init
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+
+- name: Update Git submodules
+  command: git submodule update
   args:
     chdir: '{{ zuul.project.src_dir }}'
 

--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -63,15 +63,17 @@
     update_cache: "{{ true if zuul.attempts > 1 else false }}"
 
 - name: Download Go modules
-  shell: |
-    go mod download -x
+  command: go mod download -x
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Set up Git submodules
-  shell: |
-    git submodule init
-    git submodule update
+- name: Initialize Git submodules
+  command: git submodule init
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+
+- name: Update Git submodules
+  command: git submodule update
   args:
     chdir: '{{ zuul.project.src_dir }}'
 

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -39,15 +39,17 @@
       - udisks2
 
 - name: Download Go modules
-  shell: |
-    go mod download -x
+  command: go mod download -x
   args:
     chdir: '{{ zuul.project.src_dir }}/src'
 
-- name: Set up Git submodules
-  shell: |
-    git submodule init
-    git submodule update
+- name: Initialize Git submodules
+  command: git submodule init
+  args:
+    chdir: '{{ zuul.project.src_dir }}'
+
+- name: Update Git submodules
+  command: git submodule update
   args:
     chdir: '{{ zuul.project.src_dir }}'
 


### PR DESCRIPTION
Ansible's 'shell' module is almost exactly like the 'command' module, except that it runs the command through a command line shell so that environment variables like HOSTNAME and operations like '*', '<' and '>' work.  None of those things are necessary are here.  Hence, it's better to use the 'command' module as elsewhere.