### PR TITLE
test/system: Replace the shebangs with 'shell' directives

### DIFF
--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2019 – 2023 Red Hat, Inc.
 #

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -1,6 +1,6 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
-# Copyright © 2020 – 2022 Red Hat, Inc.
+# Copyright © 2020 – 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2019 – 2023 Red Hat, Inc.
 #

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2019 – 2023 Red Hat, Inc.
 #

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -1,6 +1,6 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2021 – 2023 Red Hat, Inc.
 #

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -1,6 +1,6 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/106-rm.bats
+++ b/test/system/106-rm.bats
@@ -1,6 +1,6 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2023 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2021 – 2023 Red Hat, Inc.
 #

--- a/test/system/108-completion.bats
+++ b/test/system/108-completion.bats
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+# shellcheck shell=bats
 #
 # Copyright © 2023 Red Hat, Inc.
 #

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 #
 # Copyright © 2021 – 2023 Red Hat, Inc.
 #

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!/usr/bin/env bash
 #
 # Copyright © 2021 – 2023 Red Hat, Inc.
 #


### PR DESCRIPTION
These files aren't marked as executable, and shouldn't be, because they
aren't meant to be standalone executable scripts.  They're meant to be
part of a test suite driven by Bats.  Therefore, it doesn't make sense
for them to have shebangs, because it gives the opposite impression.

The shebangs were actually being used by external tools like Coverity to
deduce the shell when running shellcheck(1).  Shellcheck's inline
'shell' directive is a more obvious way to achieve that.