### PR TITLE
utils.go: bump fedora fallback version to 38

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -64,7 +64,7 @@ const (
 	containerNamePrefixFallback = "fedora-toolbox"
 	distroFallback              = "fedora"
 	idTruncLength               = 12
-	releaseFallback             = "37"
+	releaseFallback             = "38"
 )
 
 const (


### PR DESCRIPTION
37 will EOL soon