### PR TITLE
test/system: Replace the RHEL toolbox:8.7 image with toolbox:8.9

### DIFF
--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1,4 +1,3 @@
-
 # shellcheck shell=bats
 #
 # Copyright © 2019 – 2024 Red Hat, Inc.

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1,7 +1,7 @@
 
 # shellcheck shell=bats
 #
-# Copyright © 2019 – 2023 Red Hat, Inc.
+# Copyright © 2019 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -167,18 +167,18 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+fedora-toolbox-34"
 }
 
-@test "create: RHEL 8.7" {
-  pull_distro_image rhel 8.7
+@test "create: RHEL 8.9" {
+  pull_distro_image rhel 8.9
 
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.7
+  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.9
 
   assert_success
-  assert_output --partial "Created container: rhel-toolbox-8.7"
-  assert_output --partial "Enter with: toolbox enter rhel-toolbox-8.7"
+  assert_output --partial "Created container: rhel-toolbox-8.9"
+  assert_output --partial "Enter with: toolbox enter rhel-toolbox-8.9"
 
   run podman ps -a
 
-  assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.7"
+  assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.9"
 }
 
 @test "create: Ubuntu 16.04" {

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2019 – 2023 Red Hat, Inc.
+# Copyright © 2019 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -215,8 +215,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "list: RHEL 8.7 image" {
-  pull_distro_image rhel 8.7
+@test "list: RHEL 8.9 image" {
+  pull_distro_image rhel 8.9
 
   local num_of_images
   num_of_images="$(list_images)"
@@ -225,7 +225,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" list
 
   assert_success
-  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.7"
+  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 2 ]
@@ -236,8 +236,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "list: RHEL 8.7 image (using --images)" {
-  pull_distro_image rhel 8.7
+@test "list: RHEL 8.9 image (using --images)" {
+  pull_distro_image rhel 8.9
 
   local num_of_images
   num_of_images="$(list_images)"
@@ -246,7 +246,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
 
   assert_success
-  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.7"
+  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 2 ]

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -89,10 +89,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "run: Smoke test with RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "run: Smoke test with RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 true
+  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -116,10 +116,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: /etc/resolv.conf inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "network: /etc/resolv.conf inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -348,7 +348,7 @@ teardown() {
   fi
 }
 
-@test "network: DNS inside RHEL 8.7" {
+@test "network: DNS inside RHEL 8.9" {
   local ipv4_skip=false
   local ipv4_addr
   if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
@@ -365,12 +365,12 @@ teardown() {
     skip "DNS not working on host"
   fi
 
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   if ! $ipv4_skip; then
     run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
       --distro rhel \
-      --release 8.7 \
+      --release 8.9 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" A k.root-servers.net
 
     assert_success
@@ -388,7 +388,7 @@ teardown() {
   if ! $ipv6_skip; then
     run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
       --distro rhel \
-      --release 8.7 \
+      --release 8.9 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
 
     assert_success
@@ -620,10 +620,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: ping(8) inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "network: ping(8) inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,14 +105,14 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: root in shadow(5) inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.7)"
+@test "user: root in shadow(5) inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
 
-  "$TOOLBOX" run --distro rhel --release 8.7 true
+  "$TOOLBOX" run --distro rhel --release 8.9 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.7
+  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
 
   assert_success
   assert_line --regexp '^root::.+$'
@@ -230,16 +230,16 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in passwd(5) inside RHEL 8.7" {
+@test "user: $USER in passwd(5) inside RHEL 8.9" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
 
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -360,14 +360,14 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in shadow(5) inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.7)"
+@test "user: $USER in shadow(5) inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
 
-  "$TOOLBOX" run --distro rhel --release 8.7 true
+  "$TOOLBOX" run --distro rhel --release 8.9 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.7
+  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
 
   assert_success
   refute_line --regexp "^$USER:.*$"
@@ -467,10 +467,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in group(5) inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "user: $USER in group(5) inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 cat /etc/group
 
   assert_success
   assert_line --regexp "^wheel:x:[[:digit:]]+:$USER$"

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -121,7 +121,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: session bus inside RHEL 8.7" {
+@test "dbus: session bus inside RHEL 8.9" {
   local expected_response
   expected_response="$(gdbus call \
                          --session \
@@ -129,11 +129,11 @@ teardown() {
                          --object-path /org/freedesktop/DBus \
                          --method org.freedesktop.DBus.Peer.Ping)"
 
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
     --distro rhel \
-    --release 8.7 \
+    --release 8.9 \
     gdbus call \
       --session \
       --dest org.freedesktop.DBus \
@@ -314,7 +314,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: system bus inside RHEL 8.7" {
+@test "dbus: system bus inside RHEL 8.9" {
   local expected_response
   expected_response="$(gdbus call \
                          --system \
@@ -324,11 +324,11 @@ teardown() {
                          org.freedesktop.systemd1.Manager \
                          Version)"
 
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
     --distro rhel \
-    --release 8.7 \
+    --release 8.9 \
     gdbus call \
       --system \
       --dest org.freedesktop.systemd1 \

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -115,8 +115,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "environment variables: HISTFILESIZE inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
@@ -129,7 +129,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -323,10 +323,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTSIZE inside RHEL 8.7" {
+@test "environment variables: HISTSIZE inside RHEL 8.9" {
   skip "https://pagure.io/setup/pull-request/48"
 
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
@@ -339,7 +339,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -494,11 +494,11 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HOSTNAME inside RHEL 8.7" {
-  create_distro_container rhel 8.7 rhel-toolbox-8.7
+@test "environment variables: HOSTNAME inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.7 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HOSTNAME"'
 
   assert_success
   assert_line --index 0 "toolbox"

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ setup_suite() {
   # Cache all images that will be needed during the tests
   _pull_and_cache_distro_image arch latest || false
   _pull_and_cache_distro_image fedora 34 || false
-  _pull_and_cache_distro_image rhel 8.7 || false
+  _pull_and_cache_distro_image rhel 8.9 || false
   _pull_and_cache_distro_image ubuntu 16.04 || false
   _pull_and_cache_distro_image ubuntu 18.04 || false
   _pull_and_cache_distro_image ubuntu 20.04 || false


### PR DESCRIPTION
Red Hat Enterprise Linux 8.7 reached End of Life on 31st May 2023: https://access.redhat.com/articles/4038291
https://access.redhat.com/support/policy/updates/errata

Since the tests are intended for Toolbx, not the Red Hat infrastructure, it will be better to use a newer image, because it will be closer to what the users are seeing.