### PR TITLE
test/system: Silence SC1090

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -502,7 +502,9 @@ function get_system_id() (
     return
   fi
 
+  # shellcheck disable=SC1090
   . "$os_release"
+
   echo "$ID"
 )
 
@@ -518,7 +520,9 @@ function get_system_version() (
     return
   fi
 
+  # shellcheck disable=SC1090
   . "$os_release"
+
   echo "$VERSION_ID"
 )
 
@@ -528,6 +532,7 @@ function is_fedora_rawhide() (
   os_release="$(find_os_release)"
   [ -z "$os_release" ] && return 1
 
+  # shellcheck disable=SC1090
   . "$os_release"
 
   [ "$ID" != "fedora" ] && return 1

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -439,10 +439,9 @@ function container_started() {
   for TRIES in 1 2 3 4 5
   do
     run "$PODMAN" logs "$container_name"
-    container_output="$output"
+
     # Look for last line of the container startup log
-    run grep 'Listening to file system and ticker events' <<< "$container_output"
-    if [[ "$status" -eq 0 ]]; then
+    if echo "$output" | grep "Listening to file system and ticker events"; then
       container_initialized=0
       break
     fi

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -436,8 +436,7 @@ function container_started() {
   # Used as a return value
   container_initialized=1
 
-  for TRIES in 1 2 3 4 5
-  do
+  for TRIES in 1 2 3 4 5; do
     run "$PODMAN" logs "$container_name"
 
     # Look for last line of the container startup log

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -431,7 +431,7 @@ function container_started() {
   local container_name
   container_name="$1"
 
-  run "$PODMAN" start "$container_name"
+  start_container "$container_name"
 
   # Used as a return value
   container_initialized=1


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
```
  Line 505:
  . "$os_release"
    ^-----------^ SC1090 (warning): ShellCheck can't follow non-constant
                  source. Use a directive to specify location.
```

See: https://www.shellcheck.net/wiki/SC1090