### PR TITLE
test/system: Unbreak the line count checks with Bats >= 1.10.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,7 +51,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbox's system tests in Fedora Rawhide
-    timeout: 3600
+    timeout: 4800
     nodeset:
       nodes:
         - name: fedora-rawhide
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-39
     description: Run Toolbx's system tests in Fedora 39
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-39
@@ -73,7 +73,7 @@
 - job:
     name: system-test-fedora-38
     description: Run Toolbx's system tests in Fedora 38
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-38
@@ -84,7 +84,7 @@
 - job:
     name: system-test-fedora-37
     description: Run Toolbx's system tests in Fedora 37
-    timeout: 2400
+    timeout: 3000
     nodeset:
       nodes:
         - name: fedora-37

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -97,7 +97,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -115,7 +121,13 @@ teardown() {
 
   assert_success
   assert_line --index 1 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 3 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -428,7 +440,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "$default_image"
   assert_line --index 2 --partial "$default_image-copy"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -447,7 +465,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "$default_image"
   assert_line --index 2 --partial "$default_image-copy"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -477,7 +501,13 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 2 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 4 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 3 ]
+  else
+    assert [ ${#lines[@]} -eq 4 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check containers
@@ -487,7 +517,13 @@ teardown() {
   assert_line --index 1 --partial "$default_container"
   assert_line --index 2 --partial "non-default-one"
   assert_line --index 3 --partial "non-default-two"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check all together
@@ -499,7 +535,13 @@ teardown() {
   assert_line --index 5 --partial "$default_container"
   assert_line --index 6 --partial "non-default-one"
   assert_line --index 7 --partial "non-default-two"
-  assert [ ${#lines[@]} -eq 9 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 8 ]
+  else
+    assert [ ${#lines[@]} -eq 9 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -521,7 +563,13 @@ teardown() {
   assert_line --index 1 --partial "<none>"
   assert_line --index 2 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 3 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -539,7 +587,13 @@ teardown() {
   assert_line --index 1 --partial "<none>"
   assert_line --index 2 --partial "registry.fedoraproject.org/fedora-toolbox:34"
   assert_line --index 3 --partial "$default_image"
-  assert [ ${#lines[@]} -eq 5 ]
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 4 ]
+  else
+    assert [ ${#lines[@]} -eq 5 ]
+  fi
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 


### PR DESCRIPTION
Until Bats 1.10.0, 'run --keep-empty-lines' had a bug where it counted the trailing newline on the last line as a separate line [1].  However, Bats 1.10.0 is only available in Fedora >= 39 and is absent from Fedoras 37 and 38.

[1] Bats commit 6648e2143bffb933
    https://github.com/bats-core/bats-core/commit/6648e2143bffb933
    https://github.com/bats-core/bats-core/issues/708