### PR TITLE
Fix pacman cache removal in Arch image

### DIFF
--- a/images/arch/Containerfile
+++ b/images/arch/Containerfile
@@ -13,7 +13,7 @@ RUN pacman -Syu --needed --noconfirm - < extra-packages
 RUN rm /extra-packages
 
 # Clean up cache
-RUN pacman -Scc --noconfirm
+RUN yes | pacman -Scc
 
 # Enable sudo permission for wheel users
 RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox


### PR DESCRIPTION
The `--noconfirm` pacman flag automatically accepts the default answer for each questions and the default answer to removing cached packages when using `pacman -Scc` is "N" (no).
That means that `pacman -Scc --noconfirm` does not actually remove cached packages.

Since pacman doesn't have a way to choose to answer yes or no automatically *(yet?)*, a simple workaround is to use `yes | pacman -Scc ` instead. However, while it is [recommended to set `pipefail` when using pipes](https://docs.docker.com/develop/develop-images/instructions/#using-pipes), it is not possible with the `yes` command (see [this comment](https://stackoverflow.com/a/70852402) for more details).  
Although, it should be safe to just use a piped `yes` without setting `pipefail` as I don't see how it could be a cause of failure in that particular case.

If using a pipe without setting `pipefail` is a concern, one can simply run `rm -f /var/cache/pacman/pkg/*` instead.  
I can adapt this PR accordingly if needed.

I remain available if needed :slightly_smiling_face: 