### PR TITLE
cmd/initContainer: Simplify removing the user's password

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -393,6 +393,7 @@ func configureUsers(targetUserUid int, targetUser, targetUserHome, targetUserShe
 			"--groups", sudoGroup,
 			"--home-dir", targetUserHome,
 			"--no-create-home",
+			"--password", "",
 			"--shell", targetUserShell,
 			"--uid", fmt.Sprint(targetUserUid),
 			targetUser,
@@ -413,6 +414,7 @@ func configureUsers(targetUserUid int, targetUser, targetUserHome, targetUserShe
 			"--append",
 			"--groups", sudoGroup,
 			"--home", targetUserHome,
+			"--password", "",
 			"--shell", targetUserShell,
 			"--uid", fmt.Sprint(targetUserUid),
 			targetUser,
@@ -426,12 +428,6 @@ func configureUsers(targetUserUid int, targetUser, targetUserHome, targetUserShe
 		if err := shell.Run("usermod", nil, nil, nil, usermodArgs...); err != nil {
 			return fmt.Errorf("failed to modify user %s with UID %d: %w", targetUser, targetUserUid, err)
 		}
-	}
-
-	logrus.Debugf("Removing password for user %s", targetUser)
-
-	if err := shell.Run("passwd", nil, nil, nil, "--delete", targetUser); err != nil {
-		return fmt.Errorf("failed to remove password for user %s: %w", targetUser, err)
 	}
 
 	logrus.Debug("Removing password for user root")


### PR DESCRIPTION
It's one less invocation of an external command, which is good because
spawning a new process is generally expensive.

One positive side-effect of this is that on some Active Directory
set-ups, the entry point no longer fails with:
```
  Error: failed to remove password for user login@company.com: failed
      to invoke passwd(1)
```
... because of:
```
  # passwd --delete login@company.com
  passwd: Libuser error at line: 210 - name contains invalid char `@'.
```

This is purely an accident, and isn't meant to be an intential change to
support Active Directory.  Tools like `useradd(8)` and `usermod(8)` from
Shadow aren't meant to work with Active Directory users, and, hence, it
can still break in other ways.  For that, one option is to expose `$USER`
from the host operating system to the Toolbx container through a Varlink
interface that can be used by nss-systemd inside the container.

Based on an idea from Si.

https://github.com/containers/toolbox/issues/585