### PR TITLE
cmd/initContainer: Simplify code by removing a function parameter

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -52,7 +52,7 @@ var (
 		source        string
 		flags         string
 	}{
-		{"/etc/machine-id", "/run/host/etc/machine-id", "ro"},
+		{"/etc/machine-id", "/run/host/etc/machine-id", ""},
 		{"/run/libvirt", "/run/host/run/libvirt", ""},
 		{"/run/systemd/journal", "/run/host/run/systemd/journal", ""},
 		{"/run/systemd/resolve", "/run/host/run/systemd/resolve", ""},


### PR DESCRIPTION
Until now, `configureUsers()` was pushing the burden of deciding whether
to add a new user or modify an existing one on the callers, even though
it can trivially decide itself.  Involving the caller loosens the
encapsulation of the user configuration logic by spreading it across
`configureUsers()` and it's caller, and adds an extra function parameter
that needs to be carefully set and is vulnerable to programmer errors.

Fallout from 9ea6fe5852ea8f5225114d825e8e6813e2a3cfea