### PR TITLE
test/system: Silence SC2155

### DIFF
--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -621,7 +621,9 @@ teardown() {
 
 @test "create: Try a non-default distro without a release" {
   local distro="fedora"
-  local system_id="$(get_system_id)"
+
+  local system_id
+  system_id="$(get_system_id)"
 
   if [ "$system_id" = "fedora" ]; then
     distro="rhel"

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -30,7 +30,8 @@ teardown() {
 
 
 @test "container: Check container starts without issues" {
-  readonly CONTAINER_NAME="$(get_system_id)-toolbox-$(get_system_version)"
+  CONTAINER_NAME="$(get_system_id)-toolbox-$(get_system_version)"
+  readonly CONTAINER_NAME
 
   create_default_container
 
@@ -46,8 +47,11 @@ teardown() {
 }
 
 @test "container(Fedora Rawhide): Containers with supported versions start without issues" {
-  local system_id="$(get_system_id)"
-  local system_version="$(get_system_version)"
+  local system_id
+  system_id="$(get_system_id)"
+
+  local system_version
+  system_version="$(get_system_version)"
 
   if ! is_fedora_rawhide; then
     skip "This test is only for Fedora Rawhide"

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -203,7 +203,9 @@ teardown() {
 @test "run: Ensure that the default container is used" {
   test -z "${name+x}"
 
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+
   create_default_container
   create_container other-container
 
@@ -227,7 +229,9 @@ teardown() {
   assert_success
   assert_output ""
 
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+
   create_default_container
   create_container other-container
 
@@ -246,7 +250,9 @@ teardown() {
 }
 
 @test "run: Ensure that $HOME is used as a fallback working directory" {
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+
   create_default_container
 
   pushd /etc/kernel
@@ -275,7 +281,8 @@ teardown() {
 }
 
 @test "run: Try the non-existent default container with none other present" {
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
 
   run --separate-stderr "$TOOLBOX" run true
 
@@ -289,7 +296,8 @@ teardown() {
 }
 
 @test "run: Try the non-existent default container with another present" {
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
 
   create_container other-container
 
@@ -574,7 +582,9 @@ teardown() {
 
 @test "run: Try a non-default distro without a release" {
   local distro="fedora"
-  local system_id="$(get_system_id)"
+
+  local system_id
+  system_id="$(get_system_id)"
 
   if [ "$system_id" = "fedora" ]; then
     distro="rhel"
@@ -600,7 +610,9 @@ teardown() {
 }
 
 @test "run: Pass down 1 invalid file descriptor" {
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+
   create_default_container
 
   # File descriptors 3 and 4 are reserved by Bats.

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -37,7 +37,8 @@ teardown() {
 }
 
 @test "enter: Try to enter the default container with more than 1 other containers present" {
-  local default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
 
   create_container first
   create_container second
@@ -127,7 +128,9 @@ teardown() {
 
 @test "enter: Try to enter a container based on non-default distro without providing a version" {
   local distro="fedora"
-  local system_id="$(get_system_id)"
+
+  local system_id
+  system_id="$(get_system_id)"
 
   if [ "$system_id" = "fedora" ]; then
     distro="rhel"

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -33,8 +33,11 @@ setup_suite() {
     return 1
   fi
 
-  local system_id="$(get_system_id)"
-  local system_version="$(get_system_version)"
+  local system_id
+  system_id="$(get_system_id)"
+
+  local system_version
+  system_version="$(get_system_version)"
 
   _setup_environment
   # Cache the default image for the system


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
```
  Line 624:
  local system_id="$(get_system_id)"
        ^-------^ SC2155 (warning): Declare and assign separately to
                  avoid masking return values.
```

See: https://www.shellcheck.net/wiki/SC2155