### PR TITLE
Be aware of security hardened mount points

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -62,10 +62,10 @@ var (
 		{"/run/udev/data", "/run/host/run/udev/data", ""},
 		{"/run/udev/tags", "/run/host/run/udev/tags", ""},
 		{"/tmp", "/run/host/tmp", "rslave"},
-		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", "ro"},
+		{"/var/lib/flatpak", "/run/host/var/lib/flatpak", ""},
 		{"/var/lib/libvirt", "/run/host/var/lib/libvirt", ""},
-		{"/var/lib/systemd/coredump", "/run/host/var/lib/systemd/coredump", "ro"},
-		{"/var/log/journal", "/run/host/var/log/journal", "ro"},
+		{"/var/lib/systemd/coredump", "/run/host/var/lib/systemd/coredump", ""},
+		{"/var/log/journal", "/run/host/var/log/journal", ""},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},
 	}
 )

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -211,6 +211,7 @@ teardown() {
   assert [ ${#lines[@]} -gt 0 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
+  # shellcheck disable=SC1090
   source <(echo "$output")
   run echo "$name"
 
@@ -234,6 +235,7 @@ teardown() {
   assert [ ${#lines[@]} -gt 0 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
+  # shellcheck disable=SC1090
   source <(echo "$output")
   run echo "$name"
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -107,7 +107,7 @@ function _pull_and_cache_distro_image() {
     assert_success
   fi
 
-  for ((i = ${num_of_retries}; i > 0; i--)); do
+  for ((i = num_of_retries; i > 0; i--)); do
     run $SKOPEO copy --dest-compress docker://${image} dir:${IMAGE_CACHE_DIR}/${image_archive}
 
     if [ "$status" -eq 0 ]; then


### PR DESCRIPTION
Sometimes locations such as `/var/lib/flatpak`, `/var/lib/systemd/coredump` and `/var/log/journal` sit on security hardened mount points that are marked as `nosuid,nodev,noexec` [1].  In such cases, when Toolbx is used rootless, an attempt to bind mount these locations read-only at runtime with `mount(8)` fails because of permission problems:
```
  # mount --rbind -o ro <source> <containerPath>
  mount: <containerPath>: filesystem was mounted, but any subsequent
      operation failed: Unknown error 5005.
```

(Note that the above error message from mount(8) was subsequently improved to show something more meaningful than 'Unknown error' [2].)

The problem is that `init-container` is running inside the container's mount and user namespace and the source paths were mounted inside the host's namespace with `nosuid,nodev,noexec`.  The above `mount(8)` call tries to remove the `nosuid,nodev,noexec` flags from the mount point and replace them with only `ro`, which is something that can't be done from a child namespace.

Note that this doesn't fail when Toolbx is running as root.  This is because the container uses the host's user namespace and is able to remove the `nosuid,nodev,noexec` flags from the mount point and replace them with only `ro`.  Even though it doesn't fail, the flags shouldn't get replaced like that inside the container, because it removes the security hardening of those mount points.

There's actually no benefit in bind mounting these paths as read-only. It was historically done this way 'just to be safe' because a user isn't expected to write to these locations from inside a container.  However, Toolbx doesn't intend to provide any heightened security beyond what's already available on the host.

Hence, it's better to get out of the way and leave it to the permissions on the source location from the host operating system to guard the castle.  This is accomplished by not passing any file system options to `mount(8)` [1].

Note that this isn't a problem when Toolbx is running as root, because the container uses the host's user namespace.

Based on an idea from Si.

[1] https://man7.org/linux/man-pages/man8/mount.8.html

[2] util-linux commit 9420ca34dc8b6f0f
    https://github.com/util-linux/util-linux/commit/9420ca34dc8b6f0f
    https://github.com/util-linux/util-linux/pull/2376

https://github.com/containers/toolbox/issues/911