### PR TITLE
test/system: Limit the scope of temporary files used by a single test

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -111,5 +111,6 @@ subdir('data')
 subdir('doc')
 subdir('profile.d')
 subdir('src')
+subdir('test')
 
 meson.add_install_script('meson_post_install.py')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,1 @@
+subdir('system')

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -28,7 +28,6 @@ teardown() {
   cleanup_containers
 }
 
-
 @test "create: Smoke test" {
   pull_default_image
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -29,7 +29,6 @@ teardown() {
   cleanup_all
 }
 
-
 @test "list: Smoke test" {
   run --keep-empty-lines --separate-stderr $TOOLBOX list
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -166,11 +166,11 @@ teardown() {
 @test "run: 'sudo id' inside the default container" {
   create_default_container
 
-  output="$($TOOLBOX --verbose run sudo id 2>$BATS_TMPDIR/stderr)"
+  output="$($TOOLBOX --verbose run sudo id 2>$BATS_TEST_TMPDIR/stderr)"
   status="$?"
 
   echo "# stderr"
-  cat $BATS_TMPDIR/stderr
+  cat $BATS_TEST_TMPDIR/stderr
   echo "# stdout"
   echo $output
 

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -1,0 +1,46 @@
+# shellcheck shell=bats
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'libs/helpers'
+
+setup() {
+  bats_require_minimum_version 1.7.0
+  _setup_environment
+  cleanup_containers
+}
+
+teardown() {
+  cleanup_containers
+}
+
+@test "ipc: no namespace" {
+  local ns_host
+  ns_host=$(readlink /proc/$$/ns/ipc)
+
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'readlink /proc/$$/ns/ipc'
+
+  assert_success
+  assert_line --index 0 "$ns_host"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -1,0 +1,156 @@
+# shellcheck shell=bats
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'libs/helpers'
+
+setup() {
+  bats_require_minimum_version 1.7.0
+  _setup_environment
+  cleanup_containers
+}
+
+teardown() {
+  cleanup_containers
+}
+
+@test "network: no namespace" {
+  local ns_host
+  ns_host=$(readlink /proc/$$/ns/net)
+
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'readlink /proc/$$/ns/net'
+
+  assert_success
+  assert_line --index 0 "$ns_host"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside the default container" {
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside RHEL 8.7" {
+  create_distro_container rhel 8.7 rhel-toolbox-8.7
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  run -2 --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 ping -c 2 f.root-servers.net
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -gt 0 ]
+
+  skip "doesn't use ICMP Echo sockets"
+}
+
+@test "network: ping(8) inside Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -227,9 +227,9 @@ function _clean_docker_registry() {
 
 
 function build_image_without_name() {
-  echo -e "FROM scratch\n\nLABEL com.github.containers.toolbox=\"true\"" > "$BATS_TMPDIR"/Containerfile
+  echo -e "FROM scratch\n\nLABEL com.github.containers.toolbox=\"true\"" > "$BATS_TEST_TMPDIR"/Containerfile
 
-  run $PODMAN build "$BATS_TMPDIR"
+  run $PODMAN build "$BATS_TEST_TMPDIR"
 
   assert_success
   assert_line --index 0 --partial "FROM scratch"
@@ -239,7 +239,7 @@ function build_image_without_name() {
   last=$((${#lines[@]}-1))
   assert_line --index "$last" --regexp "^[a-f0-9]{64}$"
 
-  rm -f "$BATS_TMPDIR"/Containerfile
+  rm -f "$BATS_TEST_TMPDIR"/Containerfile
 
   echo "${lines[$last]}"
 }

--- a/test/system/meson.build
+++ b/test/system/meson.build
@@ -1,4 +1,5 @@
 test_system = files(
+  '201-ipc.bats',
   '203-network.bats',
 )
 

--- a/test/system/meson.build
+++ b/test/system/meson.build
@@ -1,0 +1,7 @@
+test_system = files(
+  '203-network.bats',
+)
+
+if shellcheck.found()
+  test('shellcheck test/system', shellcheck, args: [test_system])
+endif


### PR DESCRIPTION
BATS_TMPDIR is the base directory used by Bats for all temporary files and directories, and BATS_TEST_TMPDIR is unique to each test [1].  It's better to limit the scope of the tests' temporary files as much as possible to avoid unexpected collisions with Bats' own internal temporary files.

[1] https://bats-core.readthedocs.io/en/stable/writing-tests.html