### PR TITLE
Add support for creating toolboxes from Containerfile

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -6,6 +6,7 @@ toolbox\-create - Create a new toolbox container
 ## SYNOPSIS
 **toolbox create** [*--authfile FILE*]
                [*--distro DISTRO* | *-d DISTRO*]
+               [*--file CONTAINERFILE* | *-f CONTAINERFILE*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
                [*CONTAINER*]
@@ -95,6 +96,12 @@ Create a toolbox container for a different operating system DISTRO than the
 host. Cannot be used with `--image`. Has to be coupled with `--release` unless
 the selected DISTRO matches the host.
 
+**--file** CONTAINERFILE, **-f** CONTAINERFILE
+
+Create a toolbox container from a Containerfile. If used with `--image`, then
+the built image will be tagged with that value, otherwise the current directory
+name will be used.
+
 **--image** NAME, **-i** NAME
 
 Change the NAME of the image used to create the toolbox container. This is
@@ -134,6 +141,12 @@ $ toolbox create --image bar foo
 
 ```
 $ toolbox create --authfile ~/auth.json --image registry.example.com/bar
+```
+
+### Create a custom toolbox container from a Containerfile
+
+```
+$ toolbox create --file Containerfile
 ```
 
 ## SEE ALSO


### PR DESCRIPTION
This adds a new flag to `toolbox create`, `-f, --file`, which allows the user to create a toolbox from the given Containerfile. If `--image` is provided, then that is the name that is used to tag the container. If `--container` is provided, then that is used as the name of the newly created container. If either of those parameters are absent, then the name of the current directory is used in its place. I used the following `Containerfile` to test this, which installs the dependencies needed to build `toolbox`:

<details>
<summary>Containerfile</summary>
<pre><code>
FROM registry.fedoraproject.org/fedora-toolbox:39

ENV NAME=toolbox-dev VERSION=39
LABEL com.github.containers.toolbox=true \\
      com.redhat.component="$NAME" \\
      name="$NAME" \\
      version="$VERSION" \\
      usage="This is a toolbox development container" \\
      summary="Container used for development of the toolbox tool itself" \\
      maintainer="William Brawner <me@wbrawner.com>"

RUN dnf install -y golang \\
        clang \\
        meson \\
        ninja-build \\
        go-md2man \\
        shadow-utils-subid-devel
</code></pre>
</details>

Of note with this is I found that using `registry.fedoraproject.org/fedora` instead of `registry.fedoraproject.org/fedora-toolbox` led to errors in toolbox initialization. Should we attempt to detect this and print a warning to the user to ensure they have the necessary packages installed in order for toolbox to work?

This closes #1397.

