### PR TITLE
test/system: Simplify the check for Fedora Rawhide

### DIFF
--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+- name: Install python3-dnf
+  become: true
+  command: dnf5 --assumeyes install python3-dnf
+  when: ansible_distribution_major_version | int >= 39
+
 - name: Ensure that subordinate group ID ranges are absent
   become: yes
   file:

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+- name: Install python3-dnf
+  become: true
+  command: dnf5 --assumeyes install python3-dnf
+  when: ansible_distribution_major_version | int >= 39
+
 - name: Install RPM packages
   become: yes
   package:

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -33,7 +33,6 @@ setup_suite() {
     return 1
   fi
 
-  local os_release="$(find_os_release)"
   local system_id="$(get_system_id)"
   local system_version="$(get_system_version)"
 
@@ -49,8 +48,7 @@ setup_suite() {
   _pull_and_cache_distro_image ubuntu 20.04 || false
   _pull_and_cache_distro_image busybox || false
   # If run on Fedora Rawhide, cache 2 extra images (previous Fedora versions)
-  local rawhide_res="$(awk '/rawhide/' $os_release)"
-  if [ "$system_id" = "fedora" ] && [ -n "$rawhide_res" ]; then
+  if is_fedora_rawhide; then
     _pull_and_cache_distro_image fedora "$((system_version-1))" || false
     _pull_and_cache_distro_image fedora "$((system_version-2))" || false
   fi


### PR DESCRIPTION
First, it's not a good idea to use awk(1) as a grep(1) replacement. Unless one really needs the AWK programming language, it's better to stick to grep(1) because it's simpler.

Secondly, it's better to look for a specific os-release(5) field instead of looking for the occurrence of 'rawhide' anywhere in the file, because it lowers the possibility of false positives.