### PR TITLE
test/system: Unbreak Podman's downstream Fedora CI

### DIFF
--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -17,7 +17,7 @@
 
 missing_dependencies=false
 
-if [ -f test/system/libs/bats-assert/load.bash ] && [ -f test/system/libs/bats-support/load.bash ]; then
+if [ -f "$BATS_TEST_DIRNAME/libs/bats-assert/load.bash" ] && [ -f "$BATS_TEST_DIRNAME/libs/bats-support/load.bash" ]; then
   load 'libs/helpers'
 else
   missing_dependencies=true


### PR DESCRIPTION
The paths to `bats-assert` and `bats-support` are broken, if `bats(1)` is invoked from any other location than the parent directory of the `tests` directory.  eg., Podman's downstream Fedora CI invokes the tests as:
```
  $ cd /path/to/toolbox/test/system
  $ bats .
```

... and it led to [1]:
```
  1..306
  # test suite: Set up
  # Missing dependencies
  # Forgot to run 'git submodule init' and 'git submodule update' ?
  # test suite: Tear down
  not ok 1 setup_suite
  # (from function `setup_suite' in test file ./setup_suite.bash, line 33)
  #   `return 1' failed
  # bats warning: Executed 1 instead of expected 306 tests
```

Fallout from 2c0960660330dc6be6861502988695f9812c475a

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2263968