### PR TITLE
test/system: Limit the scope of temporary files used by all tests

### DIFF
--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -722,7 +722,7 @@ teardown() {
 }
 
 @test "create: Try a non-existent authentication file" {
-  local file="$BATS_RUN_TMPDIR/non-existent-file"
+  local file="$BATS_TEST_TMPDIR/non-existent-file"
 
   run "$TOOLBX" create --authfile "$file"
 
@@ -734,7 +734,7 @@ teardown() {
 }
 
 @test "create: Try a non-existent authentication file (using --assumeyes)" {
-  local file="$BATS_RUN_TMPDIR/non-existent-file"
+  local file="$BATS_TEST_TMPDIR/non-existent-file"
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --authfile "$file"
 
@@ -748,7 +748,7 @@ teardown() {
 }
 
 @test "create: With a custom image that needs an authentication file" {
-  local authfile="$BATS_RUN_TMPDIR/authfile"
+  local authfile="$BATS_TEST_TMPDIR/authfile"
   local image="fedora-toolbox:34"
 
   run $PODMAN login --authfile "$authfile" --username user --password user "$DOCKER_REG_URI"

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -7,13 +7,13 @@ load 'libs/bats-assert/load'
 readonly TEMP_BASE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/toolbx"
 readonly TEMP_STORAGE_DIR="${TEMP_BASE_DIR}/system-test-storage"
 
-readonly IMAGE_CACHE_DIR="${BATS_RUN_TMPDIR}/image-cache"
+readonly IMAGE_CACHE_DIR="${BATS_SUITE_TMPDIR}/image-cache"
 readonly ROOTLESS_PODMAN_STORE_DIR="${TEMP_STORAGE_DIR}/storage"
 readonly ROOTLESS_PODMAN_RUNROOT_DIR="${TEMP_STORAGE_DIR}/runroot"
 readonly PODMAN_STORE_CONFIG_FILE="${TEMP_STORAGE_DIR}/storage.conf"
 readonly DOCKER_REG_ROOT="${TEMP_STORAGE_DIR}/docker-registry-root"
-readonly DOCKER_REG_CERTS_DIR="${BATS_RUN_TMPDIR}/certs"
-readonly DOCKER_REG_AUTH_DIR="${BATS_RUN_TMPDIR}/auth"
+readonly DOCKER_REG_CERTS_DIR="${BATS_SUITE_TMPDIR}/certs"
+readonly DOCKER_REG_AUTH_DIR="${BATS_SUITE_TMPDIR}/auth"
 readonly DOCKER_REG_URI="localhost:50000"
 readonly DOCKER_REG_NAME="docker-registry"
 


### PR DESCRIPTION
`BATS_RUN_DIR` is the directory used by Bats for its own internal temporary files, and `BATS_SUITE_TMPDIR` is for creating files common to all tests in the test suite [1].  It's better to stay away from Bats' own internal temporary files to avoid unexpected collisions.

[1] https://bats-core.readthedocs.io/en/stable/writing-tests.html