### PR TITLE
cmd/utils: Increase buffer size when discarding terminal input

### DIFF
--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -204,7 +205,7 @@ func discardInputAsync(ctx context.Context) (<-chan int, <-chan error) {
 				if pollFDs[0].Revents&unix.POLLIN != 0 {
 					logrus.Debug("Returned from /dev/stdin: POLLIN")
 
-					buffer := make([]byte, 1)
+					buffer := make([]byte, bytes.MinRead)
 					n, err := os.Stdin.Read(buffer)
 					total += n
 


### PR DESCRIPTION
Without a sufficient buffer size the discard function does not read fast/efficiently enough causing multiple lines indicating "passed and discarded input" to show up.

I used an already defined constant[0] for the buffer size to prevent the use of a yet-another magical constant.

[0] https://pkg.go.dev/bytes#pkg-constants