### PR TITLE
test/system: Make it easier to debug why a container didn't initialize

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -461,6 +461,7 @@ function container_started() {
       ret_val=0
       break
     fi
+
     sleep 1
   done
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -436,10 +436,9 @@ function container_started() {
   local container_name
   container_name="$1"
 
-  start_container "$container_name"
+  local -i ret_val=1
 
-  # Used as a return value
-  local -i container_initialized=1
+  start_container "$container_name"
 
   local -i j
   local num_of_retries=5
@@ -450,13 +449,13 @@ function container_started() {
     # Look for last line of the container startup log
     # shellcheck disable=SC2154
     if echo "$output" | grep "Listening to file system and ticker events"; then
-      container_initialized=0
+      ret_val=0
       break
     fi
     sleep 1
   done
 
-  return "$container_initialized"
+  return "$ret_val"
 }
 
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -439,7 +439,7 @@ function container_started() {
   start_container "$container_name"
 
   # Used as a return value
-  container_initialized=1
+  local -i container_initialized=1
 
   local -i j
   local num_of_retries=5

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -444,11 +444,20 @@ function container_started() {
   local num_of_retries=5
 
   for ((j = 0; j < num_of_retries; j++)); do
-    run "$PODMAN" logs "$container_name"
+    run --separate-stderr "$PODMAN" logs "$container_name"
+
+    # shellcheck disable=SC2154
+    if [ "$status" -ne 0 ]; then
+      fail "Failed to invoke '$PODMAN logs'"
+      [ "$output" != "" ] && echo "$output"
+      [ "$stderr" != "" ] && echo "$stderr" >&2
+      ret_val="$status"
+      break
+    fi
 
     # Look for last line of the container startup log
     # shellcheck disable=SC2154
-    if echo "$output" | grep "Listening to file system and ticker events"; then
+    if echo "$output $stderr" | grep "Listening to file system and ticker events"; then
       ret_val=0
       break
     fi

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -449,8 +449,6 @@ function container_started() {
     # shellcheck disable=SC2154
     if [ "$status" -ne 0 ]; then
       fail "Failed to invoke '$PODMAN logs'"
-      [ "$output" != "" ] && echo "$output"
-      [ "$stderr" != "" ] && echo "$stderr" >&2
       ret_val="$status"
       break
     fi
@@ -464,6 +462,15 @@ function container_started() {
 
     sleep 1
   done
+
+  if [ "$ret_val" -ne 0 ]; then
+    if [ "$j" -eq "$num_of_retries" ]; then
+      fail "Failed to initialize container $container_name"
+    fi
+
+    [ "$output" != "" ] && echo "$output"
+    [ "$stderr" != "" ] && echo "$stderr" >&2
+  fi
 
   return "$ret_val"
 }


### PR DESCRIPTION
Currently, if a Toolbx container's entry point fails to initialize the
container, there's no way to see the debug logs and error messages from
the entry point:
```
  not ok 106 container: Check container starts without issues
  # (from function `assert_success' in file
       test/system/libs/bats-assert/src/assert.bash, line 114,
  #  in test file test/system/103-container.bats, line 39)
  #   `assert_success' failed
  #
  # -- command failed --
  # status : 1
  # output :
  # --
  #
```

Instead, from now on, they will be visible:
```
  not ok 106 container: Check container starts without issues
  # (from function `assert_success' in file
       test/system/libs/bats-assert/src/assert.bash, line 114,
  #  in test file test/system/103-container.bats, line 39)
  #   `assert_success' failed
  #
  # -- command failed --
  # status : 1
  # output (90 lines):
  #   Failed to initialize container fedora-toolbox-38
  #   level=debug msg="Running as real user ID 0"
  #   level=debug msg="Resolved absolute path to the executable as
        /usr/bin/toolbox"
  #   level=debug msg="TOOLBOX_PATH is /opt/bin/toolbox"
  #   level=debug msg="Migrating to newer Podman"
  #   level=debug msg="Migration not needed: running inside a container"
  #   level=debug msg="Setting up configuration"
  #   ...
  # --
  #
```