### PR TITLE
cmd/initContainer: Do not try to remount /etc/machine-id as ro

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -52,7 +52,7 @@ var (
 		source        string
 		flags         string
 	}{
-		{"/etc/machine-id", "/run/host/etc/machine-id", "ro"},
+		{"/etc/machine-id", "/run/host/etc/machine-id", ""},
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -1,0 +1,89 @@
+# shellcheck shell=bats
+#
+# Copyright © 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'libs/helpers'
+
+setup() {
+  bats_require_minimum_version 1.7.0
+  _setup_environment
+  cleanup_containers
+}
+
+teardown() {
+  cleanup_containers
+}
+
+@test "dbus: session bus" {
+  local expected_response
+  expected_response="$(gdbus call \
+                         --session \
+                         --dest org.freedesktop.DBus \
+                         --object-path /org/freedesktop/DBus \
+                         --method org.freedesktop.DBus.Peer.Ping)"
+
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'gdbus call \
+                                                                   --session \
+                                                                   --dest org.freedesktop.DBus \
+                                                                   --object-path /org/freedesktop/DBus \
+                                                                   --method org.freedesktop.DBus.Peer.Ping'
+
+  assert_success
+  assert_line --index 0 "$expected_response"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "dbus: system bus" {
+  local expected_response
+  expected_response="$(gdbus call \
+                         --system \
+                         --dest org.freedesktop.systemd1 \
+                         --object-path /org/freedesktop/systemd1 \
+                         --method org.freedesktop.DBus.Properties.Get org.freedesktop.systemd1.Manager Version)"
+
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'gdbus call \
+                                                                   --system \
+                                                                   --dest org.freedesktop.systemd1 \
+                                                                   --object-path /org/freedesktop/systemd1 \
+                                                                   --method org.freedesktop.DBus.Properties.Get \
+                                                                     org.freedesktop.systemd1.Manager Version'
+
+  assert_success
+  assert_line --index 0 "$expected_response"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/meson.build
+++ b/test/system/meson.build
@@ -3,6 +3,7 @@ test_system = files(
   '203-network.bats',
   '206-user.bats',
   '210-ulimit.bats',
+  '211-dbus.bats',
 )
 
 if shellcheck.found()


### PR DESCRIPTION
Followup to 1cc9e07b7c36fe9f9784b40b58f0a2a3694dd328

Sometimes the parent location might be mounted with nosuid,nodev,noexec and trying to remount it as ro would remove those and thus fails.

See commit mentioned above for more details.

https://github.com/containers/toolbox/issues/911