### PR TITLE
test/system: Silence SC2034

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -439,7 +439,9 @@ function container_started() {
   # Used as a return value
   container_initialized=1
 
-  for TRIES in 1 2 3 4 5; do
+  local num_of_retries=5
+
+  for ((i = 0; i < num_of_retries; i++)); do
     run "$PODMAN" logs "$container_name"
 
     # Look for last line of the container startup log


### PR DESCRIPTION
Otherwise https://www.shellcheck.net/ would complain:
```
  Line 442:
  for TRIES in 1 2 3 4 5; do
  ^-^ SC2034 (warning): TRIES appears unused. Verify use (or export if
      used externally).
```

See: https://www.shellcheck.net/wiki/SC2034

This also makes the code consistent with the rest.