### PR TITLE
test/system: Unbreak the 'help' tests on Fedora >= 39 with GNU roff 1.23

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,7 +51,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 3600
+    timeout: 4800
     nodeset:
       nodes:
         - name: fedora-rawhide
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-39
     description: Run Toolbx's system tests in Fedora 39
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-39
@@ -73,7 +73,7 @@
 - job:
     name: system-test-fedora-38
     description: Run Toolbx's system tests in Fedora 38
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-38
@@ -84,7 +84,7 @@
 - job:
     name: system-test-fedora-37
     description: Run Toolbx's system tests in Fedora 37
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-37

--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -54,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* golang shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -78,4 +78,4 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang flatpak-session-helper
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man flatpak-session-helper

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -54,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -24,14 +24,14 @@ setup() {
 }
 
 @test "help: Try to run toolbox with no command" {
-  run "$TOOLBOX"
+  run --keep-empty-lines "$TOOLBOX"
 
   assert_failure
   assert_line --index 0 "Error: missing command"
-  assert_line --index 1 "create    Create a new toolbox container"
-  assert_line --index 2 "enter     Enter an existing toolbox container"
-  assert_line --index 3 "list      List all existing toolbox containers and images"
-  assert_line --index 4 "Run 'toolbox --help' for usage."
+  assert_line --index 2 "create    Create a new toolbox container"
+  assert_line --index 3 "enter     Enter an existing toolbox container"
+  assert_line --index 4 "list      List all existing toolbox containers and images"
+  assert_line --index 6 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Run command 'help'" {
@@ -39,7 +39,7 @@ setup() {
     skip "Test works only if man is in PATH"
   fi
 
-  run "$TOOLBOX" help
+  run --keep-empty-lines "$TOOLBOX" help
 
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
@@ -51,26 +51,26 @@ setup() {
     skip "Test works only if man is not in PATH"
   fi
 
-  run "$TOOLBOX" help
+  run --keep-empty-lines "$TOOLBOX" help
 
   assert_success
   assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
-  assert_line --index 1 "Common commands are:"
-  assert_line --index 2 "create    Create a new toolbox container"
-  assert_line --index 3 "enter     Enter an existing toolbox container"
-  assert_line --index 4 "list      List all existing toolbox containers and images"
-  assert_line --index 5 "Go to https://github.com/containers/toolbox for further information."
+  assert_line --index 2 "Common commands are:"
+  assert_line --index 3 "create    Create a new toolbox container"
+  assert_line --index 4 "enter     Enter an existing toolbox container"
+  assert_line --index 5 "list      List all existing toolbox containers and images"
+  assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
 }
 
 @test "help: Use flag '--help' (it should show usage screen)" {
-  run "$TOOLBOX" --help
+  run --keep-empty-lines "$TOOLBOX" --help
 
   assert_success
   assert_output --partial "toolbox - Tool for containerized command line environments on Linux"
 }
 
 @test "help: Try to run toolbox with non-existent command (shows usage screen)" {
-  run "$TOOLBOX" foo
+  run --keep-empty-lines "$TOOLBOX" foo
 
   assert_failure
   assert_line --index 0 "Error: unknown command \"foo\" for \"toolbox\""
@@ -78,7 +78,7 @@ setup() {
 }
 
 @test "help: Try to run toolbox with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" --foo
+  run --keep-empty-lines "$TOOLBOX" --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -86,7 +86,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox create' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" create --foo
+  run --keep-empty-lines "$TOOLBOX" create --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -94,7 +94,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox enter' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" enter --foo
+  run --keep-empty-lines "$TOOLBOX" enter --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -102,7 +102,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox help' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" help --foo
+  run --keep-empty-lines "$TOOLBOX" help --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -110,7 +110,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox init-container' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" init-container --foo
+  run --keep-empty-lines "$TOOLBOX" init-container --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -118,7 +118,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox list' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" list --foo
+  run --keep-empty-lines "$TOOLBOX" list --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -126,7 +126,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox rm' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" rm --foo
+  run --keep-empty-lines "$TOOLBOX" rm --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -134,7 +134,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox rmi' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" rmi --foo
+  run --keep-empty-lines "$TOOLBOX" rmi --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"
@@ -142,7 +142,7 @@ setup() {
 }
 
 @test "help: Try to run 'toolbox run' with non-existent flag (shows usage screen)" {
-  run "$TOOLBOX" run --foo
+  run --keep-empty-lines "$TOOLBOX" run --foo
 
   assert_failure
   assert_line --index 0 "Error: unknown flag: --foo"

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -62,11 +62,42 @@ setup() {
   assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
 }
 
-@test "help: Use flag '--help' (it should show usage screen)" {
+@test "help: Use flag '--help'" {
+  if ! command -v man 2>/dev/null; then
+    skip "not found man(1)"
+  fi
+
   run --keep-empty-lines "$TOOLBOX" --help
 
   assert_success
-  assert_output --partial "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 0 --partial "toolbox(1)"
+  assert_line --index 0 --partial "General Commands Manual"
+  assert_line --index 3 --partial "toolbox - Tool for containerized command line environments on Linux"
+}
+
+@test "help: Use flag '--help' with man(1) absent" {
+  if command -v man 2>/dev/null; then
+    skip "found man(1)"
+  fi
+
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" --help
+
+  assert_success
+  assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 2 "Common commands are:"
+  assert_line --index 3 "create    Create a new toolbox container"
+  assert_line --index 4 "enter     Enter an existing toolbox container"
+  assert_line --index 5 "list      List all existing toolbox containers and images"
+  assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 8 ]
+  else
+    assert [ ${#lines[@]} -eq 9 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "help: Try to run toolbox with non-existent command (shows usage screen)" {

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -24,9 +24,10 @@ setup() {
 }
 
 @test "help: Try to run toolbox with no command" {
-  run --keep-empty-lines "$TOOLBOX"
+  run --keep-empty-lines --separate-stderr "$TOOLBOX"
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: missing command"
   assert_line --index 2 "create    Create a new toolbox container"
   assert_line --index 3 "enter     Enter an existing toolbox container"
@@ -39,7 +40,7 @@ setup() {
     skip "Test works only if man is in PATH"
   fi
 
-  run --keep-empty-lines "$TOOLBOX" help
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" help
 
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
@@ -51,7 +52,7 @@ setup() {
     skip "Test works only if man is not in PATH"
   fi
 
-  run --keep-empty-lines "$TOOLBOX" help
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" help
 
   assert_success
   assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
@@ -67,7 +68,7 @@ setup() {
     skip "not found man(1)"
   fi
 
-  run --keep-empty-lines "$TOOLBOX" --help
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" --help
 
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
@@ -101,81 +102,91 @@ setup() {
 }
 
 @test "help: Try to run toolbox with non-existent command (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown command \"foo\" for \"toolbox\""
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run toolbox with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox create' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" create --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" create --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox enter' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" enter --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" enter --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox help' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" help --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" help --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox init-container' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" init-container --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" init-container --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox list' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" list --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox rm' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" rm --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rm --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox rmi' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" rmi --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "help: Try to run 'toolbox run' with non-existent flag (shows usage screen)" {
-  run --keep-empty-lines "$TOOLBOX" run --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --foo
 
   assert_failure
+  lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -23,7 +23,7 @@ setup() {
   _setup_environment
 }
 
-@test "help: Try to run toolbox with no command" {
+@test "help: Smoke test" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX"
 
   assert_failure
@@ -37,9 +37,9 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 7 ]
 }
 
-@test "help: Run command 'help'" {
+@test "help: Command 'help'" {
   if ! command -v man 2>/dev/null; then
-    skip "Test works only if man is in PATH"
+    skip "not found man(1)"
   fi
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" help
@@ -52,9 +52,9 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "help: Run command 'help' with no man present" {
+@test "help: Command 'help' with man(1) absent" {
   if command -v man 2>/dev/null; then
-    skip "Test works only if man is not in PATH"
+    skip "found man(1)"
   fi
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" help
@@ -70,7 +70,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "help: Use flag '--help'" {
+@test "help: Flag '--help'" {
   if ! command -v man 2>/dev/null; then
     skip "not found man(1)"
   fi
@@ -85,7 +85,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "help: Use flag '--help' with man(1) absent" {
+@test "help: Flag '--help' with man(1) absent" {
   if command -v man 2>/dev/null; then
     skip "found man(1)"
   fi
@@ -110,7 +110,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "help: Try to run toolbox with non-existent command (shows usage screen)" {
+@test "help: Try unknown command" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" foo
 
   assert_failure
@@ -121,7 +121,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run toolbox with non-existent flag (shows usage screen)" {
+@test "help: Try unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" --foo
 
   assert_failure
@@ -132,7 +132,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox create' with non-existent flag (shows usage screen)" {
+@test "help: Try 'create' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" create --foo
 
   assert_failure
@@ -143,7 +143,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox enter' with non-existent flag (shows usage screen)" {
+@test "help: Try 'enter' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" enter --foo
 
   assert_failure
@@ -154,7 +154,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox help' with non-existent flag (shows usage screen)" {
+@test "help: Try 'help' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" help --foo
 
   assert_failure
@@ -165,7 +165,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox init-container' with non-existent flag (shows usage screen)" {
+@test "help: Try 'init-container' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" init-container --foo
 
   assert_failure
@@ -176,7 +176,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox list' with non-existent flag (shows usage screen)" {
+@test "help: Try 'list' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" list --foo
 
   assert_failure
@@ -187,7 +187,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox rm' with non-existent flag (shows usage screen)" {
+@test "help: Try 'rm' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rm --foo
 
   assert_failure
@@ -198,7 +198,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox rmi' with non-existent flag (shows usage screen)" {
+@test "help: Try 'rmi' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --foo
 
   assert_failure
@@ -209,7 +209,7 @@ setup() {
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
-@test "help: Try to run 'toolbox run' with non-existent flag (shows usage screen)" {
+@test "help: Try 'run' with unknown flag" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" run --foo
 
   assert_failure

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -27,12 +27,14 @@ setup() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX"
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: missing command"
   assert_line --index 2 "create    Create a new toolbox container"
   assert_line --index 3 "enter     Enter an existing toolbox container"
   assert_line --index 4 "list      List all existing toolbox containers and images"
   assert_line --index 6 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 7 ]
 }
 
 @test "help: Run command 'help'" {
@@ -45,6 +47,8 @@ setup() {
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
   assert_line --index 0 --partial "General Commands Manual"
+  assert [ ${#lines[@]} -gt 4 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "help: Run command 'help' with no man present" {
@@ -61,6 +65,8 @@ setup() {
   assert_line --index 4 "enter     Enter an existing toolbox container"
   assert_line --index 5 "list      List all existing toolbox containers and images"
   assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
+  assert [ ${#lines[@]} -eq 8 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "help: Use flag '--help'" {
@@ -74,6 +80,8 @@ setup() {
   assert_line --index 0 --partial "toolbox(1)"
   assert_line --index 0 --partial "General Commands Manual"
   assert_line --index 3 --partial "toolbox - Tool for containerized command line environments on Linux"
+  assert [ ${#lines[@]} -gt 4 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "help: Use flag '--help' with man(1) absent" {
@@ -105,88 +113,108 @@ setup() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown command \"foo\" for \"toolbox\""
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run toolbox with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox create' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" create --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox enter' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" enter --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox help' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" help --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox init-container' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" init-container --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox list' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" list --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox rm' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rm --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox rmi' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }
 
 @test "help: Try to run 'toolbox run' with non-existent flag (shows usage screen)" {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" run --foo
 
   assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: unknown flag: --foo"
   assert_line --index 1 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
 }

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -47,6 +47,7 @@ setup() {
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
   assert_line --index 0 --partial "General Commands Manual"
+  assert_line --index 3 --partial "toolbox - Tool for containerized command line environments on Linux"
   assert [ ${#lines[@]} -gt 4 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -97,7 +97,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -115,7 +121,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -428,7 +440,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "$default_image"
   assert_line --index 2 --partial "$default_image-copy"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -447,7 +465,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "$default_image"
   assert_line --index 2 --partial "$default_image-copy"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -477,7 +501,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 2 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check containers
@@ -487,7 +517,13 @@ teardown() {
   assert_line --index 1 --partial "$default_container"
   assert_line --index 2 --partial "non-default-one"
   assert_line --index 3 --partial "non-default-two"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check all together
@@ -499,7 +535,13 @@ teardown() {
   assert_line --index 5 --partial "$default_container"
   assert_line --index 6 --partial "non-default-one"
   assert_line --index 7 --partial "non-default-two"
-  assert [ ${#lines[@]} -eq 9 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 8 ]
+  else
+    assert [ ${#lines[@]} -eq 9 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -521,7 +563,13 @@ teardown() {
   assert_line --index 1 --partial "<none>"
   assert_line --index 2 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 3 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -539,7 +587,13 @@ teardown() {
   assert_line --index 1 --partial "<none>"
   assert_line --index 2 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 3 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 


### PR DESCRIPTION
See:
https://github.com/cpuguy83/go-md2man/issues/99
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1049968