### PR TITLE
Add ZDOTDIR to the list of preserved env vars

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -111,6 +111,7 @@ var (
 		"XDG_SESSION_TYPE",
 		"XDG_VTNR",
 		"XTERM_VERSION",
+		"ZDOTDIR",
 	}
 
 	releaseDefault string

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -913,3 +913,176 @@ teardown() {
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
+
+@test "environment variables: ZDOTDIR inside the default container" {
+  create_default_container
+
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside RHEL 8.9" {
+  create_distro_container rhel 8.9 rhel-toolbox-8.9
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    # shellcheck disable=SC2030
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: ZDOTDIR inside Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  # shellcheck disable=SC2031
+  if [ "$ZDOTDIR" = "" ]; then
+    export ZDOTDIR="$HOME/.config/zsh"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$ZDOTDIR"'
+
+  assert_success
+  assert_line --index 0 "$ZDOTDIR"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}


### PR DESCRIPTION
As discussed [here](https://github.com/containers/toolbox/issues/1454#issue-2143947296).

- Adds `ZDOTDIR` to the list of preserved environment variables

Closes #1454  