### PR TITLE
test/system: Ensure failure if an invalid distribution is specified

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -88,6 +88,7 @@ function _pull_and_cache_distro_image() {
 
   if [ -z "${IMAGES[$distro]+x}" ]; then
     fail "Requested distro (${distro}) does not have a matching image"
+    return 1
   fi
 
   image="${IMAGES[$distro]}"
@@ -309,6 +310,7 @@ function pull_distro_image() {
 
   if [ -z "${IMAGES[$distro]+x}" ]; then
     fail "Requested distro (${distro}) does not have a matching image"
+    return 1
   fi
 
   image="${IMAGES[$distro]}"

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -218,7 +218,10 @@ function _setup_docker_registry() {
 # Stop, removes and cleans after a locally hosted Docker registry
 function _clean_docker_registry() {
   # Stop Docker registry container
-  "$PODMAN" --root "${DOCKER_REG_ROOT}" stop --time 0 "${DOCKER_REG_NAME}"
+  if "$PODMAN" --root "$DOCKER_REG_ROOT" container exists "$DOCKER_REG_NAME"; then
+    "$PODMAN" --root "${DOCKER_REG_ROOT}" stop --time 0 "${DOCKER_REG_NAME}"
+  fi
+
   # Clean up Podman's registry root state
   "$PODMAN" --root "${DOCKER_REG_ROOT}" rm --all --force
   "$PODMAN" --root "${DOCKER_REG_ROOT}" rmi --all --force

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -56,7 +56,7 @@ function _setup_containers_storage() {
 
 
 function _clean_temporary_storage() {
-  "$PODMAN" system reset -f
+  "$PODMAN" system reset --force
 
   rm --force --recursive "${ROOTLESS_PODMAN_STORE_DIR}"
   rm --force --recursive "${ROOTLESS_PODMAN_RUNROOT_DIR}"

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -56,7 +56,7 @@ function _setup_containers_storage() {
 
 
 function _clean_temporary_storage() {
-  "$PODMAN" system reset --force
+  "$PODMAN" system reset --force >/dev/null
 
   rm --force --recursive "${ROOTLESS_PODMAN_STORE_DIR}"
   rm --force --recursive "${ROOTLESS_PODMAN_RUNROOT_DIR}"


### PR DESCRIPTION
Contrary to what the documentation might seem to imply [1], Bats' `fai`' helper only aborts a test case under certain circumstances.  eg., when called from `setup_suite()`, but not from within a child function, and a `@test` case, but not from within the `run` helper.

If `fail` is called from within `run`, then the code after it will continue to execute.  The test case will only fail if `run` eventually catches a non-zero exit code that's caught by `assert_success` [2]. Similarly, it doesn't abort if called from within a child function in `setup_suite()`.

Currently, `_pull_and_cache_distro_image()` is a child function called from `setup_suite()`.  So `fail` won't abort if an invalid distribution is specified.

Fortunately, `pull_distro_image()` is being called from within `@test` cases, but outside `run`.  So, there's no problem with it now.  However, some future code changes can unknowingly alter this reality and it too can run into unexpected behaviour.

Therefore, it's better to be safe, and explicitly specify a non-zero exit code after `fail`.  It will ensure that it works as expected under all circumstances.

[1] https://github.com/bats-core/bats-support

[2] https://github.com/bats-core/bats-assert