### PR TITLE
test/system: Unbreak the manual page checks with GNU roff >= 1.23

### DIFF
--- a/gen-docs-list
+++ b/gen-docs-list
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2019 - 2022 Red Hat, Inc.
+# Copyright © 2019 – 2022 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -47,7 +47,7 @@ setup() {
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
   assert_line --index 0 --partial "General Commands Manual"
-  assert_line --index 3 --partial "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 3 --regexp "^[[:blank:]]+toolbox [‐-] Tool for containerized command line environments on Linux$"
   assert [ ${#lines[@]} -gt 4 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
@@ -80,7 +80,7 @@ setup() {
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
   assert_line --index 0 --partial "General Commands Manual"
-  assert_line --index 3 --partial "toolbox - Tool for containerized command line environments on Linux"
+  assert_line --index 3 --regexp "^[[:blank:]]+toolbox [‐-] Tool for containerized command line environments on Linux$"
   assert [ ${#lines[@]} -gt 4 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }


### PR DESCRIPTION
GNU roff 1.23 stopped remapping unescaped Hyphen-Minus (ie., - or 0x2D)
characters in the input to Hyphen-Minus in the output.  Instead, it
follows the specified behaviour of converting unescaped Hyphen-Minus
characters in the input to Hyphen (ie., ‐ or 0x2010) in the output.  To
get Hyphen-Minus characters in the output, one needs to escape the
Hyphen-Minus with a backslash (ie., \-) in the input [1].

Therefore, the command line options documented in the manuals are no
longer prefixed with the Hyphen-Minus character that's needed to
ctually use them.  This breaks copying and pasting from the manuals and
searching within them.

Unfortunately, escaping the Hyphen-Minus characters in Markdown doesn't
have the intended effect of having Hyphen-Minus in the generated manual
pages [2].  Therefore, this is worked around by having the tests check
for both Hyphen-Minus and Hyphen.

Note that some operating system distributions, like Debian, have
reverted this change from GNU roff, but others haven't.  So, unless it
can be guaranteed that the manuals will always have Hyphen-Minus
regardless of which GNU roff version or variant is being used, the tests
need to check for both.

[1] https://lwn.net/Articles/947941/
    https://lists.gnu.org/archive/html/info-gnu/2023-07/msg00001.html
    https://git.savannah.gnu.org/cgit/groff.git/tree/PROBLEMS?h=1.23.0#n82

[2] https://github.com/cpuguy83/go-md2man/issues/101