### PR TITLE
cmd/create: Support passing --device option to podman-create

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -8,6 +8,7 @@ toolbox\-create - Create a new Toolbx container
                [*--distro DISTRO* | *-d DISTRO*]
                [*--image NAME* | *-i NAME*]
                [*--release RELEASE* | *-r RELEASE*]
+               [*--device DEVICE*]
                [*CONTAINER*]
 
 ## DESCRIPTION
@@ -110,6 +111,12 @@ remote registry.
 Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `--image`.
 
+**--device** DEVICE
+
+Add a host device to the container. Passed as is to podman-create(1).
+This option can be specified multiple times or
+multiple comma-separated arguments can be specified.
+
 ## EXAMPLES
 
 ### Create the default Toolbx container matching the host OS
@@ -134,6 +141,12 @@ $ toolbox create --image bar foo
 
 ```
 $ toolbox create --authfile ~/auth.json --image registry.example.com/bar
+```
+
+### Create the default toolbox container with nvidia CDI device
+
+```
+$ toolbox create --device=nvidia.com/gpu=all
 ```
 
 ## SEE ALSO

--- a/doc/toolbox.conf.5.md
+++ b/doc/toolbox.conf.5.md
@@ -31,6 +31,11 @@ remote registry.
 Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `image`.
 
+**devices** = ["DEVICE", ...]
+
+Add a host device to the container. Accepts a list of devices.
+Each device specification is assed as is to podman-create(1).
+
 ## FILES
 
 The following locations are looked up in increasing order of priority:

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -216,7 +216,7 @@ func runCommand(container string,
 				return nil
 			}
 
-			if err := createContainer(container, image, release, "", false); err != nil {
+			if err := createContainer(container, image, release, "", nil, false); err != nil {
 				return err
 			}
 		} else if containersCount == 1 && defaultContainer {


### PR DESCRIPTION
This allows to use CDI infrastructure, which often does more then just mapping devices in `/dev` -
for NVIDIA this will additionally map a set of libraries into container (which are essential to use the device without a hassle).

Since this is only a pass-through, maybe instead of having a `--device` specific option  we should have an ability to pass arbitrary option to `podman-create`? Like after `toolbox create -c my-container -- --device foo:bar --other-podman-option`?

Fixes: #116 (although it is possible to use nvidia devices inside toolboxes - this change improves the usability significantly when using NVIDIA CTK+CDI with toolbox)