### PR TITLE
Drop one "o" and rename the project as "Toolbx"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Toolbox's bug report template
+about: Toolbx's bug report template
 title: ''
 labels: 1. Bug
 assignees: ''
@@ -28,7 +28,7 @@ If applicable, add screenshots to help explain your problem.
 **Output of `toolbox --version` (v0.0.90+)**
 e.g., `toolbox version 0.0.90`
 
-**Toolbox package info (`rpm -q toolbox`)**
+**Toolbx package info (`rpm -q toolbox`)**
 e.g., `toolbox-0.0.18-2.fc32.noarch`
 
 **Output of `podman version`**
@@ -49,6 +49,6 @@ e.g., Fedora Silverblue 32
 **Additional context**
 Add any other context about the problem here.
 When did the issue start occurring? After an update (what packages were updated)?
-If the issue is about operating with containers/images (creating, using, deleting,..), share here what image you used. If you're unsure, share here the output of `toolbox list -i` (shows all toolbox images on your system).
+If the issue is about operating with containers/images (creating, using, deleting,..), share here what image you used. If you're unsure, share here the output of `toolbox list -i` (shows all Toolbx images on your system).
 
 If you see an error message saying: `Error: invalid entry point PID of container <name-of-container>`, add to the ticket output of command `podman start --attach <name-of-container>`.

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Toolbox's feature request template
+about: Toolbx's feature request template
 title: ''
 labels: 1. Feature request
 assignees: ''

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2020 – 2023 Red Hat, Inc.
+# Copyright © 2020 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 ---
 - job:
     name: unit-test
-    description: Run Toolbox's unit tests declared in Meson
+    description: Run Toolbx's unit tests declared in Meson
     timeout: 1800
     nodeset:
       nodes:
@@ -28,7 +28,7 @@
 
 - job:
     name: unit-test-migration-path-for-coreos-toolbox
-    description: Run Toolbox's unit tests declared in Meson when built with -Dmigration_path_for_coreos_toolbox
+    description: Run Toolbx's unit tests declared in Meson when built with -Dmigration_path_for_coreos_toolbox
     timeout: 600
     nodeset:
       nodes:
@@ -39,7 +39,7 @@
 
 - job:
     name: unit-test-restricted
-    description: Run Toolbox's unit tests declared in Meson in a restricted build environment
+    description: Run Toolbx's unit tests declared in Meson in a restricted build environment
     timeout: 1800
     nodeset:
       nodes:
@@ -50,7 +50,7 @@
 
 - job:
     name: system-test-fedora-rawhide
-    description: Run Toolbox's system tests in Fedora Rawhide
+    description: Run Toolbx's system tests in Fedora Rawhide
     timeout: 4800
     nodeset:
       nodes:

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
-## The Toolbox Project Community Code of Conduct
+## The Toolbx Project Community Code of Conduct
 
-The Toolbox project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
+The Toolbx project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 ![Contributing](data/gfx/CONTRIBUTING.gif)
 
-# Contributing to Toolbox
+# Contributing to Toolbx
 
-Thank you for wanting to contribute to Toolbox! We greatly appreciate your
+Thank you for wanting to contribute to Toolbx! We greatly appreciate your
 interest!
 
 # Reporting Bugs
@@ -13,7 +13,7 @@ interest!
   - If the issue is already reported and is marked as **OPEN**, comment on it
     and if possible and needed, share info about the issue just as if you were
     submitting a new issue
-  - If the issue is marked as **CLOSED**, check if your version of Toolbox is
+  - If the issue is marked as **CLOSED**, check if your version of Toolbx is
     up-to-date or if there are some steps, described in the closed issue, that
     you should follow. If you are still experiencing the issue, please file a
     new issue
@@ -37,14 +37,14 @@ When writing a bug report:
   reproduce it.
 - **Describe the behavior you received and what you expected** - Sometimes it
   may not be clear what the *right* behavior should look like.
-- **Provide info about the version of used software** - What version of Toolbox
+- **Provide info about the version of used software** - What version of Toolbx
   and Podman do you use?
 - **Provide info about your system** - What distribution do you use? Which
   desktop environment? Is it a VM or a real machine?
 
 # Making Suggestions
 
-Toolbox is not feature-complete and some of it's functionality is not-there-yet.
+Toolbx is not feature-complete and some of it's functionality is not-there-yet.
 We are thankful for all suggestions and ideas but be ready that your suggestion
 may be rejected.
 
@@ -63,7 +63,7 @@ may be rejected.
 When writing a suggestion:
 
 - **Use a clear and descriptive title**
-- **Describe the idea** - What parts of Toolbox does it affect? Is it a major
+- **Describe the idea** - What parts of Toolbx does it affect? Is it a major
   functionality or a minor tweak?
 - **Provide step-by-step description of the suggested behavior** so that we
   will understand.
@@ -72,13 +72,13 @@ When writing a suggestion:
 
 # First Contribution
 
