### PR TITLE
Honor XDG_RUNTIME_DIR if variable is set

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -547,7 +547,8 @@ func GetRuntimeDirectory(targetUser *user.User) (string, error) {
 
 	if uid == 0 {
 		runtimeDirectory = "/run"
-	} else {
+	} 
+	if _, ok := os.LookupEnv("XDG_RUNTIME_DIR"); ok {
 		runtimeDirectory = os.Getenv("XDG_RUNTIME_DIR")
 	}
 


### PR DESCRIPTION
Podman unshare sets uid to zero. Podman [documentation](https://docs.podman.io/en/latest/markdown/podman-unshare.1.html)

But the root filesystem (/) is not always writeable. Creating directory **/run/toolbox** can fail. We can set **XDG_RUNTIME_DIR** and not have to write to root (/)

![image](https://github.com/containers/toolbox/assets/5769910/af4c0005-85c5-4495-b5f6-9e2f7c2f8776)



