### PR TITLE
test/system: Fix typos in conditional expressions

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -86,7 +86,7 @@ function _pull_and_cache_distro_image() {
   distro="$1"
   version="$2"
 
-  if [ ! -v IMAGES[$distro] ]; then
+  if ! [ -v IMAGES[$distro] ]; then
     fail "Requested distro (${distro}) does not have a matching image"
   fi
 
@@ -302,7 +302,7 @@ function pull_distro_image() {
   distro="$1"
   version="$2"
 
-  if [ ! -v IMAGES[$distro] ]; then
+  if ! [ -v IMAGES[$distro] ]; then
     fail "Requested distro (${distro}) does not have a matching image"
   fi
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -86,7 +86,7 @@ function _pull_and_cache_distro_image() {
   distro="$1"
   version="$2"
 
-  if ! [ -v IMAGES[$distro] ]; then
+  if [ -z "${IMAGES[$distro]+x}" ]; then
     fail "Requested distro (${distro}) does not have a matching image"
   fi
 
@@ -302,7 +302,7 @@ function pull_distro_image() {
   distro="$1"
   version="$2"
 
-  if ! [ -v IMAGES[$distro] ]; then
+  if [ -z "${IMAGES[$distro]+x}" ]; then
     fail "Requested distro (${distro}) does not have a matching image"
   fi
 


### PR DESCRIPTION
Fallout from 54a2ca1ead343c3db2c7443cc58b9d9e896d3c46