### PR TITLE
test/system: Avoid future problems caused by Bat's 'run' overwriting 'i'

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -107,6 +107,8 @@ function _pull_and_cache_distro_image() {
     assert_success
   fi
 
+  local -i j
+
   for ((j = 0; j < num_of_retries; j++)); do
     run "$SKOPEO" copy --dest-compress "docker://${image}" "dir:${IMAGE_CACHE_DIR}/${image_archive}"
 
@@ -439,6 +441,7 @@ function container_started() {
   # Used as a return value
   container_initialized=1
 
+  local -i j
   local num_of_retries=5
 
   for ((j = 0; j < num_of_retries; j++)); do

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -107,7 +107,7 @@ function _pull_and_cache_distro_image() {
     assert_success
   fi
 
-  for ((i = num_of_retries; i > 0; i--)); do
+  for ((i = 0; i < num_of_retries; i++)); do
     run "$SKOPEO" copy --dest-compress "docker://${image}" "dir:${IMAGE_CACHE_DIR}/${image_archive}"
 
     if [ "$status" -eq 0 ]; then

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -107,7 +107,7 @@ function _pull_and_cache_distro_image() {
     assert_success
   fi
 
-  for ((i = 0; i < num_of_retries; i++)); do
+  for ((j = 0; j < num_of_retries; j++)); do
     run "$SKOPEO" copy --dest-compress "docker://${image}" "dir:${IMAGE_CACHE_DIR}/${image_archive}"
 
     if [ "$status" -eq 0 ]; then
@@ -441,7 +441,7 @@ function container_started() {
 
   local num_of_retries=5
 
-  for ((i = 0; i < num_of_retries; i++)); do
+  for ((j = 0; j < num_of_retries; j++)); do
     run "$PODMAN" logs "$container_name"
 
     # Look for last line of the container startup log


### PR DESCRIPTION
Until Bats 1.10.0, `run` with options had a bug where it would overwrite
the value of the `i` variable even outside `run` [1].

In these particular instances, no options are being passed to 'run',
and, hence, currently there's no problem.  However, in case a future
commit adds an option, then it could lead to hard-to-debug problems.
eg., `--separate-stderr` sets `i` to 1, `--show-output-of-passing-tests`
sets it to 2, etc..  Therefore, depending on the flag and the loop, the
loop might get terminated prematurely or run infinitely or something
else.

Moreover, Bats 1.10.0 is only available in Fedora >= 39 and is absent
from Fedoras 37 and 38.  Therefore, it's not possible to consider this
bug fixed.

Hence, it's better to preemptively work around it to avoid any future
issues.

[1] Bats commit 502dc47dd063c187
    https://github.com/bats-core/bats-core/commit/502dc47dd063c187
    https://github.com/bats-core/bats-core/issues/726