### PR TITLE
test/system: Unbreak the line count checks with Bats >= 1.10.0

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: bats-core/bats-core
-          ref: v1.9.0
+          ref: v1.10.0
           repository: bats-core/bats-core.git
           submodules: true
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -128,7 +128,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -143,7 +149,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -158,7 +170,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -173,7 +191,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -188,7 +212,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.7"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -203,7 +233,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.7"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -218,7 +254,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -233,7 +275,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -248,7 +296,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -263,7 +317,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -278,7 +338,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:20.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -293,7 +359,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:20.04"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -308,7 +380,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "<none>"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -323,7 +401,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "<none>"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -39,7 +39,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$ns_host"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -39,7 +39,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$ns_host"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -39,7 +39,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -55,7 +60,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -71,7 +81,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -87,7 +102,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -103,7 +123,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -119,7 +144,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -135,7 +165,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -151,7 +186,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -167,7 +207,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -183,7 +228,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -199,7 +249,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -215,7 +270,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -231,7 +291,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -247,7 +312,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -263,7 +333,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -279,7 +354,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -295,7 +375,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -311,7 +396,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -327,7 +417,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -343,7 +438,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -359,7 +459,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -375,7 +480,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -391,7 +501,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -407,7 +522,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -423,7 +543,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -439,7 +564,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -455,7 +585,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -471,7 +606,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -487,7 +627,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -503,7 +648,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -519,7 +669,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -535,7 +690,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -551,7 +711,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -567,7 +732,12 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-  assert [ ${#lines[@]} -eq 2 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]


### PR DESCRIPTION
Until Bats 1.10.0, `run --keep-empty-lines` had a bug where it counted the trailing newline on the last line as a separate line [1].  However, Bats 1.10.0 is only available in Fedora >= 39 and is absent from Fedoras 37 and 38.

[1] Bats commit 6648e2143bffb933
    https://github.com/bats-core/bats-core/commit/6648e2143bffb933
    https://github.com/bats-core/bats-core/issues/708