### PR TITLE
README.md, images/fedora: Unbreak OSTree URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the Wayland and X11 sockets, networking (including Avahi), removable devices
 udev database, etc..
 
 This is particularly useful on
-[OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
+[OSTree](https://ostreedev.github.io/ostree/) based operating systems like
 [Fedora CoreOS](https://coreos.fedoraproject.org/) and
 [Silverblue](https://silverblue.fedoraproject.org/). The intention of these
 systems is to discourage installation of software on the host, and instead

--- a/images/fedora/f38/README.md
+++ b/images/fedora/f38/README.md
@@ -10,7 +10,7 @@ the Wayland and X11 sockets, networking (including Avahi), removable devices
 udev database, etc..
 
 This is particularly useful on
-[OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
+[OSTree](https://ostreedev.github.io/ostree/) based operating systems like
 [Fedora CoreOS](https://coreos.fedoraproject.org/) and
 [Silverblue](https://silverblue.fedoraproject.org/). The intention of these
 systems is to discourage installation of software on the host, and instead

--- a/images/fedora/f39/README.md
+++ b/images/fedora/f39/README.md
@@ -10,7 +10,7 @@ the Wayland and X11 sockets, networking (including Avahi), removable devices
 udev database, etc..
 
 This is particularly useful on
-[OSTree](https://ostree.readthedocs.io/en/latest/) based operating systems like
+[OSTree](https://ostreedev.github.io/ostree/) based operating systems like
 [Fedora CoreOS](https://coreos.fedoraproject.org/) and
 [Silverblue](https://silverblue.fedoraproject.org/). The intention of these
 systems is to discourage installation of software on the host, and instead


### PR DESCRIPTION
Only the images for currently maintained Fedoras (ie., 38 and 39) were updated.

https://github.com/containers/toolbox/issues/1417