### PR TITLE
build: Do not use use auto dependencies for shell completion scripts

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ skopeo = find_program('skopeo', required: false)
 
 bashcompletionsdir = get_option('bash_completions_dir')
 if bashcompletionsdir == ''
-  bash_completion_dep = dependency('bash-completion', required: false)
+  bash_completion_dep = dependency('bash-completion', required: get_option('bash_completions'))
   if bash_completion_dep.found()
     bashcompletionsdir = bash_completion_dep.get_variable(pkgconfig: 'completionsdir')
   endif
@@ -37,7 +37,7 @@ endif
 
 fishcompletionsdir = get_option('fish_completions_dir')
 if fishcompletionsdir == ''
-  fish_completion_dep = dependency('fish', required: false)
+  fish_completion_dep = dependency('fish', required: get_option('fish_completions'))
   if fish_completion_dep.found()
     fishcompletionsdir = fish_completion_dep.get_variable(pkgconfig: 'completionsdir')
   endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,19 @@
 option(
+  'bash_completions',
+  description: 'Install Bash completion scripts',
+  type: 'feature',
+)
+
+option(
   'bash_completions_dir',
   description: 'Directory for Bash completion scripts',
   type: 'string',
+)
+
+option(
+  'fish_completions',
+  description: 'Install fish completion scripts',
+  type: 'feature',
 )
 
 option(


### PR DESCRIPTION
It is difficult for downstream to track dependencies when they are automatic. This results in shell completion scripts not being installed in packages because builders do not have the right dependency. This commit adds meson feature arguments to guard those dependencies so that downstream distributions can use `-Dauto_features=enabled`.

For more explanation, see rule #3 of:
https://blogs.gnome.org/mcatanzaro/2022/07/15/best-practices-for-build-options/