### PR TITLE
images/fedora: Add cracklib-dicts to Fedora 38 and 39

### DIFF
--- a/images/fedora/f38/ensure-files
+++ b/images/fedora/f38/ensure-files
@@ -6,6 +6,9 @@
 /usr/share/man/man1/cp.1*
 /usr/share/man/man1/ls.1*
 
+/usr/share/cracklib/cracklib-small.pwd*
+/usr/share/cracklib/pw_dict.pwd*
+
 /usr/share/man/man8/dnf.8*
 /usr/share/man/man5/dnf.conf.5*
 

--- a/images/fedora/f38/extra-packages
+++ b/images/fedora/f38/extra-packages
@@ -1,6 +1,7 @@
 bash-completion
 bc
 bzip2
+cracklib-dicts
 diffutils
 dnf-plugins-core
 findutils

--- a/images/fedora/f38/missing-docs
+++ b/images/fedora/f38/missing-docs
@@ -33,6 +33,7 @@ libassuan
 libblkid
 libcap
 libcap-ng
+libcomps
 libdb
 libdnf
 libeconf

--- a/images/fedora/f39/ensure-files
+++ b/images/fedora/f39/ensure-files
@@ -6,6 +6,9 @@
 /usr/share/man/man1/cp.1*
 /usr/share/man/man1/ls.1*
 
+/usr/share/cracklib/cracklib-small.pwd*
+/usr/share/cracklib/pw_dict.pwd*
+
 /usr/share/man/man8/dnf.8*
 /usr/share/man/man5/dnf.conf.5*
 

--- a/images/fedora/f39/extra-packages
+++ b/images/fedora/f39/extra-packages
@@ -1,6 +1,7 @@
 bash-completion
 bc
 bzip2
+cracklib-dicts
 diffutils
 dnf-plugins-core
 findutils


### PR DESCRIPTION
Currently, the libpwquality package mentions cracklib-dicts as a weak dependency [1,2].  However, the libpwquality package is part of the fedora base image, which doesn't include weak dependencies [3], and that leads to cracklib-dicts going missing.

The absence of the cracklib-dicts package causes various operations that go through libpwquality (eg., pwmake(1)) to fail [1], and sometimes in confusing ways [4].

[1] Fedora libpwquality commit f84a5e3ba6c166e5
    https://src.fedoraproject.org/rpms/libpwquality/c/f84a5e3ba6c166e5
    https://bugzilla.redhat.com/show_bug.cgi?id=2158891

[2] Fedora libpwquality commit 303154338d6d3650
    https://src.fedoraproject.org/rpms/libpwquality/c/303154338d6d3650
    https://bugzilla.redhat.com/show_bug.cgi?id=2006063

[3] fedora-kickstarts commit 1c39c0adb0d44866
    https://pagure.io/fedora-kickstarts/c/1c39c0adb0d44866
    https://pagure.io/fedora-kickstarts/pull-request/551
    https://pagure.io/releng/issue/8530

[4] https://github.com/libpwquality/libpwquality/pull/85

https://github.com/containers/toolbox/issues/1351