### PR TITLE
Don't block user interaction while fetching the image size

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -44,7 +44,7 @@ jobs:
             fish \
             gcc \
             go-md2man \
-            golang \
+            golang-1.20 \
             meson \
             ninja-build \
             openssl \
@@ -53,6 +53,10 @@ jobs:
             skopeo \
             systemd \
             udisks2
+
+      - name: Set up PATH for Go 1.20
+        run: |
+          echo "PATH=/usr/lib/go-1.20/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: Checkout Bats
         uses: actions/checkout@v3

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -28,12 +28,12 @@ import (
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/skopeo"
+	"github.com/containers/toolbox/pkg/term"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/docker/go-units"
 	"github.com/godbus/dbus/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 const (
@@ -449,10 +449,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 	}
 
 	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
-
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && term.IsTerminal(stdoutFdInt) {
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && term.IsTerminal(os.Stdout) {
 		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
 		s.Writer = os.Stdout
 		s.Start()
@@ -731,9 +728,7 @@ func pullImage(image, release, authFile string) (bool, error) {
 
 	logrus.Debugf("Pulling image %s", imageFull)
 
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && term.IsTerminal(stdoutFdInt) {
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel && term.IsTerminal(os.Stdout) {
 		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond)
 		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
 		s.Writer = os.Stdout

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -17,6 +17,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -573,7 +574,8 @@ func getFullyQualifiedImageFromRepoTags(image string) (string, error) {
 }
 
 func getImageSizeFromRegistry(imageFull string) (string, error) {
-	image, err := skopeo.Inspect(imageFull)
+	ctx := context.Background()
+	image, err := skopeo.Inspect(ctx, imageFull)
 	if err != nil {
 		return "", err
 	}

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ import (
 	"text/tabwriter"
 
 	"github.com/containers/toolbox/pkg/podman"
+	"github.com/containers/toolbox/pkg/term"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 type toolboxContainer struct {
@@ -247,11 +247,9 @@ func listOutput(images []podman.Image, containers []toolboxContainer) {
 		const defaultColor = "\033[0;00m" // identical to resetColor, but same length as boldGreenColor
 		const resetColor = "\033[0m"
 
-		stdoutFd := os.Stdout.Fd()
-		stdoutFdInt := int(stdoutFd)
 		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 
-		if term.IsTerminal(stdoutFdInt) {
+		if term.IsTerminal(os.Stdout) {
 			fmt.Fprintf(writer, "%s", defaultColor)
 		}
 
@@ -263,7 +261,7 @@ func listOutput(images []podman.Image, containers []toolboxContainer) {
 			"STATUS",
 			"IMAGE NAME")
 
-		if term.IsTerminal(stdoutFdInt) {
+		if term.IsTerminal(os.Stdout) {
 			fmt.Fprintf(writer, "%s", resetColor)
 		}
 
@@ -275,7 +273,7 @@ func listOutput(images []podman.Image, containers []toolboxContainer) {
 				isRunning = container.Status == "running"
 			}
 
-			if term.IsTerminal(stdoutFdInt) {
+			if term.IsTerminal(os.Stdout) {
 				var color string
 				if isRunning {
 					color = boldGreenColor
@@ -293,7 +291,7 @@ func listOutput(images []podman.Image, containers []toolboxContainer) {
 				container.Status,
 				container.Image)
 
-			if term.IsTerminal(stdoutFdInt) {
+			if term.IsTerminal(os.Stdout) {
 				fmt.Fprintf(writer, "%s", resetColor)
 			}
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -166,6 +166,7 @@ func runCommand(container string,
 	preserveFDs uint,
 	command []string,
 	emitEscapeSequence, fallbackToBash, pedantic bool) error {
+
 	if !pedantic {
 		if image == "" {
 			panic("image not specified")
@@ -300,6 +301,7 @@ func runCommandWithFallbacks(container string,
 	preserveFDs uint,
 	command []string,
 	emitEscapeSequence, fallbackToBash bool) error {
+
 	logrus.Debug("Checking if 'podman exec' supports disabling the detach keys")
 
 	var detachKeysSupported bool
@@ -485,6 +487,7 @@ func constructExecArgs(container, preserveFDs string,
 	fallbackToBash bool,
 	ttyNeeded bool,
 	workDir string) []string {
+
 	logLevelString := podman.LogLevel.String()
 
 	execArgs := []string{

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
+	"github.com/containers/toolbox/pkg/term"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"golang.org/x/term"
 )
 
 var (
@@ -317,13 +317,7 @@ func runCommandWithFallbacks(container string,
 	var stderr io.Writer
 	var ttyNeeded bool
 
-	stdinFd := os.Stdin.Fd()
-	stdinFdInt := int(stdinFd)
-
-	stdoutFd := os.Stdout.Fd()
-	stdoutFdInt := int(stdoutFd)
-
-	if term.IsTerminal(stdinFdInt) && term.IsTerminal(stdoutFdInt) {
+	if term.IsTerminal(os.Stdin) && term.IsTerminal(os.Stdout) {
 		ttyNeeded = true
 		if logLevel := logrus.GetLevel(); logLevel >= logrus.DebugLevel {
 			stderr = os.Stderr

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -55,29 +55,15 @@ var (
 func askForConfirmation(prompt string) bool {
 	var retVal bool
 
-	for {
-		fmt.Printf("%s ", prompt)
+	ctx := context.Background()
+	retValCh, errCh := askForConfirmationAsync(ctx, prompt, nil)
 
-		var response string
-
-		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Split(bufio.ScanLines)
-		if scanner.Scan() {
-			response = scanner.Text()
-		}
-
-		if response == "" {
-			response = "n"
-		} else {
-			response = strings.ToLower(response)
-		}
-
-		if response == "no" || response == "n" {
-			break
-		} else if response == "yes" || response == "y" {
-			retVal = true
-			break
-		}
+	select {
+	case val := <-retValCh:
+		retVal = val
+	case err := <-errCh:
+		logrus.Debugf("Failed to ask for confirmation: %s", err)
+		retVal = false
 	}
 
 	return retVal

--- a/src/go.mod
+++ b/src/go.mod
@@ -14,5 +14,4 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.1.0
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/containers/toolbox
 
-go 1.14
+go 1.20
 
 require (
 	github.com/HarryMichal/go-version v1.0.1
@@ -14,4 +14,26 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.1.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -203,7 +203,6 @@ github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pf
 github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0eJc8R6ouapiM=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.11.0/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
-github.com/hashicorp/consul/api v1.12.0/go.mod h1:6pVBMo0ebnYdt2S3H87XhekM/HHrUoTD2XXb/VrZVy0=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -319,7 +318,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.3.0/go.mod h1:uD/D+6UF4SrIR1uGEv7bBNkNqLGqUr43MRiaGWX1Nig=
-github.com/sagikazarmark/crypt v0.4.0/go.mod h1:ALv2SRj7GxYV4HO9elxH9nS6M9gW+xDNxqmyJ6RfDFM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
@@ -551,7 +549,6 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211205182925-97ca703d548d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -658,7 +655,6 @@ google.golang.org/api v0.57.0/go.mod h1:dVPlbZyBo2/OjBpmvNdpn2GRm6rPy75jyU7bmhdr
 google.golang.org/api v0.59.0/go.mod h1:sT2boj7M9YJxZzgeZqXogmhfmRWDtPzT31xkieUbuZU=
 google.golang.org/api v0.61.0/go.mod h1:xQRti5UdCmoCEqFxcz93fTl338AVqDgyaDRuOZ3hg9I=
 google.golang.org/api v0.62.0/go.mod h1:dKmwPCydfsad4qCH08MSdgWjfHOyfpd4VtDGgRFdavw=
-google.golang.org/api v0.63.0/go.mod h1:gs4ij2ffTRXwuzzgJl/56BdwJaA194ijkfn++9tDuPo=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -756,7 +752,6 @@ google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnD
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/src/go.sum
+++ b/src/go.sum
@@ -555,8 +555,6 @@ golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
-golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/src/meson.build
+++ b/src/meson.build
@@ -24,6 +24,8 @@ sources = files(
   'pkg/shell/shell.go',
   'pkg/shell/shell_test.go',
   'pkg/skopeo/skopeo.go',
+  'pkg/term/term.go',
+  'pkg/term/term_test.go',
   'pkg/utils/libsubid-wrappers.c',
   'pkg/utils/errors.go',
   'pkg/utils/utils.go',

--- a/src/pkg/skopeo/skopeo.go
+++ b/src/pkg/skopeo/skopeo.go
@@ -18,6 +18,7 @@ package skopeo
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	"github.com/containers/toolbox/pkg/shell"
@@ -30,13 +31,13 @@ type Image struct {
 	LayersData []Layer
 }
 
-func Inspect(target string) (*Image, error) {
+func Inspect(ctx context.Context, target string) (*Image, error) {
 	var stdout bytes.Buffer
 
 	targetWithTransport := "docker://" + target
 	args := []string{"inspect", "--format", "json", targetWithTransport}
 
-	if err := shell.Run("skopeo", nil, &stdout, nil, args...); err != nil {
+	if err := shell.RunContext(ctx, "skopeo", nil, &stdout, nil, args...); err != nil {
 		return nil, err
 	}
 

--- a/src/pkg/term/term.go
+++ b/src/pkg/term/term.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2023 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package term
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func GetState(file *os.File) (*unix.Termios, error) {
+	fileFD := file.Fd()
+	fileFDInt := int(fileFD)
+	state, err := unix.IoctlGetTermios(fileFDInt, unix.TCGETS)
+	return state, err
+}
+
+func IsTerminal(file *os.File) bool {
+	if _, err := GetState(file); err != nil {
+		return false
+	}
+
+	return true
+}

--- a/src/pkg/term/term_test.go
+++ b/src/pkg/term/term_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2023 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package term
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTerminalTemporaryFile(t *testing.T) {
+	dir := t.TempDir()
+	file, err := os.CreateTemp(dir, "TestIsTerminalTempFile")
+	assert.NoError(t, err)
+	fileName := file.Name()
+	defer os.Remove(fileName)
+	defer file.Close()
+
+	ok := IsTerminal(file)
+	assert.False(t, ok)
+}
+
+func TestIsTerminalTerminal(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	ok := IsTerminal(file)
+	assert.True(t, ok)
+}

--- a/src/pkg/term/term_test.go
+++ b/src/pkg/term/term_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 func TestIsTerminalTemporaryFile(t *testing.T) {
@@ -42,4 +43,98 @@ func TestIsTerminalTerminal(t *testing.T) {
 
 	ok := IsTerminal(file)
 	assert.True(t, ok)
+}
+
+func TestNewStateFromDifferent(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	oldState, err := GetState(file)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(unix.ECHO), oldState.Lflag&unix.ECHO)
+	assert.Equal(t, uint32(unix.ICANON), oldState.Lflag&unix.ICANON)
+	assert.NotEqual(t, uint8(13), oldState.Cc[unix.VMIN])
+	assert.NotEqual(t, uint8(42), oldState.Cc[unix.VTIME])
+
+	newState := NewStateFrom(oldState, WithVMIN(13), WithVTIME(42), WithoutECHO(), WithoutICANON())
+	assert.Empty(t, newState.Lflag&unix.ECHO)
+	assert.Empty(t, newState.Lflag&unix.ICANON)
+	assert.Equal(t, uint8(13), newState.Cc[unix.VMIN])
+	assert.Equal(t, uint8(42), newState.Cc[unix.VTIME])
+}
+
+func TestNewStateFromNOP(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	oldState, err := GetState(file)
+	assert.NoError(t, err)
+
+	newState := NewStateFrom(oldState)
+	assert.Equal(t, oldState.Cc, newState.Cc)
+	assert.Equal(t, oldState.Cflag, newState.Cflag)
+	assert.Equal(t, oldState.Iflag, newState.Iflag)
+	assert.Equal(t, oldState.Ispeed, newState.Ispeed)
+	assert.Equal(t, oldState.Lflag, newState.Lflag)
+	assert.Equal(t, oldState.Line, newState.Line)
+	assert.Equal(t, oldState.Oflag, newState.Oflag)
+	assert.Equal(t, oldState.Ospeed, newState.Ospeed)
+}
+
+func TestSetStateDifferent(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	oldState, err := GetState(file)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(unix.ECHO), oldState.Lflag&unix.ECHO)
+	assert.Equal(t, uint32(unix.ICANON), oldState.Lflag&unix.ICANON)
+	assert.NotEqual(t, uint8(13), oldState.Cc[unix.VMIN])
+	assert.NotEqual(t, uint8(42), oldState.Cc[unix.VTIME])
+
+	newState := NewStateFrom(oldState, WithVMIN(13), WithVTIME(42), WithoutECHO(), WithoutICANON())
+	assert.Empty(t, newState.Lflag&unix.ECHO)
+	assert.Empty(t, newState.Lflag&unix.ICANON)
+	assert.Equal(t, uint8(13), newState.Cc[unix.VMIN])
+	assert.Equal(t, uint8(42), newState.Cc[unix.VTIME])
+
+	err = SetState(file, newState)
+	assert.NoError(t, err)
+
+	newState2, err := GetState(file)
+	assert.NoError(t, err)
+	assert.Equal(t, newState.Cc, newState2.Cc)
+	assert.Equal(t, newState.Cflag, newState2.Cflag)
+	assert.Equal(t, newState.Iflag, newState2.Iflag)
+	assert.Equal(t, newState.Ispeed, newState2.Ispeed)
+	assert.Equal(t, newState.Lflag, newState2.Lflag)
+	assert.Equal(t, newState.Line, newState2.Line)
+	assert.Equal(t, newState.Oflag, newState2.Oflag)
+	assert.Equal(t, newState.Ospeed, newState2.Ospeed)
+}
+
+func TestSetStateNOP(t *testing.T) {
+	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
+	assert.NoError(t, err)
+	defer file.Close()
+
+	oldState, err := GetState(file)
+	assert.NoError(t, err)
+
+	err = SetState(file, oldState)
+	assert.NoError(t, err)
+
+	newState, err := GetState(file)
+	assert.NoError(t, err)
+	assert.Equal(t, oldState.Cc, newState.Cc)
+	assert.Equal(t, oldState.Cflag, newState.Cflag)
+	assert.Equal(t, oldState.Iflag, newState.Iflag)
+	assert.Equal(t, oldState.Ispeed, newState.Ispeed)
+	assert.Equal(t, oldState.Lflag, newState.Lflag)
+	assert.Equal(t, oldState.Line, newState.Line)
+	assert.Equal(t, oldState.Oflag, newState.Oflag)
+	assert.Equal(t, oldState.Ospeed, newState.Ospeed)
 }


### PR DESCRIPTION
It takes `skopeo inspect` a few seconds to fetch the image size from the
remote registry, and while that happens the user can't interact with the
image download prompt:
```
  $ toolbox create
  Image required to create toolbox container.
  <wait for a few seconds>
  Download registry.fedoraproject.org/fedora-toolbox:39 (359.8MB)? [y/N]:
```

This feels awkward because it's not clear to the user what's going on
during those few seconds.  Moreover, while knowing the image size can be
convenient at times, for example when disk space and network bandwidth
are limited, it's not always important.

It will be better if `skopeo inspect` ran in the background, while
waiting for the user to respond to the image download prompt, and once
the image size has been fetched, the prompt can be updated to include
it.

So, initially:
```
  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 (...)? [y/N]:
```

... and then once the size is available:
```
  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 (359.8MB)? [y/N]:
```

If skopeo(1) is missing or too old, then the prompt can continue without
the size, as it did before:
```
  $ toolbox create
  Image required to create toolbox container.
  Download registry.fedoraproject.org/fedora-toolbox:39 [y/N]:
```

https://github.com/containers/toolbox/issues/752
https://github.com/containers/toolbox/issues/1263