### PR TITLE
test/system: Simplify checking if the container started or not

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -439,10 +439,9 @@ function container_started() {
   for TRIES in 1 2 3 4 5
   do
     run "$PODMAN" logs "$container_name"
-    container_output="$output"
+
     # Look for last line of the container startup log
-    run grep 'Listening to file system and ticker events' <<< "$container_output"
-    if [[ "$status" -eq 0 ]]; then
+    if echo "$output" | grep "Listening to file system and ticker events"; then
       container_initialized=0
       break
     fi

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -436,8 +436,7 @@ function container_started() {
   # Used as a return value
   container_initialized=1
 
-  for TRIES in 1 2 3 4 5
-  do
+  for TRIES in 1 2 3 4 5; do
     run "$PODMAN" logs "$container_name"
 
     # Look for last line of the container startup log

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -431,7 +431,7 @@ function container_started() {
   local container_name
   container_name="$1"
 
-  run "$PODMAN" start "$container_name"
+  start_container "$container_name"
 
   # Used as a return value
   container_initialized=1


### PR DESCRIPTION
Bats' `run` helper is not necessary to merely check if a command succeeded or not [1].  In this case, it's idiomatic to pipe the *output* directly to `grep(1)` and use it as the condition for an `if` branch.

[1] https://bats-core.readthedocs.io/en/stable/writing-tests.html