### PR TITLE
images/fedora: Add translations for gawk, and all the iconv converter modules for glibc

### DIFF
--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -6,7 +6,7 @@ LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \
       version="$VERSION" \
-      usage="This image is meant to be used with the toolbox command" \
+      usage="This image is meant to be used with the toolbox(1) command" \
       summary="Image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 

--- a/images/fedora/f38/Containerfile
+++ b/images/fedora/f38/Containerfile
@@ -7,7 +7,7 @@ LABEL com.github.containers.toolbox="true" \
       name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Fedora Toolbx containers" \
+      summary="Image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 
 COPY README.md /

--- a/images/fedora/f38/ensure-files
+++ b/images/fedora/f38/ensure-files
@@ -15,6 +15,9 @@
 /usr/share/locale/de/LC_MESSAGES/elfutils.mo
 /usr/share/locale/ja/LC_MESSAGES/elfutils.mo
 
+/usr/share/locale/fr/LC_MESSAGES/gawk.mo
+/usr/share/locale/ko/LC_MESSAGES/gawk.mo
+
 /usr/share/man/man1/gpg2.1*
 /usr/share/man/man7/gnupg2.7*
 

--- a/images/fedora/f38/extra-packages
+++ b/images/fedora/f38/extra-packages
@@ -7,6 +7,7 @@ dnf-plugins-core
 findutils
 flatpak-spawn
 fpaste
+gawk-all-langpacks
 git
 gnupg2
 gnupg2-smime

--- a/images/fedora/f38/extra-packages
+++ b/images/fedora/f38/extra-packages
@@ -9,6 +9,7 @@ flatpak-spawn
 fpaste
 gawk-all-langpacks
 git
+glibc-gconv-extra
 gnupg2
 gnupg2-smime
 gvfs-client

--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -6,7 +6,7 @@ LABEL com.github.containers.toolbox="true" \
       com.redhat.component="$NAME" \
       name="$NAME" \
       version="$VERSION" \
-      usage="This image is meant to be used with the toolbox command" \
+      usage="This image is meant to be used with the toolbox(1) command" \
       summary="Image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 

--- a/images/fedora/f39/Containerfile
+++ b/images/fedora/f39/Containerfile
@@ -7,7 +7,7 @@ LABEL com.github.containers.toolbox="true" \
       name="$NAME" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
-      summary="Base image for creating Fedora Toolbx containers" \
+      summary="Image for creating Fedora Toolbx containers" \
       maintainer="Debarshi Ray <rishi@fedoraproject.org>"
 
 COPY README.md /

--- a/images/fedora/f39/ensure-files
+++ b/images/fedora/f39/ensure-files
@@ -15,6 +15,9 @@
 /usr/share/locale/de/LC_MESSAGES/elfutils.mo
 /usr/share/locale/ja/LC_MESSAGES/elfutils.mo
 
+/usr/share/locale/fr/LC_MESSAGES/gawk.mo
+/usr/share/locale/ko/LC_MESSAGES/gawk.mo
+
 /usr/share/man/man1/gpg2.1*
 /usr/share/man/man7/gnupg2.7*
 

--- a/images/fedora/f39/extra-packages
+++ b/images/fedora/f39/extra-packages
@@ -7,6 +7,7 @@ dnf-plugins-core
 findutils
 flatpak-spawn
 fpaste
+gawk-all-langpacks
 git
 gnupg2
 gnupg2-smime

--- a/images/fedora/f39/extra-packages
+++ b/images/fedora/f39/extra-packages
@@ -9,6 +9,7 @@ flatpak-spawn
 fpaste
 gawk-all-langpacks
 git
+glibc-gconv-extra
 gnupg2
 gnupg2-smime
 gvfs-client


### PR DESCRIPTION
Only the images for currently maintained Fedoras (ie., 38 and 39) were updated.