### PR TITLE
Update F39 image so that xdg-open links to flatpak-xdg-open

### DIFF
--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -27,7 +27,7 @@ COPY extra-packages /
 RUN dnf -y install $(<extra-packages)
 RUN rm /extra-packages
 
-RUN ln -s /usr/bin/flatpak-xdg-open /usr/bin/xdg-open
+RUN ln --symbolic /usr/bin/flatpak-xdg-open /usr/bin/xdg-open
 
 COPY ensure-files /
 RUN ret_val=0; \

--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -27,6 +27,8 @@ COPY extra-packages /
 RUN dnf -y install $(<extra-packages)
 RUN rm /extra-packages
 
+RUN ln -s /usr/bin/flatpak-xdg-open /usr/bin/xdg-open
+
 COPY ensure-files /
 RUN ret_val=0; \
   while read file; do \

--- a/images/fedora/f39/extra-packages
+++ b/images/fedora/f39/extra-packages
@@ -6,6 +6,7 @@ diffutils
 dnf-plugins-core
 findutils
 flatpak-spawn
+flatpak-xdg-utils
 fpaste
 git
 gnupg2


### PR DESCRIPTION
This implements the changes proposed [here](https://github.com/containers/toolbox/issues/291#issuecomment-1952038605).

**Changes**
- Adds the `flatpak-xdg-utils` to the list of extra packages
- Links `xdg-open` to `flatpak-xdg-open`

Closes #291