### PR TITLE
test/system: Test that the HOSTNAME environment variable is set

### DIFF
--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -439,3 +439,129 @@ teardown() {
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
+
+@test "environment variables: HOSTNAME inside the default container" {
+  create_default_container
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 --regexp "^(toolbox|$HOSTNAME)$"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbox"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "$HOSTNAME"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside RHEL 8.7" {
+  create_distro_container rhel 8.7 rhel-toolbox-8.7
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbox"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbox"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbox"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbox"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,6 +57,182 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "environment variables: HISTFILESIZE inside Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside RHEL 8.7" {
+  create_distro_container rhel 8.7 rhel-toolbox-8.7
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 \
+                                             bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 \
+                                             bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 \
+                                             bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "environment variables: HISTSIZE inside the default container" {
   skip "https://pagure.io/setup/pull-request/48"
 
@@ -87,35 +263,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HISTSIZE inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -134,35 +281,6 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HISTFILESIZE inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -205,35 +323,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HISTSIZE inside RHEL 8.7" {
   skip "https://pagure.io/setup/pull-request/48"
 
@@ -254,36 +343,6 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HISTFILESIZE inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 \
-                                             bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -324,36 +383,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 \
-                                             bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HISTSIZE inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -372,35 +401,6 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HISTFILESIZE inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 \
-                                             bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]


### PR DESCRIPTION
Bash automatically sets the `HOSTNAME` environment variable to the name of
the current host [1] as returned by `gethostname(2)`, which is the same as
`hostname(1)`.

However, on Fedora, from Fedora 33 onwards, `/etc/profile` sets the
`HOSTNAME` environment variable to `hostnamectl --transient` [2], and,
from Fedora 35 onwards, it has a fallback to `hostname(1)` [3].  These two
approaches return different values when used inside a Toolbx container.
The former picks up the hostname of the host operating system, while the
fallback gets the name that was set when creating the container with
`podman create --hostname toolbox ...`.

Hence, the value of `HOSTNAME` inside a Toolbx container for Fedora
depends on whether the corresponding version of the `fedora-toolbox` image
contained `hostnamectl(1)` or not.

[1] https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html

[2] setup commit eb9cc4dce89be24f
    https://pagure.io/setup/c/eb9cc4dce89be24f
    https://bugzilla.redhat.com/show_bug.cgi?id=1745245

[3] setup commit ddd74b5d971a734c
    https://pagure.io/setup/c/ddd74b5d971a734c
    https://pagure.io/setup/pull-request/28
    https://bugzilla.redhat.com/show_bug.cgi?id=1938223

https://github.com/containers/toolbox/issues/558