### PR TITLE
.github/workflows: Run the CI on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -1,0 +1,146 @@
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: ubuntu-tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  ubuntu-jammy-tests:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: containers/toolbox
+          submodules: true
+
+      - name: Install deb packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            apache2-utils \
+            bash-completion \
+            codespell \
+            fish \
+            gcc \
+            go-md2man \
+            golang \
+            meson \
+            ninja-build \
+            openssl \
+            podman \
+            shellcheck \
+            skopeo \
+            systemd \
+            udisks2
+
+      - name: Checkout Bats
+        uses: actions/checkout@v3
+        with:
+          path: bats-core/bats-core
+          ref: v1.9.0
+          repository: bats-core/bats-core.git
+          submodules: true
+
+      - name: Install deb packages for Bats
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            bash \
+            parallel
+
+      - name: Install Bats
+        run: sudo ./install.sh /usr/local
+        working-directory: bats-core/bats-core
+
+      - name: Checkout shadow
+        uses: actions/checkout@v3
+        with:
+          path: shadow-maint/shadow
+          ref: 4.13
+          repository: shadow-maint/shadow.git
+          submodules: true
+
+      - name: Install deb packages for shadow
+        run: |
+          sudo apt-get update
+          sudo apt-get install \
+            autoconf \
+            autopoint \
+            gettext \
+            libaudit-dev \
+            libcrypt-dev \
+            libpam0g-dev \
+            libselinux1-dev \
+            libsemanage-dev
+
+      - name: Set up build directory for shadow
+        run: |
+          autoreconf --force --install --verbose
+          ./configure \
+            --disable-account-tools-setuid \
+            --disable-silent-rules \
+            --with-audit \
+            --with-libpam \
+            --with-selinux \
+            --with-yescrypt \
+            --without-acl \
+            --without-attr \
+            --without-su \
+            --without-tcb \
+            SHELL=/bin/sh
+        working-directory: shadow-maint/shadow
+
+      - name: Build shadow
+        run: make
+        working-directory: shadow-maint/shadow
+
+      - name: Install shadow
+        run: sudo make install
+        working-directory: shadow-maint/shadow
+
+      - name: Download Go modules
+        run: go mod download -x
+        working-directory: containers/toolbox/src
+
+      - name: Set up build directory
+        run: meson setup --fatal-meson-warnings builddir
+        working-directory: containers/toolbox
+
+      - name: Build
+        run: meson compile -C builddir --verbose
+        working-directory: containers/toolbox
+
+      - name: Install
+        run: sudo meson install -C builddir
+        working-directory: containers/toolbox
+
+      - name: Unit tests
+        run: meson test -C builddir --verbose
+        working-directory: containers/toolbox
+
+      - name: System tests
+        run: bats --timing test/system/001-version.bats test/system/002-help.bats test/system/108-completion.bats
+        env:
+          TOOLBOX: /usr/local/bin/toolbox
+        working-directory: containers/toolbox


### PR DESCRIPTION
Now that Toolbx offers built-in support for Ubuntu containers [1],
adding an Ubuntu host to the upstream CI will help ensure that Toolbx
continues to work well on Ubuntu.  Ubuntu 22.04 is the latest long term
support (or LTS) release [2] from Ubuntu, and is the latest Ubuntu
version that GitHub provides runners for [3].

Ubuntu 22.04 only has Bats 1.2.1 [4], while Toolbx requires 1.7.0 [5];
and Shadow 4.8 [6], while Toolbx requires 4.9 because it needs
libsubid.so [7,8].  Hence, newer versions of these dependencies need to
be built to run the tests.  The build flags for Shadow were taken from
the Debian package [9].

A separate sub-directory inside $GITHUB_WORKSPACE [10] is used for
Toolbx itself to prevent codespell from getting triggered by spelling
mistakes in these dependencies themselves [11].

Unfortunately, the SHELL environment variable goes mysteriously missing
from the runtime environment of the GitHub Actions workflow [12].  This
breaks the 'create' and 'enter' commands, and therefore tests involving
them can't be run until this is resolved.  Meanwhile, running the CI on
Ubuntu with a subset of the tests, is still better than not running the
CI on Ubuntu at all.

[1] Commit a84a358b3b90dac9
    https://github.com/containers/toolbox/pull/483
    https://github.com/containers/toolbox/pull/1284

[2] https://wiki.ubuntu.com/Releases

[3] https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners

[4] https://packages.ubuntu.com/jammy/bats

[5] Commit e22a82fec8e59c5a
    https://github.com/containers/toolbox/pull/1273

[6] https://packages.ubuntu.com/source/jammy/shadow
    https://packages.ubuntu.com/source/jammy-updates/shadow

[7] Shadow commit 0a7888b1fad613a0
    https://github.com/shadow-maint/shadow/commit/0a7888b1fad613a0
    https://github.com/shadow-maint/shadow/issues/154

[8] Commit ca8007c192b3bb77
    https://github.com/containers/toolbox/issues/1074

[9] https://salsa.debian.org/debian/shadow/

[10] https://docs.github.com/en/actions/learn-github-actions/variables

[11] https://github.com/bats-core/bats-core/pull/743

[12] https://github.com/orgs/community/discussions/59413