### PR TITLE
cmd: Let the terminal know the active container on all host OSes

### DIFF
--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2023 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,33 +124,7 @@ func enter(cmd *cobra.Command, args []string) error {
 
 	command := []string{userShell, "-l"}
 
-	hostID, err := utils.GetHostID()
-	if err != nil {
-		return fmt.Errorf("failed to get the host ID: %w", err)
-	}
-
-	hostVariantID, err := utils.GetHostVariantID()
-	if err != nil {
-		return errors.New("failed to get the host VARIANT_ID")
-	}
-
-	var emitEscapeSequence bool
-
-	if hostID == "fedora" && (hostVariantID == "silverblue" || hostVariantID == "workstation") {
-		emitEscapeSequence = true
-	} else if hostID == "fedora-asahi-remix" {
-		emitEscapeSequence = true
-	}
-
-	if err := runCommand(container,
-		defaultContainer,
-		image,
-		release,
-		0,
-		command,
-		emitEscapeSequence,
-		true,
-		false); err != nil {
+	if err := runCommand(container, defaultContainer, image, release, 0, command, true, true, false); err != nil {
 		return err
 	}
 

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -1,5 +1,5 @@
 //
-// Copyright © 2021 – 2022 Red Hat Inc.
+// Copyright © 2021 – 2023 Red Hat Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -72,33 +72,7 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 
 	command := []string{userShell, "-l"}
 
-	hostID, err := utils.GetHostID()
-	if err != nil {
-		return fmt.Errorf("failed to get the host ID: %w", err)
-	}
-
-	hostVariantID, err := utils.GetHostVariantID()
-	if err != nil {
-		return errors.New("failed to get the host VARIANT_ID")
-	}
-
-	var emitEscapeSequence bool
-
-	if hostID == "fedora" && (hostVariantID == "silverblue" || hostVariantID == "workstation") {
-		emitEscapeSequence = true
-	} else if hostID == "fedora-asahi-remix" {
-		emitEscapeSequence = true
-	}
-
-	if err := runCommand(container,
-		true,
-		image,
-		release,
-		0,
-		command,
-		emitEscapeSequence,
-		true,
-		false); err != nil {
+	if err := runCommand(container, true, image, release, 0, command, true, true, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Prompt is a new terminal emulation application [1] designed for a container-oriented desktop that implements the OSC 777 escape sequence to track and preserve the user's current Toolbx container [2].  Hence, Fedora's fork of GNOME Terminal is no longer the only one to offer this.

Therefore, it's time let users of all host operating systems enjoy this feature.

This reverts commits a3e8d8d12bac6dd63010b71c6e091486fb585f37 and 3a96feba478448cd0c5628238619c3805c6aca1e.

[1] https://gitlab.gnome.org/chergert/prompt

[2] https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/17

https://github.com/containers/toolbox/issues/218