-Toolbox is written in [Go](https://golang.org) and uses [Meson](https://mesonbuild.com)
+Toolbx is written in [Go](https://golang.org) and uses [Meson](https://mesonbuild.com)
 as it's buildsystem.
 
-Instructions for building Toolbox from source are in our [README](https://github.com/containers/toolbox/blob/main/README.md).
+Instructions for building Toolbx from source are in our [README](https://github.com/containers/toolbox/blob/main/README.md).
 
 > You may not need to build the project from source if your contribution is not
-> related to the code of Toolbox itself (e.g., documentation, updating CI
+> related to the code of Toolbx itself (e.g., documentation, updating CI
 > config, playing with image definitions,...).
 
 Here are some ideas of what you could contribute with:
@@ -88,18 +88,18 @@ Here are some ideas of what you could contribute with:
 - Write tests - Go has [tools](https://golang.org/pkg/testing/) for writing tests.
   There are also [some](https://github.com/stretchr/testify) [libraries](https://github.com/onsi/ginkgo)
   used for creating even more sophisticated tests.
-- Play with custom images - Toolbox currently officially works with Fedora-based
+- Play with custom images - Toolbx currently officially works with Fedora-based
   images. Ultimately there should be a wide variety of supported distro images.
   You can help with testing other people's image definitions or creating your
   own. **Beware**, maintainers still don't have a clear idea of how the image
   infrastructure should look like.
-- Write documentation - Some functions in Toolbox's code don't have comments and
-  it's not very clear what they do. Toolbox has it's [documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/)
+- Write documentation - Some functions in Toolbx's code don't have comments and
+  it's not very clear what they do. Toolbx has it's [documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/)
   hosted by Fedora. It's not very large and could use some attention.
 - Hack on the code and share the result - Seriously! Sometimes random ideas are
   the best.
 
-Toolbox currently does not have an infrastructure for translations. You can help
+Toolbx currently does not have an infrastructure for translations. You can help
 us to set it up!
 
 # Pull Requests
@@ -115,7 +115,7 @@ documentation, code comments and much more.
   code you're contributing to, consider opening another PR if you want to
   implement it yourself or file an issue so that somebody else can pick it up.
 - Update documentation to reflect your changes - Manual pages can be found in
-  directory `doc`. If your changes affect Toolbox's [documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/),
+  directory `doc`. If your changes affect Toolbx's [documentation](https://docs.fedoraproject.org/en-US/fedora-silverblue/toolbox/),
   consider creating a PR there (but to save yourself time, you can do it
   after your changes are accepted), too.
 - After creating a PR add to the bottom of all your commits a link to the PR. This helps the future maintainers find discussions around the changes.
@@ -131,16 +131,16 @@ If it takes us a very long time to even respond to your Pull Request, you can
 try to @ping us at our communication channels (see section #Communication).
 
 ## 
-Toolbox has a CI (Continuous Integration) setup for running tests. Their goal is to check if your
-changes don't affect adversely Toolbox's functionality. Sometimes these tests
+Toolbx has a CI (Continuous Integration) setup for running tests. Their goal is to check if your
+changes don't affect adversely Toolbx's functionality. Sometimes these tests
 mail fail with a false-positive. If you are not sure about the outcome of the
 tests, you can try to trigger a new test run by writing a comment with text `recheck` (really just that). If the issue persists, reach out to the maintainers!
 
-Toolbox's CI system is [Zuul](https://zuul-ci.org/) hosted at [softwarefactory](https://softwarefactory-project.io/). The CI is defined using [Ansible](https://www.ansible.com) playbooks. For more information on writing Zuul jobs see their [documentation](https://zuul-ci.org/docs/zuul/reference/user.html).
+Toolbx's CI system is [Zuul](https://zuul-ci.org/) hosted at [softwarefactory](https://softwarefactory-project.io/). The CI is defined using [Ansible](https://www.ansible.com) playbooks. For more information on writing Zuul jobs see their [documentation](https://zuul-ci.org/docs/zuul/reference/user.html).
 
 # Little Style Guide
 
-Toolbox is written in [Go](https://golang.org) and uses its default set of tools
+Toolbx is written in [Go](https://golang.org) and uses its default set of tools
 including `gofmt` and `golint`.
 
 Here are some good materials to learn from about the way how to write nice and

--- a/GOALS.md
+++ b/GOALS.md
@@ -13,7 +13,7 @@
 
 ### Non-goals
 
-- Supporting multiple container runtimes. Toolbox will use Podman exclusively
+- Supporting multiple container runtimes. Toolbx will use Podman exclusively
 - Adding significant features on top of Podman
   - Significant feature requests should be driven into Podman upstream
 - To run containers that aren't tightly integrated with the host
@@ -26,9 +26,9 @@
   - Some cases: user needs root for testing
 - Desktop Development:
   - Developers need things like D-Bus, display, etc. to be forwarded into the
-    toolbox container
+    Toolbx container
 - Headless Development:
-  - Toolbox works properly in headless environments (no display, etc)
+  - Toolbx works properly in headless environments (no display, etc)
 - Need development tools like GDB, strace, etc. to work
 
 ### Debugging and System Management Use Cases
@@ -50,8 +50,8 @@
 - Fedora Silverblue
   - Silverblue comes with a subset of packages and discourages host software
     changes
-    - Users need a toolbox container as a working environment
-    - Future: use toolbox container by default when a user opens a shell
+    - Users need a Toolbx container as a working environment
+    - Future: use Toolbx container by default when a user opens a shell
 - Fedora CoreOS
   - Similar to Silverblue, but non-graphical and smaller package set
 - RHEL CoreOS
@@ -59,8 +59,8 @@
     operating system for OpenShift
   - Need to [use default authfile on pull](https://github.com/coreos/toolbox/pull/58/commits/413f83f7240d3c31121b557bfd55e489fad24489)
   - Need to ensure compatibility with the rhel7/support-tools container
-    - Currently not a toolbox image, opportunity for collaboration
+    - Currently not a Toolbx image, opportunity for collaboration
   - Alignment with `oc debug node/` (OpenShift)
     - `oc debug node` opens a shell on a kubernetes node
-    - Value in having a consistent environment for both Toolbox's debugging
+    - Value in having a consistent environment for both Toolbx's debugging
       mode and `oc debug node`

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 [![Arch Linux package](https://img.shields.io/archlinux/v/extra/x86_64/toolbox)](https://www.archlinux.org/packages/extra/x86_64/toolbox/)
 [![Fedora package](https://img.shields.io/fedora/v/toolbox/rawhide)](https://src.fedoraproject.org/rpms/toolbox/)
 
-[Toolbox](https://containertoolbx.org/) is a tool for Linux, which allows the
+[Toolbx](https://containertoolbx.org/) is a tool for Linux, which allows the
 use of interactive command line environments for development and
 troubleshooting the host operating system, without having to install software
 on the host. It is built on top of [Podman](https://podman.io/) and other
 standard container technologies from [OCI](https://opencontainers.org/).
 
-Toolbox environments have seamless access to the user's home directory,
+Toolbx environments have seamless access to the user's home directory,
 the Wayland and X11 sockets, networking (including Avahi), removable devices
 (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the
 udev database, etc..
@@ -26,7 +26,7 @@ install software as (or in) containers — they mostly don't even have package
 managers like DNF or YUM. This makes it difficult to set up a development
 environment or troubleshoot the operating system in the usual way.
 
-Toolbox solves this problem by providing a fully mutable container within
+Toolbx solves this problem by providing a fully mutable container within
 which one can install their favourite development and troubleshooting tools,
 editors and SDKs. For example, it's possible to do `yum install ansible`
 without affecting the base operating system.
@@ -35,12 +35,12 @@ However, this tool doesn't *require* using an OSTree based system. It works
 equally well on Fedora Workstation and Server, and that's a useful way to
 incrementally adopt containerization.
 
-The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
+The Toolbx environment is based on an [OCI](https://www.opencontainers.org/)
 image. On Fedora this is the `fedora-toolbox` image. This image is used to
-create a toolbox container that offers the interactive command line
+create a Toolbx container that offers the interactive command line
 environment.
 
-Note that Toolbox makes no promise about security beyond what's already
+Note that Toolbx makes no promise about security beyond what's already
 available in the usual command line environment on the host that everybody is
 familiar with.
 
@@ -49,4 +49,4 @@ familiar with.
 
 See our guides on
 [installing & getting started](https://containertoolbx.org/install/) with
-Toolbox and [Linux distro support](https://containertoolbx.org/distros/).
+Toolbx and [Linux distro support](https://containertoolbx.org/distros/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
-## Security and Disclosure Information Policy for the Toolbox Project
+## Security and Disclosure Information Policy for the Toolbx Project
 
-The Toolbox Project follows the
+The Toolbx Project follows the
 [Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md)
 for the Containers Projects.

--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -1,7 +1,7 @@
 % toolbox-create 1
 
 ## NAME
-toolbox\-create - Create a new toolbox container
+toolbox\-create - Create a new Toolbx container
 
 ## SYNOPSIS
 **toolbox create** [*--authfile FILE*]
@@ -12,10 +12,10 @@ toolbox\-create - Create a new toolbox container
 
 ## DESCRIPTION
 
-Creates a new toolbox container. You can then use the `toolbox enter` command
+Creates a new Toolbx container. You can then use the `toolbox enter` command
 to interact with the container at any point.
 
-A toolbox container is an OCI container created from an OCI image. On Fedora,
+A Toolbx container is an OCI container created from an OCI image. On Fedora,
 the default image is known as `fedora-toolbox:N`, where N is the release of
 the host. If the image is not present locally, then it is pulled from a
 well-known registry like `registry.fedoraproject.org`. Other images may be
@@ -25,43 +25,43 @@ Fedora image will be used.
 The container is created with `podman create`, and its entry point is set to
 `toolbox init-container`.
 
-By default, a toolbox container is named after its corresponding image. If the
+By default, a Toolbx container is named after its corresponding image. If the
 image had a tag, then the tag is included in the name of the container, but
 it's separated by a hyphen, not a colon. A different name can be assigned by
 using the CONTAINER argument.
 
 ### Container Configuration
 
-A toolbox container seamlessly integrates with the rest of the operating
+A Toolbx container seamlessly integrates with the rest of the operating
 system by providing access to the user's home directory, the Wayland and X11
 sockets, networking (including Avahi), removable devices (like USB sticks),
 systemd journal, SSH agent, D-Bus, ulimits, /dev and the udev database, etc..
 
-The user ID and account details from the host is propagated into the toolbox
+The user ID and account details from the host is propagated into the Toolbx
 container, SELinux label separation is disabled, and the host file system can
 be accessed by the container at /run/host. The container has access to the
 host's Kerberos credentials cache if it's configured to use KCM caches.
 
-A toolbox container can be identified by the `com.github.containers.toolbox`
+A Toolbx container can be identified by the `com.github.containers.toolbox`
 label or the `/run/.toolboxenv` file.
 
-The entry point of a toolbox container is the `toolbox init-container` command
+The entry point of a Toolbx container is the `toolbox init-container` command
 which plays a role in setting up the container, along with the options passed
 to `podman create`.
 
 ### Entry Point
 
-A key feature of toolbox containers is their entry point, the `toolbox
+A key feature of Toolbx containers is their entry point, the `toolbox
 init-container` command.
 
 OCI containers are inherently immutable. Configuration options passed through
 `podman create` are baked into the definition of the OCI container, and can't
 be changed later. This means that changes and improvements made in newer
-versions of Toolbox can't be applied to pre-existing toolbox containers
-created by older versions of Toolbox. This is avoided by using the entry point
+versions of Toolbx can't be applied to pre-existing Toolbx containers
+created by older versions of Toolbx. This is avoided by using the entry point
 to configure the container at runtime.
 
-The entry point of a toolbox container customizes the container to fit the
+The entry point of a Toolbx container customizes the container to fit the
 current user by ensuring that it has a user that matches the one on the host,
 and grants it `sudo` and `root` access.
 
@@ -91,13 +91,13 @@ its format is specified in `containers-auth.json(5)`.
 
 **--distro** DISTRO, **-d** DISTRO
 
-Create a toolbox container for a different operating system DISTRO than the
+Create a Toolbx container for a different operating system DISTRO than the
 host. Cannot be used with `--image`. Has to be coupled with `--release` unless
 the selected DISTRO matches the host.
 
 **--image** NAME, **-i** NAME
 
-Change the NAME of the image used to create the toolbox container. This is
+Change the NAME of the image used to create the Toolbx container. This is
 useful for creating containers from custom-built images. Cannot be used with
 `--distro` and `--release`.
 
@@ -107,30 +107,30 @@ remote registry.
 
 **--release** RELEASE, **-r** RELEASE
 
-Create a toolbox container for a different operating system RELEASE than the
+Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `--image`.
 
 ## EXAMPLES
 
-### Create the default toolbox container matching the host OS
+### Create the default Toolbx container matching the host OS
 
 ```
 $ toolbox create
 ```
 
-### Create the default toolbox container for Fedora 36
+### Create the default Toolbx container for Fedora 36
 
 ```
 $ toolbox create --distro fedora --release f36
 ```
 
-### Create a custom toolbox container from a custom image
+### Create a custom Toolbx container from a custom image
 
 ```
 $ toolbox create --image bar foo
 ```
 
-### Create a custom toolbox container from a custom image that's private
+### Create a custom Toolbx container from a custom image that's private
 
 ```
 $ toolbox create --authfile ~/auth.json --image registry.example.com/bar

--- a/doc/toolbox-enter.1.md
+++ b/doc/toolbox-enter.1.md
@@ -1,7 +1,7 @@
 % toolbox-enter 1
 
 ## NAME
-toolbox\-enter - Enter a toolbox container for interactive use
+toolbox\-enter - Enter a Toolbx container for interactive use
 
 ## SYNOPSIS
 **toolbox enter** [*--distro DISTRO* | *-d DISTRO*]
@@ -10,19 +10,19 @@ toolbox\-enter - Enter a toolbox container for interactive use
 
 ## DESCRIPTION
 
-Spawns an interactive shell inside a toolbox container that was created using
+Spawns an interactive shell inside a Toolbx container that was created using
 the `toolbox create` command. It tries to spawn the user's default shell, but
 if it's not available inside the container then it falls back to `/bin/bash`.
 
 When invoked without any options, `toolbox enter` will try to enter the default
-toolbox container for the host, or if there's only one container available then
+Toolbx container for the host, or if there's only one container available then
 it will use it. On Fedora, the default container is known as
 `fedora-toolbox-N`, where N is the release of the host. If there aren't any
 containers, `toolbox enter` will offer to create the default one for you.
 
 A specific container can be selected using the CONTAINER argument.
 
-A toolbox container is an OCI container. Therefore, `toolbox enter` is
+A Toolbx container is an OCI container. Therefore, `toolbox enter` is
 analogous to a `podman start` followed by a `podman exec`.
 
 ## OPTIONS ##
@@ -31,30 +31,30 @@ The following options are understood:
 
 **--distro** DISTRO, **-d** DISTRO
 
-Enter a toolbox container for a different operating system DISTRO than the
+Enter a Toolbx container for a different operating system DISTRO than the
 host. Has to be coupled with `--release` unless the selected DISTRO matches the
 host.
 
 **--release** RELEASE, **-r** RELEASE
 
-Enter a toolbox container for a different operating system RELEASE than the
+Enter a Toolbx container for a different operating system RELEASE than the
 host.
 
 ## EXAMPLES
 
-### Enter the default toolbox container matching the host OS
+### Enter the default Toolbx container matching the host OS
 
 ```
 $ toolbox enter
 ```
 
-### Enter the default toolbox container for Fedora 36
+### Enter the default Toolbx container for Fedora 36
 
 ```
 $ toolbox enter --distro fedora --release f36
 ```
 
-### Enter a toolbox container with a custom name
+### Enter a Toolbx container with a custom name
 
 ```
 $ toolbox enter foo

--- a/doc/toolbox-help.1.md
+++ b/doc/toolbox-help.1.md
@@ -1,7 +1,7 @@
 % toolbox-help 1
 
 ## NAME
-toolbox\-help - Display help information about Toolbox
+toolbox\-help - Display help information about Toolbx
 
 ## SYNOPSIS
 **toolbox help** [*COMMAND*]

--- a/doc/toolbox-init-container.1.md
+++ b/doc/toolbox-init-container.1.md
@@ -16,21 +16,21 @@ toolbox\-init\-container - Initialize a running container
 ## DESCRIPTION
 
 Initializes a newly created container that's running. It is primarily meant to
-be used as the entry point for all toolbox containers, and must be run inside
+be used as the entry point for all Toolbx containers, and must be run inside
 the container that's to be initialized. It is not expected to be directly
 invoked by humans, and cannot be used on the host.
 
-A key feature of toolbox containers is their entry point, the `toolbox
+A key feature of Toolbx containers is their entry point, the `toolbox
 init-container` command.
 
 OCI containers are inherently immutable. Configuration options passed through
 `podman create` are baked into the definition of the OCI container, and can't
 be changed later. This means that changes and improvements made in newer
-versions of Toolbox can't be applied to pre-existing toolbox containers
-created by older versions of Toolbox. This is avoided by using the entry point
+versions of Toolbx can't be applied to pre-existing Toolbx containers
+created by older versions of Toolbx. This is avoided by using the entry point
 to configure the container at runtime.
 
-The entry point of a toolbox container customizes the container to fit the
+The entry point of a Toolbx container customizes the container to fit the
 current user by ensuring that it has a user that matches the one on the host,
 and grants it `sudo` and `root` access.
 
@@ -53,12 +53,12 @@ The following options are understood:
 
 **--gid** GID
 
-Pass GID as the user's numerical group ID from the host to the toolbox
+Pass GID as the user's numerical group ID from the host to the Toolbx
 container.
 
 **--home** HOME
 
-Create a user inside the toolbox container whose login directory is HOME. This
+Create a user inside the Toolbx container whose login directory is HOME. This
 option is required.
 
 **--home-link**
@@ -77,24 +77,24 @@ Make `/mnt` a symbolic link to `/var/mnt`.
 
 Deprecated, does nothing.
 
-Crucial configuration files inside the toolbox container are always kept
+Crucial configuration files inside the Toolbx container are always kept
 synchronized with their counterparts on the host, and various subsets of the
 host's file system hierarchy are always bind mounted to their corresponding
-locations inside the toolbox container.
+locations inside the Toolbx container.
 
 **--shell** SHELL
 
-Create a user inside the toolbox container whose login shell is SHELL. This
+Create a user inside the Toolbx container whose login shell is SHELL. This
 option is required.
 
 **--uid** UID
 
-Create a user inside the toolbox container whose numerical user ID is UID. This
+Create a user inside the Toolbx container whose numerical user ID is UID. This
 option is required.
 
 **--user** USER
 
-Create a user inside the toolbox container whose login name is LOGIN. This
+Create a user inside the Toolbx container whose login name is LOGIN. This
 option is required.
 
 ## SEE ALSO

--- a/doc/toolbox-list.1.md
+++ b/doc/toolbox-list.1.md
@@ -1,14 +1,14 @@
 % toolbox-list 1
 
 ## NAME
-toolbox\-list - List existing toolbox containers and images
+toolbox\-list - List existing Toolbx containers and images
 
 ## SYNOPSIS
 **toolbox list** [*--containers* | *-c*] [*--images* | *-i*]
 
 ## DESCRIPTION
 
-Lists existing toolbox containers and images. These are OCI containers and
+Lists existing Toolbx containers and images. These are OCI containers and
 images, which can be managed directly with a tool like `podman`.
 
 ## OPTIONS ##
@@ -17,27 +17,27 @@ The following options are understood:
 
 **--containers, -c**
 
-List only toolbox containers, not images.
+List only Toolbx containers, not images.
 
 **--images, -i**
 
-List only toolbox images, not containers.
+List only Toolbx images, not containers.
 
 ## EXAMPLES
 
-### List all existing toolbox containers and images
+### List all existing Toolbx containers and images
 
 ```
 $ toolbox list
 ```
 
-### List existing toolbox containers only
+### List existing Toolbx containers only
 
 ```
 $ toolbox list --containers
 ```
 
-### List existing toolbox images only
+### List existing Toolbx images only
 
 ```
 $ toolbox list --images

--- a/doc/toolbox-rm.1.md
+++ b/doc/toolbox-rm.1.md
@@ -1,17 +1,17 @@
 % toolbox-rm 1
 
 ## NAME
-toolbox\-rm - Remove one or more toolbox containers
+toolbox\-rm - Remove one or more Toolbx containers
 
 ## SYNOPSIS
 **toolbox rm** [*--all* | *-a*] [*--force* | *-f*] [*CONTAINER*...]
 
 ## DESCRIPTION
 
-Removes one or more toolbox containers from the host. The container should
+Removes one or more Toolbx containers from the host. The container should
 have been created using the `toolbox create` command.
 
-A toolbox container is an OCI container. Therefore, `toolbox rm` can be used
+A Toolbx container is an OCI container. Therefore, `toolbox rm` can be used
 interchangeably with `podman rm`.
 
 ## OPTIONS ##
@@ -20,28 +20,28 @@ The following options are understood:
 
 **--all, -a**
 
-Remove all toolbox containers. It can be used in conjunction with `--force` as
+Remove all Toolbx containers. It can be used in conjunction with `--force` as
 well.
 
 **--force, -f**
 
-Force the removal of running and paused toolbox containers.
+Force the removal of running and paused Toolbx containers.
 
 ## EXAMPLES
 
-### Remove a toolbox container named `fedora-toolbox-gegl:36`
+### Remove a Toolbx container named `fedora-toolbox-gegl:36`
 
 ```
 $ toolbox rm fedora-toolbox-gegl:36
 ```
 
-### Remove all toolbox containers, but not those that are running or paused
+### Remove all Toolbx containers, but not those that are running or paused
 
 ```
 $ toolbox rm --all
 ```
 
-### Remove all toolbox containers, including ones that are running or paused
+### Remove all Toolbx containers, including ones that are running or paused
 
 ```
 $ toolbox rm --all --force

--- a/doc/toolbox-rmi.1.md
+++ b/doc/toolbox-rmi.1.md
@@ -1,17 +1,17 @@
 % toolbox-rmi 1
 
 ## NAME
-toolbox\-rmi - Remove one or more toolbox images
+toolbox\-rmi - Remove one or more Toolbx images
 
 ## SYNOPSIS
 **toolbox rmi** [*--all* | *-a*] [*--force* | *-f*] [*IMAGE*...]
 
 ## DESCRIPTION
 
-Removes one or more toolbox images from the host. The image should have been
+Removes one or more Toolbx images from the host. The image should have been
 created using the `toolbox create` command.
 
-A toolbox image is an OCI image. Therefore, `toolbox rmi` can be used
+A Toolbx image is an OCI image. Therefore, `toolbox rmi` can be used
 interchangeably with `podman rmi`.
 
 ## OPTIONS ##
@@ -20,28 +20,28 @@ The following options are understood:
 
 **--all, -a**
 
-Remove all toolbox images. It can be used in conjunction with `--force` as well.
+Remove all Toolbx images. It can be used in conjunction with `--force` as well.
 
 **--force, -f**
 
-Force the removal of toolbox images that are used by toolbox containers. The
+Force the removal of Toolbx images that are used by Toolbx containers. The
 dependent containers will be removed as well.
 
 ## EXAMPLES
 
-### Remove a toolbox image named `localhost/fedora-toolbox-gegl:36`
+### Remove a Toolbx image named `localhost/fedora-toolbox-gegl:36`
 
 ```
 $ toolbox rmi localhost/fedora-toolbox-gegl:36
 ```
 
-### Remove all toolbox images, but not those that are used by containers
+### Remove all Toolbx images, but not those that are used by containers
 
 ```
 $ toolbox rmi --all
 ```
 
-### Remove all toolbox images and their dependent containers
+### Remove all Toolbx images and their dependent containers
 
 ```
 $ toolbox rmi --all --force

--- a/doc/toolbox-run.1.md
+++ b/doc/toolbox-run.1.md
@@ -1,7 +1,7 @@
 % toolbox-run 1
 
 ## NAME
-toolbox\-run - Run a command in an existing toolbox container
+toolbox\-run - Run a command in an existing Toolbx container
 
 ## SYNOPSIS
 **toolbox run** [*--container NAME* | *-c NAME*]
@@ -12,14 +12,14 @@ toolbox\-run - Run a command in an existing toolbox container
 
 ## DESCRIPTION
 
-Runs a command inside an existing toolbox container. The container should have
+Runs a command inside an existing Toolbx container. The container should have
 been created using the `toolbox create` command.
 
 On Fedora, the default container is known as `fedora-toolbox-N`, where N is
 the release of the host. A specific container can be selected using the
 `--container` option.
 
-A toolbox container is an OCI container. Therefore, `toolbox run` is analogous
+A Toolbx container is an OCI container. Therefore, `toolbox run` is analogous
 to a `podman start` followed by a `podman exec`.
 
 ## OPTIONS ##
@@ -28,13 +28,13 @@ The following options are understood:
 
 **--container** NAME, **-c** NAME
 
-Run command inside a toolbox container with the given NAME. This is useful
-when there are multiple toolbox containers created from the same image, or
+Run command inside a Toolbx container with the given NAME. This is useful
+when there are multiple Toolbx containers created from the same image, or
 entirely customized containers created from custom-built images.
 
 **--distro** DISTRO, **-d** DISTRO
 
-Run command inside a toolbox container for a different operating system DISTRO
+Run command inside a Toolbx container for a different operating system DISTRO
 than the host. Has to be coupled with `--release` unless the selected DISTRO
 matches the host system.
 
@@ -45,7 +45,7 @@ Pass down to command N additional file descriptors (in addition to 0, 1,
 
 **--release** RELEASE, **-r** RELEASE
 
-Run command inside a toolbox container for a different operating system
+Run command inside a Toolbx container for a different operating system
 RELEASE than the host.
 
 ## EXIT STATUS
@@ -53,7 +53,7 @@ RELEASE than the host.
 The exit code gives information about why the command within the container
 failed to run or why it exited.
 
-**1** There was an internal error in Toolbox
+**1** There was an internal error in Toolbx
 
 **125** There was an internal error in Podman
 
@@ -85,19 +85,19 @@ $ toolbox run false; echo $?
 
 ## EXAMPLES
 
-### Run ls inside the default toolbox container matching the host OS
+### Run ls inside the default Toolbx container matching the host OS
 
 ```
 $ toolbox run ls -la
 ```
 
-### Run emacs inside the default toolbox container for Fedora 36
+### Run emacs inside the default Toolbx container for Fedora 36
 
 ```
 $ toolbox run --distro fedora --release f36 emacs
 ```
 
-### Run uptime inside a toolbox container with a custom name
+### Run uptime inside a Toolbx container with a custom name
 
 ```
 $ toolbox run --container foo uptime

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -13,7 +13,7 @@ toolbox - Tool for containerized command line environments on Linux
 
 ## DESCRIPTION
 
-Toolbox is a tool for Linux operating systems, which allows the use of
+Toolbx is a tool for Linux operating systems, which allows the use of
 containerized command line environments. It is built on top of Podman and
 other standard container technologies from OCI.
 
@@ -24,7 +24,7 @@ containers — they mostly don't even have package managers like DNF or YUM.
 This makes it difficult to set up a development environment or install tools
 for debugging in the usual way.
 
-Toolbox solves this problem by providing a fully mutable container within
+Toolbx solves this problem by providing a fully mutable container within
 which one can install their favourite development and debugging tools, editors
 and SDKs. For example, it's possible to do `yum install ansible` without
 affecting the base operating system.
@@ -33,8 +33,8 @@ However, this tool doesn't *require* using an OSTree based system. It works
 equally well on Fedora Workstation and Server, and that's a useful way to
 incrementally adopt containerization.
 
-The toolbox environment is based on an OCI image. On Fedora this is the
-`fedora-toolbox` image. This image is used to create a toolbox container that
+The Toolbx environment is based on an OCI image. On Fedora this is the
+`fedora-toolbox` image. This image is used to create a Toolbx container that
 seamlessly integrates with the rest of the operating system by providing
 access to the user's home directory, the Wayland and X11 sockets, networking
 (including Avahi), removable devices (like USB sticks), systemd journal, SSH
@@ -42,7 +42,7 @@ agent, D-Bus, ulimits, /dev and the udev database, etc..
 
 ## Supported operating system distributions
 
-By default, Toolbox tries to use an image matching the host operating system
+By default, Toolbx tries to use an image matching the host operating system
 distribution for creating containers. If the host is not supported, then it
 falls back to a Fedora image. Supported host operating systems are:
 
@@ -66,7 +66,7 @@ ubuntu |\<YY\>.\<MM\> eg., 22.04
 
 ## USAGE
 
-### Create a Toolbox container:
+### Create a Toolbx container:
 
 ```
 [user@hostname ~]$ toolbox create
@@ -77,14 +77,14 @@ Enter with: toolbox enter
 [user@hostname ~]$
 ```
 
-### Enter the Toolbox container:
+### Enter the Toolbx container:
 
 ```
 [user@hostname ~]$ toolbox enter
 ⬢[user@toolbox ~]$
 ```
 
-### Remove the Toolbox container:
+### Remove the Toolbx container:
 
 ```
 [user@hostname ~]$ toolbox rm fedora-toolbox-36
@@ -119,19 +119,19 @@ Same as `--log-level=debug`. Use `-vv` to include `--log-podman`.
 
 ## COMMANDS
 
-Commands for working with toolbox containers and images:
+Commands for working with Toolbx containers and images:
 
 **toolbox-create(1)**
 
-Create a new toolbox container.
+Create a new Toolbx container.
 
 **toolbox-enter(1)**
 
-Enter a toolbox container for interactive use.
+Enter a Toolbx container for interactive use.
 
 **toolbox-help(1)**
 
-Display help information about Toolbox.
+Display help information about Toolbx.
 
 **toolbox-init-container(1)**
 
@@ -139,25 +139,25 @@ Initialize a running container.
 
 **toolbox-list(1)**
 
-List existing toolbox containers and images.
+List existing Toolbx containers and images.
 
 **toolbox-rm(1)**
 
-Remove one or more toolbox containers.
+Remove one or more Toolbx containers.
 
 **toolbox-rmi(1)**
 
-Remove one or more toolbox images.
+Remove one or more Toolbx images.
 
 **toolbox-run(1)**
 
-Run a command in an existing toolbox container.
+Run a command in an existing Toolbx container.
 
 ## FILES ##
 
 **toolbox.conf(5)**
 
-Toolbox configuration file.
+Toolbx configuration file.
 
 ## SEE ALSO
 

--- a/doc/toolbox.conf.5.md
+++ b/doc/toolbox.conf.5.md
@@ -1,7 +1,7 @@
 % toolbox.conf 5
 
 ## NAME
-toolbox.conf - Toolbox configuration file
+toolbox.conf - Toolbx configuration file
 
 ## DESCRIPTION
 
@@ -13,12 +13,12 @@ Currently, the only supported section is *general*.
 
 **distro** = "DISTRO"
 
-Create a toolbox container for a different operating system DISTRO than the
+Create a Toolbx container for a different operating system DISTRO than the
 host. Cannot be used with `image`.
 
 **image** = "NAME"
 
-Change the NAME of the image used to create the toolbox container. This is
+Change the NAME of the image used to create the Toolbx container. This is
 useful for creating containers from custom-built images. Cannot be used with
 `distro` and `release`.
 
@@ -28,7 +28,7 @@ remote registry.
 
 **release** = "RELEASE"
 
-Create a toolbox container for a different operating system RELEASE than the
+Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `image`.
 
 ## FILES

--- a/images/arch/Containerfile
+++ b/images/arch/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="arch-toolbox" \
       version="base-devel" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Arch Linux toolbox containers" \
+      summary="Base image for creating Arch Linux Toolbx containers" \
       maintainer="Morten Linderud <foxboron@archlinux.org>"
 
 # Install extra packages

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -7,7 +7,7 @@ LABEL com.github.containers.toolbox="true" \
       name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Fedora toolbox containers" \
+      summary="Base image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 
 COPY README.md /

--- a/images/fedora/f38/README.md
+++ b/images/fedora/f38/README.md
@@ -1,10 +1,10 @@
-[Toolbox](https://containertoolbx.org/) is a tool for Linux, which allows the
+[Toolbx](https://containertoolbx.org/) is a tool for Linux, which allows the
 use of interactive command line environments for development and
 troubleshooting the host operating system, without having to install software
 on the host. It is built on top of [Podman](https://podman.io/) and other
 standard container technologies from [OCI](https://opencontainers.org/).
 
-Toolbox environments have seamless access to the user's home directory,
+Toolbx environments have seamless access to the user's home directory,
 the Wayland and X11 sockets, networking (including Avahi), removable devices
 (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the
 udev database, etc..
@@ -18,7 +18,7 @@ install software as (or in) containers — they mostly don't even have package
 managers like DNF or YUM. This makes it difficult to set up a development
 environment or troubleshoot the operating system in the usual way.
 
-Toolbox solves this problem by providing a fully mutable container within
+Toolbx solves this problem by providing a fully mutable container within
 which one can install their favourite development and troubleshooting tools,
 editors and SDKs. For example, it's possible to do `yum install ansible`
 without affecting the base operating system.
@@ -27,12 +27,12 @@ However, this tool doesn't *require* using an OSTree based system. It works
 equally well on Fedora Workstation and Server, and that's a useful way to
 incrementally adopt containerization.
 
-The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
+The Toolbx environment is based on an [OCI](https://www.opencontainers.org/)
 image. On Fedora this is the `fedora-toolbox` image. This image is used to
-create a toolbox container that offers the interactive command line
+create a Toolbx container that offers the interactive command line
 environment.
 
-Note that Toolbox makes no promise about security beyond what's already
+Note that Toolbx makes no promise about security beyond what's already
 available in the usual command line environment on the host that everybody is
 familiar with.
 
@@ -41,4 +41,4 @@ familiar with.
 
 See our guides on
 [installing & getting started](https://containertoolbx.org/install/) with
-Toolbox and [Linux distro support](https://containertoolbx.org/distros/).
+Toolbx and [Linux distro support](https://containertoolbx.org/distros/).

--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -7,7 +7,7 @@ LABEL com.github.containers.toolbox="true" \
       name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Fedora toolbox containers" \
+      summary="Base image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 
 COPY README.md /

--- a/images/fedora/f39/README.md
+++ b/images/fedora/f39/README.md
@@ -1,10 +1,10 @@
-[Toolbox](https://containertoolbx.org/) is a tool for Linux, which allows the
+[Toolbx](https://containertoolbx.org/) is a tool for Linux, which allows the
 use of interactive command line environments for development and
 troubleshooting the host operating system, without having to install software
 on the host. It is built on top of [Podman](https://podman.io/) and other
 standard container technologies from [OCI](https://opencontainers.org/).
 
-Toolbox environments have seamless access to the user's home directory,
+Toolbx environments have seamless access to the user's home directory,
 the Wayland and X11 sockets, networking (including Avahi), removable devices
 (like USB sticks), systemd journal, SSH agent, D-Bus, ulimits, /dev and the
 udev database, etc..
@@ -18,7 +18,7 @@ install software as (or in) containers — they mostly don't even have package
 managers like DNF or YUM. This makes it difficult to set up a development
 environment or troubleshoot the operating system in the usual way.
 
-Toolbox solves this problem by providing a fully mutable container within
+Toolbx solves this problem by providing a fully mutable container within
 which one can install their favourite development and troubleshooting tools,
 editors and SDKs. For example, it's possible to do `yum install ansible`
 without affecting the base operating system.
@@ -27,12 +27,12 @@ However, this tool doesn't *require* using an OSTree based system. It works
 equally well on Fedora Workstation and Server, and that's a useful way to
 incrementally adopt containerization.
 
-The toolbox environment is based on an [OCI](https://www.opencontainers.org/)
+The Toolbx environment is based on an [OCI](https://www.opencontainers.org/)
 image. On Fedora this is the `fedora-toolbox` image. This image is used to
-create a toolbox container that offers the interactive command line
+create a Toolbx container that offers the interactive command line
 environment.
 
-Note that Toolbox makes no promise about security beyond what's already
+Note that Toolbx makes no promise about security beyond what's already
 available in the usual command line environment on the host that everybody is
 familiar with.
 
@@ -41,4 +41,4 @@ familiar with.
 
 See our guides on
 [installing & getting started](https://containertoolbx.org/install/) with
-Toolbox and [Linux distro support](https://containertoolbx.org/distros/).
+Toolbx and [Linux distro support](https://containertoolbx.org/distros/).

--- a/images/test/busybox/README.md
+++ b/images/test/busybox/README.md
@@ -1,4 +1,4 @@
 This image is just a clone of the base busybox image used for testing purposes.
 
 The Containerfile is used to build the quay.io/toolbox_tests/busybox image that
-is used in the toolbox test suite.
+is used in the Toolbx test suite.

--- a/images/ubuntu/16.04/Containerfile
+++ b/images/ubuntu/16.04/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="16.04" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/images/ubuntu/18.04/Containerfile
+++ b/images/ubuntu/18.04/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="18.04" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/images/ubuntu/20.04/Containerfile
+++ b/images/ubuntu/20.04/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="20.04" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/images/ubuntu/22.04/Containerfile
+++ b/images/ubuntu/22.04/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="22.04" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/images/ubuntu/23.04/Containerfile
+++ b/images/ubuntu/23.04/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="23.04" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/images/ubuntu/23.10/Containerfile
+++ b/images/ubuntu/23.10/Containerfile
@@ -4,7 +4,7 @@ LABEL com.github.containers.toolbox="true" \
       name="ubuntu-toolbox" \
       version="23.10" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Ubuntu toolbox containers" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
       maintainer="Ievgen Popovych <jmennius@gmail.com>"
 
 # Remove apt configuration optimized for containers

--- a/playbooks/build.yaml
+++ b/playbooks/build.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Red Hat, Inc.
+# Copyright © 2022 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
 # limitations under the License.
 #
 
-- name: Build Toolbox
+- name: Build Toolbx
   command: meson compile -C builddir
   args:
     chdir: '{{ zuul.project.src_dir }}'
     creates: builddir/src/toolbox
 
-- name: Install Toolbox
+- name: Install Toolbx
   become: yes
   command: meson install -C builddir
   args:

--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,6 @@
       command: bats --timing ./test/system
       environment:
         PODMAN: '/usr/bin/podman'
-        TOOLBOX: '/usr/local/bin/toolbox'
+        TOOLBX: '/usr/local/bin/toolbox'
       args:
         chdir: '{{ zuul.project.src_dir }}'

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -33,7 +33,7 @@ if [ -f /run/ostree-booted ] \
     echo "Welcome to ${PRETTY_NAME:-Linux}."
     echo ""
     echo "This terminal is running on the host system. You may want to try"
-    echo "out the Toolbox for a directly mutable environment that allows "
+    echo "out the Toolbx for a directly mutable environment that allows "
     echo "package installation with DNF."
     echo ""
     printf "For more information, see the "
@@ -53,7 +53,7 @@ if [ -f /run/.containerenv ] \
 
     if ! [ -f "$toolbox_welcome_stub" ]; then
         echo ""
-        echo "Welcome to the Toolbox; a container where you can install and run"
+        echo "Welcome to the Toolbx; a container where you can install and run"
         echo "all your tools."
         echo ""
 

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ var (
 
 var createCmd = &cobra.Command{
 	Use:               "create",
-	Short:             "Create a new toolbox container",
+	Short:             "Create a new Toolbx container",
 	RunE:              create,
 	ValidArgsFunction: completionEmpty,
 }
@@ -84,25 +84,25 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Assign a different name to the toolbox container")
+		"Assign a different name to the Toolbx container")
 
 	flags.StringVarP(&createFlags.distro,
 		"distro",
 		"d",
 		"",
-		"Create a toolbox container for a different operating system distribution than the host")
+		"Create a Toolbx container for a different operating system distribution than the host")
 
 	flags.StringVarP(&createFlags.image,
 		"image",
 		"i",
 		"",
-		"Change the name of the base image used to create the toolbox container")
+		"Change the name of the base image used to create the Toolbx container")
 
 	flags.StringVarP(&createFlags.release,
 		"release",
 		"r",
 		"",
-		"Create a toolbox container for a different operating system release than the host")
+		"Create a Toolbx container for a different operating system release than the host")
 
 	createCmd.SetHelpFunc(createHelp)
 
@@ -122,7 +122,7 @@ func init() {
 func create(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -408,7 +408,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 	createArgs = append(createArgs, xdgRuntimeDirEnv...)
 
 	createArgs = append(createArgs, []string{
-		"--hostname", "toolbox",
+		"--hostname", "toolbx",
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
 	}...)
@@ -479,7 +479,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 func createHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 
@@ -732,7 +732,7 @@ func pullImage(image, release, authFile string) (bool, error) {
 	if promptForDownload {
 		if !term.IsTerminal(os.Stdin) || !term.IsTerminal(os.Stdout) {
 			var builder strings.Builder
-			fmt.Fprintf(&builder, "image required to create toolbox container.\n")
+			fmt.Fprintf(&builder, "image required to create Toolbx container.\n")
 			fmt.Fprintf(&builder, "Use option '--assumeyes' to download the image.\n")
 			fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
 
@@ -961,7 +961,7 @@ func showPromptForDownloadSecond(imageFull string, errFirst *promptForDownloadEr
 }
 
 func showPromptForDownload(imageFull string) bool {
-	fmt.Println("Image required to create toolbox container.")
+	fmt.Println("Image required to create Toolbx container.")
 
 	shouldPullImage, err := showPromptForDownloadFirst(imageFull)
 	if err == nil {

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ var (
 
 var enterCmd = &cobra.Command{
 	Use:               "enter",
-	Short:             "Enter a toolbox container for interactive use",
+	Short:             "Enter a Toolbx container for interactive use",
 	RunE:              enter,
 	ValidArgsFunction: completionContainerNamesFiltered,
 }
@@ -47,19 +47,19 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Enter a toolbox container with the given name")
+		"Enter a Toolbx container with the given name")
 
 	flags.StringVarP(&enterFlags.distro,
 		"distro",
 		"d",
 		"",
-		"Enter a toolbox container for a different operating system distribution than the host")
+		"Enter a Toolbx container for a different operating system distribution than the host")
 
 	flags.StringVarP(&enterFlags.release,
 		"release",
 		"r",
 		"",
-		"Enter a toolbox container for a different operating system release than the host")
+		"Enter a Toolbx container for a different operating system release than the host")
 
 	if err := enterCmd.RegisterFlagCompletionFunc("container", completionContainerNames); err != nil {
 		panicMsg := fmt.Sprintf("failed to register flag completion function: %v", err)
@@ -77,7 +77,7 @@ func init() {
 func enter(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -134,7 +134,7 @@ func enter(cmd *cobra.Command, args []string) error {
 func enterHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/help.go
+++ b/src/cmd/help.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 
 var helpCmd = &cobra.Command{
 	Use:               "help",
-	Short:             "Display help information about Toolbox",
+	Short:             "Display help information about Toolbx",
 	RunE:              help,
 	ValidArgsFunction: completionCommands,
 }
@@ -40,7 +40,7 @@ func init() {
 func help(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -60,7 +60,7 @@ func help(cmd *cobra.Command, args []string) error {
 func helpHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,12 +84,12 @@ func init() {
 	flags.IntVar(&initContainerFlags.gid,
 		"gid",
 		0,
-		"Create a user inside the toolbox container whose numerical group ID is GID")
+		"Create a user inside the Toolbx container whose numerical group ID is GID")
 
 	flags.StringVar(&initContainerFlags.home,
 		"home",
 		"",
-		"Create a user inside the toolbox container whose login directory is HOME")
+		"Create a user inside the Toolbx container whose login directory is HOME")
 	if err := initContainerCmd.MarkFlagRequired("home"); err != nil {
 		panic("Could not mark flag --home as required")
 	}
@@ -118,7 +118,7 @@ func init() {
 	flags.StringVar(&initContainerFlags.shell,
 		"shell",
 		"",
-		"Create a user inside the toolbox container whose login shell is SHELL")
+		"Create a user inside the Toolbx container whose login shell is SHELL")
 	if err := initContainerCmd.MarkFlagRequired("shell"); err != nil {
 		panic("Could not mark flag --shell as required")
 	}
@@ -126,7 +126,7 @@ func init() {
 	flags.IntVar(&initContainerFlags.uid,
 		"uid",
 		0,
-		"Create a user inside the toolbox container whose numerical user ID is UID")
+		"Create a user inside the Toolbx container whose numerical user ID is UID")
 	if err := initContainerCmd.MarkFlagRequired("uid"); err != nil {
 		panic("Could not mark flag --uid as required")
 	}
@@ -134,7 +134,7 @@ func init() {
 	flags.StringVar(&initContainerFlags.user,
 		"user",
 		"",
-		"Create a user inside the toolbox container whose login name is USER")
+		"Create a user inside the Toolbx container whose login name is USER")
 	if err := initContainerCmd.MarkFlagRequired("user"); err != nil {
 		panic("Could not mark flag --user as required")
 	}
@@ -249,7 +249,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	if utils.PathExists("/etc/krb5.conf.d") && !utils.PathExists("/etc/krb5.conf.d/kcm_default_ccache") {
 		logrus.Debug("Setting KCM as the default Kerberos credential cache")
 
-		kcmConfigString := `# Written by Toolbox
+		kcmConfigString := `# Written by Toolbx
 # https://github.com/containers/toolbox
 #
 # # To disable the KCM credential cache, comment out the following lines.
@@ -270,7 +270,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 		logrus.Debug("Configuring RPM to ignore bind mounts")
 
 		var builder strings.Builder
-		fmt.Fprintf(&builder, "# Written by Toolbox\n")
+		fmt.Fprintf(&builder, "# Written by Toolbx\n")
 		fmt.Fprintf(&builder, "# https://github.com/containers/toolbox\n")
 		fmt.Fprintf(&builder, "\n")
 		fmt.Fprintf(&builder, "%%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt\n")
@@ -374,7 +374,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 func initContainerHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ var (
 		onlyImages     bool
 	}
 
-	// toolboxLabels holds labels used by containers/images that mark them as compatible with Toolbox
+	// toolboxLabels holds labels used by containers/images that mark them as compatible with Toolbx
 	toolboxLabels = map[string]string{
 		"com.github.debarshiray.toolbox": "true",
 		"com.github.containers.toolbox":  "true",
@@ -55,7 +55,7 @@ var (
 
 var listCmd = &cobra.Command{
 	Use:               "list",
-	Short:             "List existing toolbox containers and images",
+	Short:             "List existing Toolbx containers and images",
 	RunE:              list,
 	ValidArgsFunction: completionEmpty,
 }
@@ -67,13 +67,13 @@ func init() {
 		"containers",
 		"c",
 		false,
-		"List only toolbox containers, not images")
+		"List only Toolbx containers, not images")
 
 	flags.BoolVarP(&listFlags.onlyImages,
 		"images",
 		"i",
 		false,
-		"List only toolbox images, not containers")
+		"List only Toolbx images, not containers")
 
 	listCmd.SetHelpFunc(listHelp)
 	rootCmd.AddCommand(listCmd)
@@ -82,7 +82,7 @@ func init() {
 func list(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -163,7 +163,7 @@ func getContainers() ([]toolboxContainer, error) {
 func listHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ var (
 
 var rmCmd = &cobra.Command{
 	Use:               "rm",
-	Short:             "Remove one or more toolbox containers",
+	Short:             "Remove one or more Toolbx containers",
 	RunE:              rm,
 	ValidArgsFunction: completionContainerNamesFiltered,
 }
@@ -44,13 +44,13 @@ var rmCmd = &cobra.Command{
 func init() {
 	flags := rmCmd.Flags()
 
-	flags.BoolVarP(&rmFlags.deleteAll, "all", "a", false, "Remove all toolbox containers")
+	flags.BoolVarP(&rmFlags.deleteAll, "all", "a", false, "Remove all Toolbx containers")
 
 	flags.BoolVarP(&rmFlags.forceDelete,
 		"force",
 		"f",
 		false,
-		"Force the removal of running and paused toolbox containers")
+		"Force the removal of running and paused Toolbx containers")
 
 	rmCmd.SetHelpFunc(rmHelp)
 	rootCmd.AddCommand(rmCmd)
@@ -59,7 +59,7 @@ func init() {
 func rm(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -111,7 +111,7 @@ func rm(cmd *cobra.Command, args []string) error {
 func rmHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -36,7 +36,7 @@ var (
 
 var rmiCmd = &cobra.Command{
 	Use:               "rmi",
-	Short:             "Remove one or more toolbox images",
+	Short:             "Remove one or more Toolbx images",
 	RunE:              rmi,
 	ValidArgsFunction: completionImageNamesFiltered,
 }
@@ -44,13 +44,13 @@ var rmiCmd = &cobra.Command{
 func init() {
 	flags := rmiCmd.Flags()
 
-	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all toolbox images")
+	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all Toolbx images")
 
 	flags.BoolVarP(&rmiFlags.forceDelete,
 		"force",
 		"f",
 		false,
-		"Force the removal of toolbox images that are used by toolbox containers")
+		"Force the removal of Toolbx images that are used by Toolbx containers")
 
 	rmiCmd.SetHelpFunc(rmiHelp)
 	rootCmd.AddCommand(rmiCmd)
@@ -59,7 +59,7 @@ func init() {
 func rmi(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -111,7 +111,7 @@ func rmi(cmd *cobra.Command, args []string) error {
 func rmiHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,13 +44,13 @@ var rmiCmd = &cobra.Command{
 func init() {
 	flags := rmiCmd.Flags()
 
-	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all toolbox containers")
+	flags.BoolVarP(&rmiFlags.deleteAll, "all", "a", false, "Remove all toolbox images")
 
 	flags.BoolVarP(&rmiFlags.forceDelete,
 		"force",
 		"f",
 		false,
-		"Force the removal of running and paused toolbox containers")
+		"Force the removal of toolbox images that are used by toolbox containers")
 
 	rmiCmd.SetHelpFunc(rmiHelp)
 	rootCmd.AddCommand(rmiCmd)

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,7 +175,7 @@ func preRun(cmd *cobra.Command, args []string) error {
 func rootHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 
@@ -227,7 +227,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 
 	toolboxConfigDir := configDir + "/toolbox"
 	stampPath := toolboxConfigDir + "/podman-system-migrate"
-	logrus.Debugf("Toolbox config directory is %s", toolboxConfigDir)
+	logrus.Debugf("Toolbx config directory is %s", toolboxConfigDir)
 
 	podmanVersion, err := podman.GetVersion()
 	if err != nil {

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -1,5 +1,5 @@
 //
-// Copyright © 2021 – 2023 Red Hat Inc.
+// Copyright © 2021 – 2024 Red Hat Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ var (
 
 var runCmd = &cobra.Command{
 	Use:               "run",
-	Short:             "Run a command in an existing toolbox container",
+	Short:             "Run a command in an existing Toolbx container",
 	RunE:              run,
 	ValidArgsFunction: completionEmpty,
 }
@@ -59,13 +59,13 @@ func init() {
 		"container",
 		"c",
 		"",
-		"Run command inside a toolbox container with the given name")
+		"Run command inside a Toolbx container with the given name")
 
 	flags.StringVarP(&runFlags.distro,
 		"distro",
 		"d",
 		"",
-		"Run command inside a toolbox container for a different operating system distribution than the host")
+		"Run command inside a Toolbx container for a different operating system distribution than the host")
 
 	flags.UintVar(&runFlags.preserveFDs,
 		"preserve-fds",
@@ -76,7 +76,7 @@ func init() {
 		"release",
 		"r",
 		"",
-		"Run command inside a toolbox container for a different operating system release than the host")
+		"Run command inside a Toolbx container for a different operating system release than the host")
 
 	runCmd.SetHelpFunc(runHelp)
 
@@ -95,7 +95,7 @@ func init() {
 func run(cmd *cobra.Command, args []string) error {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			return errors.New("this is not a toolbox container")
+			return errors.New("this is not a Toolbx container")
 		}
 
 		if _, err := utils.ForwardToHost(); err != nil {
@@ -206,7 +206,7 @@ func runCommand(container string,
 			}
 
 			if promptForCreate {
-				prompt := "No toolbox containers found. Create now? [y/N]"
+				prompt := "No Toolbx containers found. Create now? [y/N]"
 				shouldCreateContainer = askForConfirmation(prompt)
 			}
 
@@ -224,12 +224,12 @@ func runCommand(container string,
 
 			container = containers[0].Names[0]
 			fmt.Fprintf(os.Stderr, "Entering container %s instead.\n", container)
-			fmt.Fprintf(os.Stderr, "Use the 'create' command to create a different toolbox.\n")
+			fmt.Fprintf(os.Stderr, "Use the 'create' command to create a different Toolbx.\n")
 			fmt.Fprintf(os.Stderr, "Run '%s --help' for usage.\n", executableBase)
 		} else {
 			var builder strings.Builder
 			fmt.Fprintf(&builder, "container %s not found\n", container)
-			fmt.Fprintf(&builder, "Use the '--container' option to select a toolbox.\n")
+			fmt.Fprintf(&builder, "Use the '--container' option to select a Toolbx.\n")
 			fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
 
 			errMsg := builder.String()
@@ -254,7 +254,7 @@ func runCommand(container string,
 	if entryPoint != "toolbox" {
 		var builder strings.Builder
 		fmt.Fprintf(&builder, "container %s is too old and no longer supported \n", container)
-		fmt.Fprintf(&builder, "Recreate it with Toolbox version 0.0.17 or newer.\n")
+		fmt.Fprintf(&builder, "Recreate it with Toolbx version 0.0.17 or newer.\n")
 
 		errMsg := builder.String()
 		return errors.New(errMsg)
@@ -412,7 +412,7 @@ func runCommandWithFallbacks(container string,
 func runHelp(cmd *cobra.Command, args []string) {
 	if utils.IsInsideContainer() {
 		if !utils.IsInsideToolboxContainer() {
-			fmt.Fprintf(os.Stderr, "Error: this is not a toolbox container\n")
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
 			return
 		}
 

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 – 2023 Red Hat Inc.
+ * Copyright © 2020 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -263,7 +263,7 @@ func discardInputAsync(ctx context.Context) (<-chan int, <-chan error) {
 func createErrorContainerNotFound(container string) error {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "container %s not found\n", container)
-	fmt.Fprintf(&builder, "Use the 'create' command to create a toolbox.\n")
+	fmt.Fprintf(&builder, "Use the 'create' command to create a Toolbx.\n")
 	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
 
 	errMsg := builder.String()
@@ -333,9 +333,9 @@ func createErrorInvalidRelease(hint string) error {
 
 func getUsageForCommonCommands() string {
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "create    Create a new toolbox container\n")
-	fmt.Fprintf(&builder, "enter     Enter an existing toolbox container\n")
-	fmt.Fprintf(&builder, "list      List all existing toolbox containers and images\n")
+	fmt.Fprintf(&builder, "create    Create a new Toolbx container\n")
+	fmt.Fprintf(&builder, "enter     Enter an existing Toolbx container\n")
+	fmt.Fprintf(&builder, "list      List all existing Toolbx containers and images\n")
 
 	usage := builder.String()
 	return usage

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -288,7 +288,7 @@ func IsToolboxContainer(container string) (bool, error) {
 
 	labels, _ := info["Config"].(map[string]interface{})["Labels"].(map[string]interface{})
 	if labels["com.github.containers.toolbox"] != "true" && labels["com.github.debarshiray.toolbox"] != "true" {
-		return false, fmt.Errorf("%s is not a toolbox container", container)
+		return false, fmt.Errorf("%s is not a Toolbx container", container)
 	}
 
 	return true, nil
@@ -301,12 +301,12 @@ func IsToolboxImage(image string) (bool, error) {
 	}
 
 	if info["Labels"] == nil {
-		return false, fmt.Errorf("%s is not a toolbox image", image)
+		return false, fmt.Errorf("%s is not a Toolbx image", image)
 	}
 
 	labels := info["Labels"].(map[string]interface{})
 	if labels["com.github.containers.toolbox"] != "true" && labels["com.github.debarshiray.toolbox"] != "true" {
-		return false, fmt.Errorf("%s is not a toolbox image", image)
+		return false, fmt.Errorf("%s is not a Toolbx image", image)
 	}
 
 	return true, nil

--- a/src/pkg/shell/shell_test.go
+++ b/src/pkg/shell/shell_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Red Hat Inc.
+ * Copyright © 2023 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,13 +55,13 @@ func TestShellRun(t *testing.T) {
 			input: input{
 				commandName: "echo",
 				stdIn:       os.Stdin,
-				args:        []string{"toolbox test"},
+				args:        []string{"Toolbx test"},
 				loglevel:    logrus.InfoLevel,
 				useStdErr:   false,
 			},
 			expect: expect{
 				err:    nil,
-				stdout: []byte("toolbox test\n"),
+				stdout: []byte("Toolbx test\n"),
 				stderr: nil,
 			},
 		},
@@ -70,7 +70,7 @@ func TestShellRun(t *testing.T) {
 			input: input{
 				commandName: "no-exist-executable",
 				stdIn:       os.Stdin,
-				args:        []string{"toolbox test"},
+				args:        []string{"Toolbx test"},
 				loglevel:    logrus.InfoLevel,
 				useStdErr:   false,
 			},
@@ -265,14 +265,14 @@ func TestShellRunWithExitCode(t *testing.T) {
 			input: input{
 				commandName: "echo",
 				stdIn:       os.Stdin,
-				args:        []string{"toolbox test"},
+				args:        []string{"Toolbx test"},
 				loglevel:    logrus.InfoLevel,
 				useStdErr:   false,
 			},
 			expect: expect{
 				err:    nil,
 				code:   0,
-				stdout: []byte("toolbox test\n"),
+				stdout: []byte("Toolbx test\n"),
 				stderr: nil,
 			},
 		},
@@ -281,14 +281,14 @@ func TestShellRunWithExitCode(t *testing.T) {
 			input: input{
 				commandName: "echo",
 				stdIn:       os.Stdin,
-				args:        []string{"toolbox test"},
+				args:        []string{"Toolbx test"},
 				loglevel:    logrus.DebugLevel,
 				useStdErr:   false,
 			},
 			expect: expect{
 				err:    nil,
 				code:   0,
-				stdout: []byte("toolbox test\n"),
+				stdout: []byte("Toolbx test\n"),
 				stderr: nil,
 			},
 		},
@@ -313,7 +313,7 @@ func TestShellRunWithExitCode(t *testing.T) {
 			input: input{
 				commandName: "no-exist-executable",
 				stdIn:       os.Stdin,
-				args:        []string{"toolbox test"},
+				args:        []string{"Toolbx test"},
 				loglevel:    logrus.InfoLevel,
 				useStdErr:   false,
 			},

--- a/src/pkg/version/version.go
+++ b/src/pkg/version/version.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ var (
 	currentVersion string
 )
 
-// GetVersion returns string with the version of Toolbox
+// GetVersion returns string with the version of Toolbx
 func GetVersion() string {
 	return currentVersion
 }

--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2019 – 2023 Red Hat, Inc.
+# Copyright © 2019 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ setup() {
 }
 
 @test "version: Check version using option --version" {
-  run --separate-stderr "$TOOLBOX" --version
+  run --separate-stderr "$TOOLBX" --version
 
   assert_success
   assert_output --regexp '^toolbox version [0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2020 – 2023 Red Hat, Inc.
+# Copyright © 2020 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,15 +24,15 @@ setup() {
 }
 
 @test "help: Smoke test" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX"
+  run --keep-empty-lines --separate-stderr "$TOOLBX"
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: missing command"
-  assert_line --index 2 "create    Create a new toolbox container"
-  assert_line --index 3 "enter     Enter an existing toolbox container"
-  assert_line --index 4 "list      List all existing toolbox containers and images"
+  assert_line --index 2 "create    Create a new Toolbx container"
+  assert_line --index 3 "enter     Enter an existing Toolbx container"
+  assert_line --index 4 "list      List all existing Toolbx containers and images"
   assert_line --index 6 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 7 ]
 }
@@ -42,7 +42,7 @@ setup() {
     skip "not found man(1)"
   fi
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" help
+  run --keep-empty-lines --separate-stderr "$TOOLBX" help
 
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
@@ -57,14 +57,14 @@ setup() {
     skip "found man(1)"
   fi
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" help
+  run --keep-empty-lines --separate-stderr "$TOOLBX" help
 
   assert_success
   assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
   assert_line --index 2 "Common commands are:"
-  assert_line --index 3 "create    Create a new toolbox container"
-  assert_line --index 4 "enter     Enter an existing toolbox container"
-  assert_line --index 5 "list      List all existing toolbox containers and images"
+  assert_line --index 3 "create    Create a new Toolbx container"
+  assert_line --index 4 "enter     Enter an existing Toolbx container"
+  assert_line --index 5 "list      List all existing Toolbx containers and images"
   assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
   assert [ ${#lines[@]} -eq 8 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -75,7 +75,7 @@ setup() {
     skip "not found man(1)"
   fi
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" --help
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --help
 
   assert_success
   assert_line --index 0 --partial "toolbox(1)"
@@ -90,14 +90,14 @@ setup() {
     skip "found man(1)"
   fi
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" --help
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --help
 
   assert_success
   assert_line --index 0 "toolbox - Tool for containerized command line environments on Linux"
   assert_line --index 2 "Common commands are:"
-  assert_line --index 3 "create    Create a new toolbox container"
-  assert_line --index 4 "enter     Enter an existing toolbox container"
-  assert_line --index 5 "list      List all existing toolbox containers and images"
+  assert_line --index 3 "create    Create a new Toolbx container"
+  assert_line --index 4 "enter     Enter an existing Toolbx container"
+  assert_line --index 5 "list      List all existing Toolbx containers and images"
   assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
 
   if check_bats_version 1.10.0; then
@@ -111,7 +111,7 @@ setup() {
 }
 
 @test "help: Try unknown command" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -122,7 +122,7 @@ setup() {
 }
 
 @test "help: Try unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -133,7 +133,7 @@ setup() {
 }
 
 @test "help: Try 'create' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" create --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -144,7 +144,7 @@ setup() {
 }
 
 @test "help: Try 'enter' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" enter --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" enter --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -155,7 +155,7 @@ setup() {
 }
 
 @test "help: Try 'help' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" help --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" help --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -166,7 +166,7 @@ setup() {
 }
 
 @test "help: Try 'init-container' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" init-container --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" init-container --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -177,7 +177,7 @@ setup() {
 }
 
 @test "help: Try 'list' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -188,7 +188,7 @@ setup() {
 }
 
 @test "help: Try 'rm' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rm --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rm --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -199,7 +199,7 @@ setup() {
 }
 
 @test "help: Try 'rmi' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -210,7 +210,7 @@ setup() {
 }
 
 @test "help: Try 'run' with unknown flag" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --foo
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -31,7 +31,7 @@ teardown() {
 @test "create: Smoke test" {
   pull_default_image
 
-  run "$TOOLBOX" --assumeyes create
+  run "$TOOLBX" --assumeyes create
 
   assert_success
 }
@@ -39,7 +39,7 @@ teardown() {
 @test "create: With a custom name (using option --container)" {
   pull_default_image
 
-  run "$TOOLBOX" --assumeyes create --container "custom-containerName"
+  run "$TOOLBX" --assumeyes create --container "custom-containerName"
 
   assert_success
 }
@@ -47,25 +47,25 @@ teardown() {
 @test "create: With a custom image and name (using option --container)" {
   pull_distro_image fedora 34
 
-  run "$TOOLBOX" --assumeyes create --container "fedora34" --image fedora-toolbox:34
+  run "$TOOLBX" --assumeyes create --container "fedora34" --image fedora-toolbox:34
 
   assert_success
 }
 
 @test "create: Try without --assumeyes" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" create
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
-  assert_line --index 0 "Error: image required to create toolbox container."
+  assert_line --index 0 "Error: image required to create Toolbx container."
   assert_line --index 1 "Use option '--assumeyes' to download the image."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 3 ]
 }
 
 @test "create: Try with an invalid custom name (using positional argument)" {
-  run "$TOOLBOX" --assumeyes create "ßpeci@l.N@m€"
+  run "$TOOLBX" --assumeyes create "ßpeci@l.N@m€"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for 'CONTAINER'"
@@ -74,7 +74,7 @@ teardown() {
 }
 
 @test "create: Try with an invalid custom name (using option --container)" {
-  run "$TOOLBOX" --assumeyes create --container "ßpeci@l.N@m€"
+  run "$TOOLBX" --assumeyes create --container "ßpeci@l.N@m€"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--container'"
@@ -85,7 +85,7 @@ teardown() {
 @test "create: Try with an invalid custom image" {
   local image="ßpeci@l.N@m€"
 
-  run "$TOOLBOX" create --image "$image"
+  run "$TOOLBX" create --image "$image"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--image'"
@@ -98,7 +98,7 @@ teardown() {
 @test "create: Try with an invalid custom image (using --assumeyes)" {
   local image="ßpeci@l.N@m€"
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" --assumeyes create --image "$image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image"
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -113,7 +113,7 @@ teardown() {
 @test "create: Arch Linux" {
   pull_distro_image arch latest
 
-  run "$TOOLBOX" --assumeyes create --distro arch
+  run "$TOOLBX" --assumeyes create --distro arch
 
   assert_success
   assert_output --partial "Created container: arch-toolbox-latest"
@@ -127,7 +127,7 @@ teardown() {
 @test "create: Arch Linux ('--release latest')" {
   pull_distro_image arch latest
 
-  run "$TOOLBOX" --assumeyes create --distro arch --release latest
+  run "$TOOLBX" --assumeyes create --distro arch --release latest
 
   assert_success
   assert_output --partial "Created container: arch-toolbox-latest"
@@ -141,7 +141,7 @@ teardown() {
 @test "create: Arch Linux ('--release rolling')" {
   pull_distro_image arch latest
 
-  run "$TOOLBOX" --assumeyes create --distro arch --release rolling
+  run "$TOOLBX" --assumeyes create --distro arch --release rolling
 
   assert_success
   assert_output --partial "Created container: arch-toolbox-latest"
@@ -155,7 +155,7 @@ teardown() {
 @test "create: Fedora 34" {
   pull_distro_image fedora 34
 
-  run "$TOOLBOX" --assumeyes create --distro fedora --release f34
+  run "$TOOLBX" --assumeyes create --distro fedora --release f34
 
   assert_success
   assert_output --partial "Created container: fedora-toolbox-34"
@@ -169,7 +169,7 @@ teardown() {
 @test "create: RHEL 8.9" {
   pull_distro_image rhel 8.9
 
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.9
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.9
 
   assert_success
   assert_output --partial "Created container: rhel-toolbox-8.9"
@@ -183,7 +183,7 @@ teardown() {
 @test "create: Ubuntu 16.04" {
   pull_distro_image ubuntu 16.04
 
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 16.04
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 16.04
 
   assert_success
   assert_output --partial "Created container: ubuntu-toolbox-16.04"
@@ -198,7 +198,7 @@ teardown() {
 @test "create: Ubuntu 18.04" {
   pull_distro_image ubuntu 18.04
 
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 18.04
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 18.04
 
   assert_success
   assert_output --partial "Created container: ubuntu-toolbox-18.04"
@@ -213,7 +213,7 @@ teardown() {
 @test "create: Ubuntu 20.04" {
   pull_distro_image ubuntu 20.04
 
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20.04
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20.04
 
   assert_success
   assert_output --partial "Created container: ubuntu-toolbox-20.04"
@@ -228,7 +228,7 @@ teardown() {
 @test "create: Try an unsupported distribution" {
   local distro="foo"
 
-  run "$TOOLBOX" --assumeyes create --distro "$distro"
+  run "$TOOLBX" --assumeyes create --distro "$distro"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--distro'"
@@ -238,19 +238,19 @@ teardown() {
 }
 
 @test "create: Try a non-existent image" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" create --image foo.org/bar
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image foo.org/bar
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
-  assert_line --index 0 "Error: image required to create toolbox container."
+  assert_line --index 0 "Error: image required to create Toolbx container."
   assert_line --index 1 "Use option '--assumeyes' to download the image."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 3 ]
 }
 
 @test "create: Try a non-existent image (using --assumeyes)" {
-  run "$TOOLBOX" --assumeyes create --image foo.org/bar
+  run "$TOOLBX" --assumeyes create --image foo.org/bar
 
   assert_failure
   assert_line --index 0 "Error: failed to pull image foo.org/bar"
@@ -259,7 +259,7 @@ teardown() {
 }
 
 @test "create: Try Arch Linux with an invalid release ('--release foo')" {
-  run "$TOOLBOX" --assumeyes create --distro arch --release foo
+  run "$TOOLBX" --assumeyes create --distro arch --release foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -269,7 +269,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release -3')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release -3
+  run "$TOOLBX" --assumeyes create --distro fedora --release -3
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -279,7 +279,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release -3.0')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release -3.0
+  run "$TOOLBX" --assumeyes create --distro fedora --release -3.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -289,7 +289,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release -3.1')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release -3.1
+  run "$TOOLBX" --assumeyes create --distro fedora --release -3.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -299,7 +299,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 0')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 0
+  run "$TOOLBX" --assumeyes create --distro fedora --release 0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -309,7 +309,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 0.0')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 0.0
+  run "$TOOLBX" --assumeyes create --distro fedora --release 0.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -319,7 +319,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 0.1')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 0.1
+  run "$TOOLBX" --assumeyes create --distro fedora --release 0.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -329,7 +329,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 3.0')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 3.0
+  run "$TOOLBX" --assumeyes create --distro fedora --release 3.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -339,7 +339,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 3.1')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 3.1
+  run "$TOOLBX" --assumeyes create --distro fedora --release 3.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -349,7 +349,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release foo')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release foo
+  run "$TOOLBX" --assumeyes create --distro fedora --release foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -359,7 +359,7 @@ teardown() {
 }
 
 @test "create: Try Fedora with an invalid release ('--release 3foo')" {
-  run "$TOOLBOX" --assumeyes create --distro fedora --release 3foo
+  run "$TOOLBX" --assumeyes create --distro fedora --release 3foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -369,7 +369,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -379,7 +379,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8.0.0')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.0.0
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.0.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -389,7 +389,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8.0.1')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.0.1
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.0.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -399,7 +399,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8.3.0')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.3.0
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.3.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -409,7 +409,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8.3.1')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.3.1
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.3.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -419,7 +419,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release foo')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release foo
+  run "$TOOLBX" --assumeyes create --distro rhel --release foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -429,7 +429,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 8.2foo')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 8.2foo
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.2foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -439,7 +439,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release -2.1')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release -2.1
+  run "$TOOLBX" --assumeyes create --distro rhel --release -2.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -449,7 +449,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release -2.-1')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release -2.-1
+  run "$TOOLBX" --assumeyes create --distro rhel --release -2.-1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -459,7 +459,7 @@ teardown() {
 }
 
 @test "create: Try RHEL with an invalid release ('--release 2.-1')" {
-  run "$TOOLBOX" --assumeyes create --distro rhel --release 2.-1
+  run "$TOOLBX" --assumeyes create --distro rhel --release 2.-1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -469,7 +469,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 20')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -479,7 +479,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 20.04.0')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20.04.0
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20.04.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -489,7 +489,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 20.04.1')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20.04.1
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20.04.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -499,7 +499,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release foo')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release foo
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -509,7 +509,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 20foo')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20foo
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -519,7 +519,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release foo.bar')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release foo.bar
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release foo.bar
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -529,7 +529,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release foo.bar.baz')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release foo.bar.baz
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release foo.bar.baz
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -539,7 +539,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 3.10')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 3.10
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 3.10
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -549,7 +549,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 202.4')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 202.4
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 202.4
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -559,7 +559,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 202.04')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 202.04
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 202.04
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -569,7 +569,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 2020.4')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 2020.4
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 2020.4
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -579,7 +579,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 2020.04')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 2020.04
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 2020.04
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -589,7 +589,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 04.10')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 04.10
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 04.10
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -599,7 +599,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 4.bar')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 4.bar
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 4.bar
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -609,7 +609,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 4.bar.baz')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 4.bar.baz
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 4.bar.baz
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -619,7 +619,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 4.0')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 4.0
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 4.0
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -629,7 +629,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 4.00')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 4.00
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 4.00
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -639,7 +639,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 4.13')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 4.13
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 4.13
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -649,7 +649,7 @@ teardown() {
 }
 
 @test "create: Try Ubuntu with an invalid release ('--release 20.4')" {
-  run "$TOOLBOX" --assumeyes create --distro ubuntu --release 20.4
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 20.4
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -668,7 +668,7 @@ teardown() {
     distro="rhel"
   fi
 
-  run "$TOOLBOX" --assumeyes create --distro "$distro"
+  run "$TOOLBX" --assumeyes create --distro "$distro"
 
   assert_failure
   assert_line --index 0 "Error: option '--release' is needed"
@@ -678,7 +678,7 @@ teardown() {
 }
 
 @test "create: Try using both --distro and --image" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" create --distro fedora --image fedora-toolbox:34
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --distro fedora --image fedora-toolbox:34
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -691,7 +691,7 @@ teardown() {
 @test "create: Try using both --distro and --image (using --assumeyes)" {
   pull_distro_image fedora 34
 
-  run "$TOOLBOX" --assumeyes create --distro fedora --image fedora-toolbox:34
+  run "$TOOLBX" --assumeyes create --distro fedora --image fedora-toolbox:34
 
   assert_failure
   assert_line --index 0 "Error: options --distro and --image cannot be used together"
@@ -700,7 +700,7 @@ teardown() {
 }
 
 @test "create: Try using both --image and --release" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" create --image fedora-toolbox:34 --release 34
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image fedora-toolbox:34 --release 34
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -713,7 +713,7 @@ teardown() {
 @test "create: Try using both --image and --release (using --assumeyes)" {
   pull_distro_image fedora 34
 
-  run "$TOOLBOX" --assumeyes create --image fedora-toolbox:34 --release 34
+  run "$TOOLBX" --assumeyes create --image fedora-toolbox:34 --release 34
 
   assert_failure
   assert_line --index 0 "Error: options --image and --release cannot be used together"
@@ -724,7 +724,7 @@ teardown() {
 @test "create: Try a non-existent authentication file" {
   local file="$BATS_RUN_TMPDIR/non-existent-file"
 
-  run "$TOOLBOX" create --authfile "$file"
+  run "$TOOLBX" create --authfile "$file"
 
   assert_failure
   assert_line --index 0 "Error: file $file not found"
@@ -736,7 +736,7 @@ teardown() {
 @test "create: Try a non-existent authentication file (using --assumeyes)" {
   local file="$BATS_RUN_TMPDIR/non-existent-file"
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" --assumeyes create --authfile "$file"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --authfile "$file"
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -754,7 +754,7 @@ teardown() {
   run $PODMAN login --authfile "$authfile" --username user --password user "$DOCKER_REG_URI"
   assert_success
 
-  run "$TOOLBOX" --assumeyes create --image "$DOCKER_REG_URI/$image"
+  run "$TOOLBX" --assumeyes create --image "$DOCKER_REG_URI/$image"
 
   assert_failure
   assert_line --index 0 "Error: failed to pull image $DOCKER_REG_URI/$image"
@@ -762,7 +762,7 @@ teardown() {
   assert_line --index 2 "Use 'toolbox --verbose ...' for further details."
   assert [ ${#lines[@]} -eq 3 ]
 
-  run "$TOOLBOX" --assumeyes create --authfile "$authfile" --image "$DOCKER_REG_URI/$image"
+  run "$TOOLBX" --assumeyes create --authfile "$authfile" --image "$DOCKER_REG_URI/$image"
 
   rm "$authfile"
 

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -30,7 +30,7 @@ teardown() {
 }
 
 @test "list: Smoke test" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -40,7 +40,7 @@ teardown() {
 }
 
 @test "list: Smoke test (using --containers)" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --containers
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --containers
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -48,7 +48,7 @@ teardown() {
 }
 
 @test "list: Smoke test (using --images)" {
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -62,7 +62,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -76,7 +76,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -93,7 +93,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "$default_image"
@@ -117,7 +117,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "$default_image"
@@ -138,7 +138,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
@@ -159,7 +159,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/arch-toolbox:latest"
@@ -180,7 +180,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
@@ -201,7 +201,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
@@ -222,7 +222,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
@@ -243,7 +243,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
@@ -264,7 +264,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
@@ -285,7 +285,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
@@ -306,7 +306,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
@@ -327,7 +327,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
@@ -348,7 +348,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:20.04"
@@ -369,7 +369,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:20.04"
@@ -390,7 +390,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "<none>"
@@ -411,7 +411,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "<none>"
@@ -435,7 +435,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "$default_image"
@@ -460,7 +460,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "$default_image"
@@ -496,7 +496,7 @@ teardown() {
   create_container non-default-two
 
   # Check images
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
@@ -511,7 +511,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check containers
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --containers
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --containers
 
   assert_success
   assert_line --index 1 --partial "$default_container"
@@ -527,7 +527,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   # Check all together
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "registry.fedoraproject.org/fedora-toolbox:34"
@@ -557,7 +557,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 3
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert_line --index 1 --partial "<none>"
@@ -581,7 +581,7 @@ teardown() {
   pull_distro_image fedora 34
   build_image_without_name >/dev/null
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert_line --index 1 --partial "<none>"
@@ -613,7 +613,7 @@ teardown() {
   num_of_containers="$(list_containers)"
   assert_equal "$num_of_containers" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -636,7 +636,7 @@ teardown() {
   num_of_containers="$(list_containers)"
   assert_equal "$num_of_containers" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --containers
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --containers
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -659,7 +659,7 @@ teardown() {
   num_of_containers="$(list_containers)"
   assert_equal "$num_of_containers" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" list --images
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -32,7 +32,7 @@ teardown() {
 @test "run: Smoke test with true(1)" {
   create_default_container
 
-  run "$TOOLBOX" run true
+  run "$TOOLBX" run true
 
   assert_success
   assert_output ""
@@ -41,7 +41,7 @@ teardown() {
 @test "run: Smoke test with false(1)" {
   create_default_container
 
-  run -1 "$TOOLBOX" run false
+  run -1 "$TOOLBX" run false
 
   assert_failure
   assert_output ""
@@ -50,7 +50,7 @@ teardown() {
 @test "run: Smoke test with Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --separate-stderr "$TOOLBOX" run --distro arch true
+  run --separate-stderr "$TOOLBX" run --distro arch true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -62,7 +62,7 @@ teardown() {
 @test "run: Smoke test with Arch Linux ('--release latest')" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --separate-stderr "$TOOLBOX" run --distro arch --release latest true
+  run --separate-stderr "$TOOLBX" run --distro arch --release latest true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -72,7 +72,7 @@ teardown() {
 @test "run: Smoke test with Arch Linux ('--release rolling')" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --separate-stderr "$TOOLBOX" run --distro arch --release rolling true
+  run --separate-stderr "$TOOLBX" run --distro arch --release rolling true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -82,7 +82,7 @@ teardown() {
 @test "run: Smoke test with Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 34 true
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 34 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -92,7 +92,7 @@ teardown() {
 @test "run: Smoke test with RHEL 8.9" {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 true
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -102,7 +102,7 @@ teardown() {
 @test "run: Smoke test with Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 true
+  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -112,7 +112,7 @@ teardown() {
 @test "run: Smoke test with Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 true
+  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -122,7 +122,7 @@ teardown() {
 @test "run: Smoke test with Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 true
+  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -135,7 +135,7 @@ teardown() {
   cp "$HOME"/.bash_profile "$HOME"/.bash_profile.orig
   echo "echo \"$HOME/.bash_profile read\"" >>"$HOME"/.bash_profile
 
-  run "$TOOLBOX" run true
+  run "$TOOLBX" run true
 
   mv "$HOME"/.bash_profile.orig "$HOME"/.bash_profile
 
@@ -147,7 +147,7 @@ teardown() {
 @test "run: 'echo \"Hello World\"' inside the default container" {
   create_default_container
 
-  run "$TOOLBOX" --verbose run echo "Hello World"
+  run "$TOOLBX" --verbose run echo "Hello World"
 
   assert_success
   assert_line --index $((${#lines[@]}-1)) "Hello World"
@@ -159,7 +159,7 @@ teardown() {
   start_container running
   stop_container running
 
-  run "$TOOLBOX" --verbose run --container running echo "Hello World"
+  run "$TOOLBX" --verbose run --container running echo "Hello World"
 
   assert_success
   assert_line --index $((${#lines[@]}-1)) "Hello World"
@@ -168,7 +168,7 @@ teardown() {
 @test "run: 'sudo id' inside the default container" {
   create_default_container
 
-  output="$("$TOOLBOX" --verbose run sudo id 2>"$BATS_TEST_TMPDIR/stderr")"
+  output="$("$TOOLBX" --verbose run sudo id 2>"$BATS_TEST_TMPDIR/stderr")"
   status="$?"
 
   echo "# stderr"
@@ -183,7 +183,7 @@ teardown() {
 @test "run: Ensure that /run/.containerenv exists" {
   create_default_container
 
-  run --separate-stderr "$TOOLBOX" run cat /run/.containerenv
+  run --separate-stderr "$TOOLBX" run cat /run/.containerenv
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -193,7 +193,7 @@ teardown() {
 @test "run: Ensure that /run/.toolboxenv exists" {
   create_default_container
 
-  run --separate-stderr "$TOOLBOX" run test -f /run/.toolboxenv
+  run --separate-stderr "$TOOLBX" run test -f /run/.toolboxenv
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -209,7 +209,7 @@ teardown() {
   create_default_container
   create_container other-container
 
-  run --separate-stderr "$TOOLBOX" run cat /run/.containerenv
+  run --separate-stderr "$TOOLBX" run cat /run/.containerenv
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -235,7 +235,7 @@ teardown() {
   create_default_container
   create_container other-container
 
-  run --separate-stderr "$TOOLBOX" run --container other-container cat /run/.containerenv
+  run --separate-stderr "$TOOLBX" run --container other-container cat /run/.containerenv
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -256,10 +256,10 @@ teardown() {
   create_default_container
 
   local host_only_dir
-  host_only_dir="$(mktemp --directory /var/tmp/toolbox-test-XXXXXXXXXX)"
+  host_only_dir="$(mktemp --directory /var/tmp/toolbx-test-XXXXXXXXXX)"
 
   pushd "$host_only_dir"
-  run --separate-stderr "$TOOLBOX" run pwd
+  run --separate-stderr "$TOOLBX" run pwd
   popd
 
   rm --force --recursive "$host_only_dir"
@@ -278,7 +278,7 @@ teardown() {
   create_default_container
 
   # File descriptors 3 and 4 are reserved by Bats.
-  run --separate-stderr "$TOOLBOX" run --preserve-fds 3 readlink /proc/self/fd/5 5>/dev/null
+  run --separate-stderr "$TOOLBX" run --preserve-fds 3 readlink /proc/self/fd/5 5>/dev/null
 
   assert_success
   assert_line --index 0 "/dev/null"
@@ -290,13 +290,13 @@ teardown() {
   local default_container_name
   default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
 
-  run --separate-stderr "$TOOLBOX" run true
+  run --separate-stderr "$TOOLBX" run true
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: container $default_container_name not found"
-  assert_line --index 1 "Use the 'create' command to create a toolbox."
+  assert_line --index 1 "Use the 'create' command to create a Toolbx."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 3 ]
 }
@@ -307,13 +307,13 @@ teardown() {
 
   create_container other-container
 
-  run --separate-stderr "$TOOLBOX" run true
+  run --separate-stderr "$TOOLBX" run true
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: container $default_container_name not found"
-  assert_line --index 1 "Use the 'create' command to create a toolbox."
+  assert_line --index 1 "Use the 'create' command to create a Toolbx."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 3 ]
 }
@@ -321,13 +321,13 @@ teardown() {
 @test "run: Try a specific non-existent container with another present" {
   create_container other-container
 
-  run --separate-stderr "$TOOLBOX" run --container wrong-container true
+  run --separate-stderr "$TOOLBX" run --container wrong-container true
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: container wrong-container not found"
-  assert_line --index 1 "Use the 'create' command to create a toolbox."
+  assert_line --index 1 "Use the 'create' command to create a Toolbx."
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 3 ]
 }
@@ -335,7 +335,7 @@ teardown() {
 @test "run: Try an unsupported distribution" {
   local distro="foo"
 
-  run --separate-stderr "$TOOLBOX" --assumeyes run --distro "$distro" ls
+  run --separate-stderr "$TOOLBX" --assumeyes run --distro "$distro" ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -347,7 +347,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release -3')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release -3 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release -3 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -359,7 +359,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release -3.0')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release -3.0 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release -3.0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -371,7 +371,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release -3.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release -3.1 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release -3.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -383,7 +383,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 0')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 0 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -395,7 +395,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 0.0')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 0.0 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 0.0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -407,7 +407,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 0.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 0.1 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 0.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -419,7 +419,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 3.0')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 3.0 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 3.0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -431,7 +431,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 3.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 3.1 ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 3.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -443,7 +443,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release foo')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release foo ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release foo ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -455,7 +455,7 @@ teardown() {
 }
 
 @test "run: Try Fedora with an invalid release ('--release 3foo')" {
-  run --separate-stderr "$TOOLBOX" run --distro fedora --release 3foo ls
+  run --separate-stderr "$TOOLBX" run --distro fedora --release 3foo ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -467,7 +467,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -479,7 +479,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8.0.0')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.0.0 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.0.0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -491,7 +491,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8.0.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.0.1 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.0.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -503,7 +503,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8.3.0')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.3.0 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.3.0 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -515,7 +515,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8.3.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.3.1 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.3.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -527,7 +527,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release foo')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release foo ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release foo ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -539,7 +539,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 8.2foo')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 8.2foo ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.2foo ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -551,7 +551,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release -2.1')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release -2.1 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release -2.1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -563,7 +563,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release -2.-1')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release -2.-1 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release -2.-1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -575,7 +575,7 @@ teardown() {
 }
 
 @test "run: Try RHEL with an invalid release ('--release 2.-1')" {
-  run --separate-stderr "$TOOLBOX" run --distro rhel --release 2.-1 ls
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 2.-1 ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -596,7 +596,7 @@ teardown() {
     distro="rhel"
   fi
 
-  run --separate-stderr "$TOOLBOX" run --distro "$distro" ls
+  run --separate-stderr "$TOOLBX" run --distro "$distro" ls
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -610,7 +610,7 @@ teardown() {
 @test "run: Smoke test with 'exit 2'" {
   create_default_container
 
-  run -2 "$TOOLBOX" run /bin/sh -c 'exit 2'
+  run -2 "$TOOLBX" run /bin/sh -c 'exit 2'
   assert_failure
   assert_output ""
 }
@@ -622,7 +622,7 @@ teardown() {
   create_default_container
 
   # File descriptors 3 and 4 are reserved by Bats.
-  run -125 --separate-stderr "$TOOLBOX" run --preserve-fds 3 readlink /proc/self/fd/5
+  run -125 --separate-stderr "$TOOLBX" run --preserve-fds 3 readlink /proc/self/fd/5
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -635,7 +635,7 @@ teardown() {
 @test "run: Try /etc as a command" {
   create_default_container
 
-  run -126 --separate-stderr "$TOOLBOX" run /etc
+  run -126 --separate-stderr "$TOOLBX" run /etc
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -651,7 +651,7 @@ teardown() {
 
   create_default_container
 
-  run -127 --separate-stderr "$TOOLBOX" run "$cmd"
+  run -127 --separate-stderr "$TOOLBX" run "$cmd"
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ teardown() {
 }
 
 @test "enter: Try to enter the default container with no containers created" {
-  run $TOOLBOX enter <<< "n"
+  run $TOOLBX enter <<< "n"
 
   assert_success
-  assert_line --index 0 "No toolbox containers found. Create now? [y/N] A container can be created later with the 'create' command."
+  assert_line --index 0 "No Toolbx containers found. Create now? [y/N] A container can be created later with the 'create' command."
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
@@ -43,37 +43,37 @@ teardown() {
   create_container first
   create_container second
 
-  run $TOOLBOX enter
+  run $TOOLBX enter
 
   assert_failure
   assert_line --index 0 "Error: container $default_container_name not found"
-  assert_line --index 1 "Use the '--container' option to select a toolbox."
+  assert_line --index 1 "Use the '--container' option to select a Toolbx."
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
 @test "enter: Try to enter a specific container with no containers created " {
-  run $TOOLBOX enter wrong-container <<< "n"
+  run $TOOLBX enter wrong-container <<< "n"
 
   assert_success
-  assert_line --index 0 "No toolbox containers found. Create now? [y/N] A container can be created later with the 'create' command."
+  assert_line --index 0 "No Toolbx containers found. Create now? [y/N] A container can be created later with the 'create' command."
   assert_line --index 1 "Run 'toolbox --help' for usage."
 }
 
 @test "enter: Try to enter a specific non-existent container with other containers present" {
   create_container other-container
 
-  run $TOOLBOX enter wrong-container
+  run $TOOLBX enter wrong-container
 
   assert_failure
   assert_line --index 0 "Error: container wrong-container not found"
-  assert_line --index 1 "Use the '--container' option to select a toolbox."
+  assert_line --index 1 "Use the '--container' option to select a Toolbx."
   assert_line --index 2 "Run 'toolbox --help' for usage."
 }
 
 @test "enter: Try to enter a container based on unsupported distribution" {
   local distro="foo"
 
-  run $TOOLBOX --assumeyes enter --distro "$distro"
+  run $TOOLBX --assumeyes enter --distro "$distro"
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--distro'"
@@ -83,7 +83,7 @@ teardown() {
 }
 
 @test "enter: Try to enter a container based on Fedora but with wrong version" {
-  run $TOOLBOX enter -d fedora -r foobar
+  run $TOOLBX enter -d fedora -r foobar
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -91,7 +91,7 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#lines[@]} -eq 3 ]
 
-  run $TOOLBOX enter --distro fedora --release -3
+  run $TOOLBX enter --distro fedora --release -3
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -101,7 +101,7 @@ teardown() {
 }
 
 @test "enter: Try to enter a container based on RHEL but with wrong version" {
-  run $TOOLBOX enter --distro rhel --release 8
+  run $TOOLBX enter --distro rhel --release 8
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -109,7 +109,7 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#lines[@]} -eq 3 ]
 
-  run $TOOLBOX enter --distro rhel --release 8.2foo
+  run $TOOLBX enter --distro rhel --release 8.2foo
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -117,7 +117,7 @@ teardown() {
   assert_line --index 2 "Run 'toolbox --help' for usage."
   assert [ ${#lines[@]} -eq 3 ]
 
-  run $TOOLBOX enter --distro rhel --release -2.1
+  run $TOOLBX enter --distro rhel --release -2.1
 
   assert_failure
   assert_line --index 0 "Error: invalid argument for '--release'"
@@ -136,7 +136,7 @@ teardown() {
     distro="rhel"
   fi
 
-  run $TOOLBOX enter -d "$distro"
+  run $TOOLBX enter -d "$distro"
 
   assert_failure
   assert_line --index 0 "Error: option '--release' is needed"
@@ -146,16 +146,16 @@ teardown() {
 }
 
 # TODO: Write the test
-@test "enter: Enter the default toolbox" {
-  skip "Testing of entering toolboxes is not implemented"
+@test "enter: Enter the default Toolbx" {
+  skip "Testing of entering Toolbxes is not implemented"
 }
 
 # TODO: Write the test
-@test "enter: Enter the default toolbox when only 1 non-default toolbox is present" {
-  skip "Testing of entering toolboxes is not implemented"
+@test "enter: Enter the default Toolbx when only 1 non-default Toolbx is present" {
+  skip "Testing of entering Toolbxes is not implemented"
 }
 
 # TODO: Write the test
-@test "enter: Enter a specific toolbox" {
-  skip "Testing of entering toolboxes is not implemented"
+@test "enter: Enter a specific Toolbx" {
+  skip "Testing of entering Toolbxes is not implemented"
 }

--- a/test/system/106-rm.bats
+++ b/test/system/106-rm.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ teardown() {
 
 @test "rm: Try to remove a non-existent container" {
   container_name="nonexistentcontainer"
-  run "$TOOLBOX" rm "$container_name"
+  run "$TOOLBX" rm "$container_name"
 
   #assert_failure  #BUG: it should return 1
   assert_output "Error: failed to inspect container $container_name"
@@ -42,7 +42,7 @@ teardown() {
   create_container running
   start_container running
 
-  run "$TOOLBOX" rm running
+  run "$TOOLBX" rm running
 
   #assert_failure  #BUG: it should return 1
   assert_output "Error: container running is running"
@@ -51,7 +51,7 @@ teardown() {
 @test "rm: Remove a not running container" {
   create_container not-running
 
-  run "$TOOLBOX" rm not-running
+  run "$TOOLBX" rm not-running
 
   assert_success
   assert_output ""
@@ -61,7 +61,7 @@ teardown() {
   create_container running
   start_container running
 
-  run "$TOOLBOX" rm --force running
+  run "$TOOLBX" rm --force running
 
   assert_success
   assert_output ""
@@ -75,7 +75,7 @@ teardown() {
   create_container not-running
   start_container running
 
-  run "$TOOLBOX" rm --force --all
+  run "$TOOLBX" rm --force --all
 
   assert_success
   assert_output ""

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 0
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi --all
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -53,7 +53,7 @@ teardown() {
 
   pull_default_image
 
-  run --keep-empty-lines "$TOOLBOX" rmi --all
+  run --keep-empty-lines "$TOOLBX" rmi --all
 
   assert_success
   assert_output ""
@@ -76,7 +76,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -96,7 +96,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi --all
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -116,7 +116,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 1
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$image"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -139,13 +139,13 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image-copy"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -168,13 +168,13 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image-copy"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -197,7 +197,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image" "$default_image-copy"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image" "$default_image-copy"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -220,7 +220,7 @@ teardown() {
   num_of_images="$(list_images)"
   assert_equal "$num_of_images" 2
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi "$default_image-copy" "$default_image"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi "$default_image-copy" "$default_image"
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]
@@ -238,7 +238,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" rmi --all
+  run --keep-empty-lines --separate-stderr "$TOOLBX" rmi --all
 
   assert_failure
   lines=("${stderr_lines[@]}")
@@ -256,7 +256,7 @@ teardown() {
   create_container foo
   start_container foo
 
-  run --keep-empty-lines "$TOOLBOX" rmi --all --force
+  run --keep-empty-lines "$TOOLBX" rmi --all --force
 
   assert_success
   assert_output ""

--- a/test/system/108-completion.bats
+++ b/test/system/108-completion.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ setup() {
 }
 
 @test "completion: Smoke test with 'bash'" {
-  run "$TOOLBOX" completion bash
+  run "$TOOLBX" completion bash
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -35,7 +35,7 @@ setup() {
 }
 
 @test "completion: Smoke test with 'fish'" {
-  run "$TOOLBOX" completion fish
+  run "$TOOLBX" completion fish
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -43,7 +43,7 @@ setup() {
 }
 
 @test "completion: Smoke test with 'zsh'" {
-  run "$TOOLBOX" completion zsh
+  run "$TOOLBX" completion zsh
 
   assert_success
   assert [ ${#lines[@]} -gt 0 ]
@@ -51,7 +51,7 @@ setup() {
 }
 
 @test "completion: Try without any arguments" {
-  run --separate-stderr "$TOOLBOX" completion
+  run --separate-stderr "$TOOLBX" completion
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -62,7 +62,7 @@ setup() {
 }
 
 @test "completion: Try with invalid arguments" {
-  run --separate-stderr "$TOOLBOX" completion foo
+  run --separate-stderr "$TOOLBX" completion foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -73,7 +73,7 @@ setup() {
 }
 
 @test "completion: Try with unknown flag" {
-  run --separate-stderr "$TOOLBOX" completion --foo
+  run --separate-stderr "$TOOLBX" completion --foo
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -84,7 +84,7 @@ setup() {
 }
 
 @test "completion: Try with unsupported shell" {
-  run --separate-stderr "$TOOLBOX" completion powershell
+  run --separate-stderr "$TOOLBX" completion powershell
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'readlink /proc/$$/ns/ipc'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run sh -c 'readlink /proc/$$/ns/ipc'
 
   assert_success
   assert_line --index 0 "$ns_host"

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -47,7 +47,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'readlink /proc/$$/ns/net'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run sh -c 'readlink /proc/$$/ns/net'
 
   assert_success
   assert_line --index 0 "$ns_host"
@@ -65,7 +65,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside the default container" {
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -83,7 +83,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -101,7 +101,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -119,7 +119,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside RHEL 8.9" {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -137,7 +137,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -155,7 +155,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -173,7 +173,7 @@ teardown() {
 @test "network: /etc/resolv.conf inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -208,7 +208,7 @@ teardown() {
   create_default_container
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
@@ -223,7 +223,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
@@ -258,7 +258,7 @@ teardown() {
   create_distro_container arch latest arch-toolbox-latest
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro arch \
       sh -c "$RESOLVER_SH" A k.root-servers.net
 
@@ -275,7 +275,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro arch \
       sh -c "$RESOLVER_SH" AAAA k.root-servers.net
 
@@ -312,7 +312,7 @@ teardown() {
   create_distro_container fedora 34 fedora-toolbox-34
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro fedora \
       --release 34 \
       python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
@@ -330,7 +330,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro fedora \
       --release 34 \
       python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
@@ -368,7 +368,7 @@ teardown() {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro rhel \
       --release 8.9 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" A k.root-servers.net
@@ -386,7 +386,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro rhel \
       --release 8.9 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
@@ -424,7 +424,7 @@ teardown() {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 16.04 \
       python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
@@ -442,7 +442,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 16.04 \
       python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
@@ -480,7 +480,7 @@ teardown() {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 18.04 \
       python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
@@ -498,7 +498,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 18.04 \
       python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
@@ -536,7 +536,7 @@ teardown() {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 20.04 \
       python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
@@ -554,7 +554,7 @@ teardown() {
   fi
 
   if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 20.04 \
       python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
@@ -575,7 +575,7 @@ teardown() {
 @test "network: ping(8) inside the default container" {
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -591,7 +591,7 @@ teardown() {
 @test "network: ping(8) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -607,7 +607,7 @@ teardown() {
 @test "network: ping(8) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -623,7 +623,7 @@ teardown() {
 @test "network: ping(8) inside RHEL 8.9" {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -639,7 +639,7 @@ teardown() {
 @test "network: ping(8) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run -2 --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 ping -c 2 f.root-servers.net
+  run -2 --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 ping -c 2 f.root-servers.net
 
   assert_failure
   assert [ ${#lines[@]} -eq 0 ]
@@ -653,7 +653,7 @@ teardown() {
 @test "network: ping(8) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -669,7 +669,7 @@ teardown() {
 @test "network: ping(8) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -35,7 +35,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run sh -c 'readlink /proc/$$/ns/user'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run sh -c 'readlink /proc/$$/ns/user'
 
   assert_success
   assert_line --index 0 --regexp '^user:\[[[:digit:]]+\]$'
@@ -58,7 +58,7 @@ teardown() {
   create_default_container
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount "$default_container")"
 
-  "$TOOLBOX" run true
+  "$TOOLBX" run true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount "$default_container"
@@ -75,7 +75,7 @@ teardown() {
   create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount arch-toolbox-latest)"
 
-  "$TOOLBOX" run --distro arch true
+  "$TOOLBX" run --distro arch true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount arch-toolbox-latest
@@ -92,7 +92,7 @@ teardown() {
   create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount fedora-toolbox-34)"
 
-  "$TOOLBOX" run --distro fedora --release 34 true
+  "$TOOLBX" run --distro fedora --release 34 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount fedora-toolbox-34
@@ -109,7 +109,7 @@ teardown() {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
 
-  "$TOOLBOX" run --distro rhel --release 8.9 true
+  "$TOOLBX" run --distro rhel --release 8.9 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
@@ -126,7 +126,7 @@ teardown() {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 16.04 true
+  "$TOOLBX" run --distro ubuntu --release 16.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-16.04
@@ -143,7 +143,7 @@ teardown() {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 18.04 true
+  "$TOOLBX" run --distro ubuntu --release 18.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-18.04
@@ -160,7 +160,7 @@ teardown() {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 20.04 true
+  "$TOOLBX" run --distro ubuntu --release 20.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-20.04
@@ -182,7 +182,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -201,7 +201,7 @@ teardown() {
 
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -220,7 +220,7 @@ teardown() {
 
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -239,7 +239,7 @@ teardown() {
 
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -258,7 +258,7 @@ teardown() {
 
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -277,7 +277,7 @@ teardown() {
 
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -296,7 +296,7 @@ teardown() {
 
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -313,7 +313,7 @@ teardown() {
   create_default_container
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount "$default_container")"
 
-  "$TOOLBOX" run true
+  "$TOOLBX" run true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount "$default_container"
@@ -330,7 +330,7 @@ teardown() {
   create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount arch-toolbox-latest)"
 
-  "$TOOLBOX" run --distro arch true
+  "$TOOLBX" run --distro arch true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount arch-toolbox-latest
@@ -347,7 +347,7 @@ teardown() {
   create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount fedora-toolbox-34)"
 
-  "$TOOLBOX" run --distro fedora --release 34 true
+  "$TOOLBX" run --distro fedora --release 34 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount fedora-toolbox-34
@@ -364,7 +364,7 @@ teardown() {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
 
-  "$TOOLBOX" run --distro rhel --release 8.9 true
+  "$TOOLBX" run --distro rhel --release 8.9 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
@@ -381,7 +381,7 @@ teardown() {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 16.04 true
+  "$TOOLBX" run --distro ubuntu --release 16.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-16.04
@@ -398,7 +398,7 @@ teardown() {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 18.04 true
+  "$TOOLBX" run --distro ubuntu --release 18.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-18.04
@@ -415,7 +415,7 @@ teardown() {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
 
-  "$TOOLBOX" run --distro ubuntu --release 20.04 true
+  "$TOOLBX" run --distro ubuntu --release 20.04 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-20.04
@@ -431,7 +431,7 @@ teardown() {
 @test "user: $USER in group(5) inside the default container" {
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /etc/group
 
   assert_success
   assert_line --regexp "^(sudo|wheel):x:[[:digit:]]+:$USER$"
@@ -444,7 +444,7 @@ teardown() {
 @test "user: $USER in group(5) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch cat /etc/group
 
   assert_success
   assert_line --regexp "^wheel:x:[[:digit:]]+:$USER$"
@@ -457,7 +457,7 @@ teardown() {
 @test "user: $USER in group(5) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 cat /etc/group
 
   assert_success
   assert_line --regexp "^wheel:x:[[:digit:]]+:$USER$"
@@ -470,7 +470,7 @@ teardown() {
 @test "user: $USER in group(5) inside RHEL 8.9" {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 cat /etc/group
 
   assert_success
   assert_line --regexp "^wheel:x:[[:digit:]]+:$USER$"
@@ -483,7 +483,7 @@ teardown() {
 @test "user: $USER in group(5) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/group
 
   assert_success
   assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
@@ -496,7 +496,7 @@ teardown() {
 @test "user: $USER in group(5) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/group
 
   assert_success
   assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
@@ -509,7 +509,7 @@ teardown() {
 @test "user: $USER in group(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/group
 
   assert_success
   assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -R
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -R
 
   assert_success
   assert_line --index 0 "$limit"
@@ -56,7 +56,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -R
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -R
 
   assert_success
   assert_line --index 0 "$limit"
@@ -77,7 +77,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -c
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -c
 
   assert_success
   assert_line --index 0 "$limit"
@@ -98,7 +98,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -c
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -c
 
   assert_success
   assert_line --index 0 "$limit"
@@ -119,7 +119,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -d
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -d
 
   assert_success
   assert_line --index 0 "$limit"
@@ -140,7 +140,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -d
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -d
 
   assert_success
   assert_line --index 0 "$limit"
@@ -161,7 +161,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -e
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -e
 
   assert_success
   assert_line --index 0 "$limit"
@@ -182,7 +182,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -e
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -e
 
   assert_success
   assert_line --index 0 "$limit"
@@ -203,7 +203,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -f
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -f
 
   assert_success
   assert_line --index 0 "$limit"
@@ -224,7 +224,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -f
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -f
 
   assert_success
   assert_line --index 0 "$limit"
@@ -245,7 +245,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -i
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -i
 
   assert_success
   assert_line --index 0 "$limit"
@@ -266,7 +266,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -i
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -i
 
   assert_success
   assert_line --index 0 "$limit"
@@ -287,7 +287,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -l
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -l
 
   assert_success
   assert_line --index 0 "$limit"
@@ -308,7 +308,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -l
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -l
 
   assert_success
   assert_line --index 0 "$limit"
@@ -329,7 +329,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -m
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -m
 
   assert_success
   assert_line --index 0 "$limit"
@@ -350,7 +350,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -m
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -m
 
   assert_success
   assert_line --index 0 "$limit"
@@ -371,7 +371,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -n
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -n
 
   assert_success
   assert_line --index 0 "$limit"
@@ -392,7 +392,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -n
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -n
 
   assert_success
   assert_line --index 0 "$limit"
@@ -413,7 +413,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -p
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -p
 
   assert_success
   assert_line --index 0 "$limit"
@@ -434,7 +434,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -p
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -p
 
   assert_success
   assert_line --index 0 "$limit"
@@ -455,7 +455,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -q
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -q
 
   assert_success
   assert_line --index 0 "$limit"
@@ -476,7 +476,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -q
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -q
 
   assert_success
   assert_line --index 0 "$limit"
@@ -497,7 +497,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -r
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -r
 
   assert_success
   assert_line --index 0 "$limit"
@@ -518,7 +518,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -r
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -r
 
   assert_success
   assert_line --index 0 "$limit"
@@ -539,7 +539,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -s
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -s
 
   assert_success
   assert_line --index 0 "$limit"
@@ -560,7 +560,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -s
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -s
 
   assert_success
   assert_line --index 0 "$limit"
@@ -581,7 +581,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -t
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -t
 
   assert_success
   assert_line --index 0 "$limit"
@@ -602,7 +602,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -t
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -t
 
   assert_success
   assert_line --index 0 "$limit"
@@ -623,7 +623,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -u
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -u
 
   assert_success
   assert_line --index 0 "$limit"
@@ -644,7 +644,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -u
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -u
 
   assert_success
   assert_line --index 0 "$limit"
@@ -665,7 +665,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -v
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -v
 
   assert_success
   assert_line --index 0 "$limit"
@@ -686,7 +686,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -v
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -v
 
   assert_success
   assert_line --index 0 "$limit"
@@ -707,7 +707,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -H -x
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -x
 
   assert_success
   assert_line --index 0 "$limit"
@@ -728,7 +728,7 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run ulimit -S -x
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -x
 
   assert_success
   assert_line --index 0 "$limit"

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -39,11 +39,11 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run gdbus call \
-                                                            --session \
-                                                            --dest org.freedesktop.DBus \
-                                                            --object-path /org/freedesktop/DBus \
-                                                            --method org.freedesktop.DBus.Peer.Ping
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run gdbus call \
+                                                           --session \
+                                                           --dest org.freedesktop.DBus \
+                                                           --object-path /org/freedesktop/DBus \
+                                                           --method org.freedesktop.DBus.Peer.Ping
 
   assert_success
   assert_line --index 0 "$expected_response"
@@ -68,7 +68,7 @@ teardown() {
 
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro arch \
     gdbus call \
       --session \
@@ -99,7 +99,7 @@ teardown() {
 
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro fedora \
     --release 34 \
     gdbus call \
@@ -131,7 +131,7 @@ teardown() {
 
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro rhel \
     --release 8.9 \
     gdbus call \
@@ -158,7 +158,7 @@ teardown() {
 
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 16.04 \
     busctl --user call \
@@ -177,7 +177,7 @@ teardown() {
 
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 18.04 \
     busctl --user call \
@@ -196,7 +196,7 @@ teardown() {
 
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 20.04 \
     busctl --user call \
@@ -222,13 +222,13 @@ teardown() {
 
   create_default_container
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run gdbus call \
-                                                            --system \
-                                                            --dest org.freedesktop.systemd1 \
-                                                            --object-path /org/freedesktop/systemd1 \
-                                                            --method org.freedesktop.DBus.Properties.Get \
-                                                            org.freedesktop.systemd1.Manager \
-                                                            Version
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run gdbus call \
+                                                           --system \
+                                                           --dest org.freedesktop.systemd1 \
+                                                           --object-path /org/freedesktop/systemd1 \
+                                                           --method org.freedesktop.DBus.Properties.Get \
+                                                           org.freedesktop.systemd1.Manager \
+                                                           Version
 
   assert_success
   assert_line --index 0 "$expected_response"
@@ -255,7 +255,7 @@ teardown() {
 
   create_distro_container arch latest arch-toolbox-latest
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro arch \
     gdbus call \
       --system \
@@ -290,7 +290,7 @@ teardown() {
 
   create_distro_container fedora 34 fedora-toolbox-34
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro fedora \
     --release 34 \
     gdbus call \
@@ -326,7 +326,7 @@ teardown() {
 
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro rhel \
     --release 8.9 \
     gdbus call \
@@ -360,7 +360,7 @@ teardown() {
 
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 16.04 \
     busctl --system get-property \
@@ -392,7 +392,7 @@ teardown() {
 
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 18.04 \
     busctl --system get-property \
@@ -424,7 +424,7 @@ teardown() {
 
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 20.04 \
     busctl --system get-property \

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -42,7 +42,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -71,7 +71,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -100,7 +100,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -129,7 +129,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -158,7 +158,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 \
                                              bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
@@ -188,7 +188,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 \
                                              bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
@@ -217,7 +217,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 \
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 \
                                              bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
@@ -248,7 +248,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -277,7 +277,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -308,7 +308,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -339,7 +339,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -368,7 +368,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -397,7 +397,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -425,7 +425,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -444,10 +444,10 @@ teardown() {
   create_default_container
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 --regexp "^(toolbox|$HOSTNAME)$"
+  assert_line --index 0 --regexp "^(toolbx|$HOSTNAME)$"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -462,10 +462,10 @@ teardown() {
   create_distro_container arch latest arch-toolbox-latest
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro arch bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 "toolbox"
+  assert_line --index 0 "toolbx"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -480,7 +480,7 @@ teardown() {
   create_distro_container fedora 34 fedora-toolbox-34
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro fedora --release 34 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 bash -c 'echo "$HOSTNAME"'
 
   assert_success
   assert_line --index 0 "$HOSTNAME"
@@ -498,10 +498,10 @@ teardown() {
   create_distro_container rhel 8.9 rhel-toolbox-8.9
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro rhel --release 8.9 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 "toolbox"
+  assert_line --index 0 "toolbx"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -516,10 +516,10 @@ teardown() {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 16.04 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 "toolbox"
+  assert_line --index 0 "toolbx"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -534,10 +534,10 @@ teardown() {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 18.04 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 "toolbox"
+  assert_line --index 0 "toolbx"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]
@@ -552,10 +552,10 @@ teardown() {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBOX" run --distro ubuntu --release 20.04 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$HOSTNAME"'
 
   assert_success
-  assert_line --index 0 "toolbox"
+  assert_line --index 0 "toolbx"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 1 ]

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -2,8 +2,8 @@
 
 These tests are built with BATS (Bash Automated Testing System).
 
-The tests are meant to ensure that Toolbox's functionality remains stable
-throughout updates of both Toolbox and Podman/libpod.
+The tests are meant to ensure that Toolbx's functionality remains stable
+throughout updates of both Toolbx and Podman/libpod.
 
 The tests are set up in a way that does not affect the host environment.
 Running them won't remove any existing containers or images.
@@ -39,9 +39,9 @@ By default the test suite uses the system versions of `podman`, `skopeo` and
 `toolbox`.
 
 If you have a `podman`, `skopeo` or `toolbox` installed in a nonstandard
-location then you can use the `PODMAN`, `SKOPEO` and `TOOLBOX` environmental
+location then you can use the `PODMAN`, `SKOPEO` and `TOOLBX` environmental
 variables to set the path to the binaries. So the command to invoke the test
-suite could look something like this: `PODMAN=/usr/libexec/podman TOOLBOX=./toolbox bats ./test/system/`.
+suite could look something like this: `PODMAN=/usr/libexec/podman TOOLBX=./toolbox bats ./test/system/`.
 
 When running the tests, make sure the `test suite: [job]` jobs are successful.
 These jobs set up the whole environment and are a strict requirement for other

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -4,7 +4,7 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 
 # Helpful globals
-readonly TEMP_BASE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/toolbox"
+readonly TEMP_BASE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/toolbx"
 readonly TEMP_STORAGE_DIR="${TEMP_BASE_DIR}/system-test-storage"
 
 readonly IMAGE_CACHE_DIR="${BATS_RUN_TMPDIR}/image-cache"
@@ -17,9 +17,9 @@ readonly DOCKER_REG_AUTH_DIR="${BATS_RUN_TMPDIR}/auth"
 readonly DOCKER_REG_URI="localhost:50000"
 readonly DOCKER_REG_NAME="docker-registry"
 
-# Podman and Toolbox commands to run
+# Podman and Toolbx commands to run
 readonly PODMAN="${PODMAN:-$(command -v podman)}"
-readonly TOOLBOX="${TOOLBOX:-$(command -v toolbox)}"
+readonly TOOLBX="${TOOLBX:-$(command -v toolbox)}"
 readonly SKOPEO="${SKOPEO:-$(command -v skopeo)}"
 
 # Images
@@ -402,8 +402,8 @@ function create_distro_container() {
 
   pull_distro_image "${distro}" "${version}"
 
-  "$TOOLBOX" --assumeyes create --container "${container_name}" --distro "${distro}" --release "${version}" >/dev/null \
-    || fail "Toolbox couldn't create container '$container_name'"
+  "$TOOLBX" --assumeyes create --container "${container_name}" --distro "${distro}" --release "${version}" >/dev/null \
+    || fail "Toolbx couldn't create container '$container_name'"
 }
 
 
@@ -425,8 +425,8 @@ function create_container() {
 function create_default_container() {
   pull_default_image
 
-  "$TOOLBOX" --assumeyes create >/dev/null \
-    || fail "Toolbox couldn't create default container"
+  "$TOOLBX" --assumeyes create >/dev/null \
+    || fail "Toolbx couldn't create default container"
 }
 
 
@@ -439,7 +439,7 @@ function start_container() {
 }
 
 
-# Checks if a toolbox container started
+# Checks if a Toolbx container started
 #
 # Parameters:
 # ===========


### PR DESCRIPTION
This is meant to make the project more searchable on the Internet.  More and more people have been pointing out that "toolbox" is terribly difficult to search for, and it's impossible to find any decent Internet real estate by that name.

Some exceptions:

  * The code repository is still https://github.com/containers/toolbox.  It will be renamed after giving a heads-up to other contributors.

  * The name of the binary is still `toolbox`.  The name is embedded into existing Toolbx containers as their entry point, which is bind mounted from the host operating system when the containers are started.  Trivially renaming the binary will prevent these containers from starting.

  * For similar reasons, the `TOOLBOX_PATH` environment variable is still the same.

  * For similar reasons, the `profile.d` file to be read by the shell on start-up is still called `toolbox.sh`.

  * The label used to identify Toolbx containers and images is still called `com.github.containers.toolbox`.  There are many existing Toolbx containers, and many Toolbx images beyond the control of the Toolbx project that use this label to identity themselves.  Simply renaming the label will prevent these containers and images from being recognized.

  * The names of the built-in Toolbx images still retain the word `toolbox`.  Images under the new name need to be published on the OCI registries and the `toolbox(1)` binary needs to be taught to handle both old and new names, wherever necessary, for backwards compatibility.

  * The stamp file used to identify Toolbx containers is still called `/run/.toolboxenv` because it's used by various external programs and users to identify Toolbx containers.

  * The OSC 777 escape sequence to track and preserve the user's current Toolbx container [1] still emits `toolbox` as the name of the container runtime.  Changing the escape sequence can break terminal emulation applications, like Prompt [2], that consume it.  Hence, it needs to be done carefully.

  * The runtime directories at `/run/toolbox`, when used as root, and `$XDG_RUNTIME_DIR/toolbox`, when used rootless, weren't renamed.

    When used as root, `/run/toolbox` is embedded into existing Toolbx containers as a bind mount from the host.  Trivially renaming the path will prevent these containers from starting.

    Secondly, both these paths are used to synchronize container start-up.  If the paths are trivially renamed, and the `toolbox(1)` binary is updated and used without stopping all existing containers, then it won't be able to enter containers that were already started.  Strictly speaking, this scenario isn't supported, since updates are always expected to be *offline* [3].  However, it's worth noting because solving the previous problem might also address this.

  * The configuration file for RPM is still called `/usr/lib/rpm/macros.d/macros.toolbox`.

[1] https://gitlab.freedesktop.org/terminal-wg/specifications/-/issues/17

[2] https://gitlab.gnome.org/chergert/prompt

[3] https://www.freedesktop.org/software/systemd/man/latest/systemd.offline-updates.html

https://github.com/containers/toolbox/issues/1399