### PR TITLE
test/system: switch HOME fallback to tmp dir (fix for Ubuntu hosts)

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -255,15 +255,21 @@ teardown() {
 
   create_default_container
 
-  pushd /etc/kernel
+  local host_only_dir
+  host_only_dir="$(mktemp --directory /var/tmp/toolbox-test-XXXXXXXXXX)"
+
+  pushd "$host_only_dir"
   run --separate-stderr "$TOOLBOX" run pwd
   popd
+
+  rm --force --recursive "$host_only_dir"
 
   assert_success
   assert_line --index 0 "$HOME"
   assert [ ${#lines[@]} -eq 1 ]
   lines=("${stderr_lines[@]}")
-  assert_line --index $((${#stderr_lines[@]}-2)) "Error: directory /etc/kernel not found in container $default_container_name"
+  assert_line --index $((${#stderr_lines[@]}-2)) \
+    "Error: directory $host_only_dir not found in container $default_container_name"
   assert_line --index $((${#stderr_lines[@]}-1)) "Using $HOME instead."
   assert [ ${#stderr_lines[@]} -gt 2 ]
 }


### PR DESCRIPTION
The test "run: Ensure that $HOME is used as a fallback working directory" assumes `/etc/kernel` will not be present in containers, but this is not the case for Ubuntu (and Debian) containers. This patch switches the test to using a temporary directory (under `/var/tmp` which is not mounted by toolboxes) to ensure fallback is activated.