### PR TITLE
test/system: Simplify the check for Fedora Rawhide

### DIFF
--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -46,12 +46,10 @@ teardown() {
 }
 
 @test "container(Fedora Rawhide): Containers with supported versions start without issues" {
-  local os_release="$(find_os_release)"
   local system_id="$(get_system_id)"
   local system_version="$(get_system_version)"
-  local rawhide_res="$(awk '/rawhide/' $os_release)"
 
-  if [ "$system_id" != "fedora" ] || [ -z "$rawhide_res" ]; then
+  if ! is_fedora_rawhide; then
     skip "This test is only for Fedora Rawhide"
   fi
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -525,6 +525,20 @@ function get_system_version() (
 )
 
 
+function is_fedora_rawhide() (
+  local os_release
+  os_release="$(find_os_release)"
+  [ -z "$os_release" ] && return 1
+
+  . "$os_release"
+
+  [ "$ID" != "fedora" ] && return 1
+  [ "$REDHAT_BUGZILLA_PRODUCT_VERSION" != "rawhide" ] && return 1
+
+  return 0
+)
+
+
 # Set up the XDG_RUNTIME_DIR variable if not set
 function check_xdg_runtime_dir() {
   if [[ -z "${XDG_RUNTIME_DIR}" ]]; then


### PR DESCRIPTION
First, it's not a good idea to use awk(1) as a grep(1) replacement. Unless one really needs the AWK programming language, it's better to stick to grep(1) because it's simpler.

Secondly, it's better to look for a specific os-release(5) field instead of looking for the occurrence of 'rawhide' anywhere in the file, because it lowers the possibility of false positives.