### PR TITLE
test/system: Silence SC2154

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -199,10 +199,7 @@ teardown() {
 }
 
 @test "run: Ensure that the default container is used" {
-  run echo "$name"
-
-  assert_success
-  assert_output ""
+  test -z "${name+x}"
 
   local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
   create_default_container


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
```
  Line 202:
  run echo "$name"
            ^---^ SC2154 (warning): name is referenced but not assigned.
```

See: https://www.shellcheck.net/wiki/SC2154