### PR TITLE
Revert "playbooks: Add workaround for Fedora Rawhide"

### DIFF
--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 
-- name: Install python3-dnf
-  become: true
-  command: dnf5 --assumeyes install python3-dnf
-  when: ansible_distribution_major_version | int >= 39
-
 - name: Ensure that subordinate group ID ranges are absent
   become: yes
   file:

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -14,11 +14,6 @@
 # limitations under the License.
 #
 
-- name: Install python3-dnf
-  become: true
-  command: dnf5 --assumeyes install python3-dnf
-  when: ansible_distribution_major_version | int >= 39
-
 - name: Install RPM packages
   become: yes
   package:


### PR DESCRIPTION
The DNF5 Change [1] was dropped from Fedora 39 (and Rawhide) [2] and postponed for a later Fedora.  Therefore, there's no need for this workaround.

This reverts commit 96791726a35d9a19c53064bbb17204f4aba92e46.

[1] https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5

[2] https://pagure.io/fesco/issue/3039