### PR TITLE
playbooks: Add workaround for Fedora Rawhide

### DIFF
--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+- name: Install python3-dnf
+  become: true
+  command: dnf5 --assumeyes install python3-dnf
+  when: ansible_distribution_major_version | int >= 39
+
 - name: Ensure that subordinate group ID ranges are absent
   become: yes
   file:

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+- name: Install python3-dnf
+  become: true
+  command: dnf5 --assumeyes install python3-dnf
+  when: ansible_distribution_major_version | int >= 39
+
 - name: Install RPM packages
   become: yes
   package:


### PR DESCRIPTION
The Ansible version that is installed in Zuul is 2.13.7 that is expecting python3-dnf library to be installed on the host.
I have done a test on the rawhide host and it seems that the ansible-core package that is available in Fedora repo (2.15) is fine and it does not require python3-dnf package. It means, that if the pull request will be merged, we should revert it later, after Zuul update. 