### PR TITLE
cmd/create: Require valid terminal when prompting to pull an image

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -730,6 +730,16 @@ func pullImage(image, release, authFile string) (bool, error) {
 	}
 
 	if promptForDownload {
+		if !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
+			var builder strings.Builder
+			fmt.Fprintf(&builder, "image required to create toolbox container.\n")
+			fmt.Fprintf(&builder, "Use option '--assumeyes' to download the image.\n")
+			fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
+
+			errMsg := builder.String()
+			return false, errors.New(errMsg)
+		}
+
 		shouldPullImage = showPromptForDownload(imageFull)
 	}
 


### PR DESCRIPTION
To limit the possible misbehaviour of Toolbx when ued in scripting, require the presence of valid terminal on stdin when an image needs to be pulled to create a new toolbx.