### PR TITLE
images: Update the tests for Fedora 39

### DIFF
--- a/images/fedora/f39/ensure-files
+++ b/images/fedora/f39/ensure-files
@@ -13,9 +13,8 @@
 /usr/share/man/ko/man1/pstree.1*
 /usr/share/man/man1/pstree.1*
 
-/usr/share/man/fr/man8/rpm.8*
-/usr/share/man/ja/man8/rpm.8*
 /usr/share/man/man8/rpm.8*
+/usr/share/man/man8/rpm2cpio.8*
 
 /usr/share/man/man1/cal.1.*
 /usr/share/man/man1/getopt.1*


### PR DESCRIPTION
The translations for the RPM manuals were removed upstream during the RPM 4.19 development cycle [1].  So, replace them with rpm2cpio(8), which is another popular command shipped by the rpm package.

[1] RPM commit 4df74a9644b18136
    https://github.com/rpm-software-management/rpm/commit/4df74a9644b18136
    https://github.com/rpm-software-management/rpm/pull/2245