### PR TITLE
test/system: Unbreak Podman's downstream Fedora CI (part 2)

### DIFF
--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -35,9 +35,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -23,9 +23,11 @@ setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_containers
 }
 


### PR DESCRIPTION
The working directory from which `bats(1)` is invoked might not be part of the Toolbx container.  eg., Podman's downstream Fedora CI invokes the tests as:
```
  $ cd /path/to/toolbox/test/system
  $ bats .
```

... and it led to [1]:
```
  not ok 110 run: Smoke test with true(1)
  # (from function `assert_output' in file
      ./libs/bats-assert/src/assert.bash, line 255,
  #  in test file ./104-run.bats, line 38)
  #   `assert_output ""' failed
  #
  # -- output differs --
  # expected (0 lines):
  #
  # actual (3 lines):
  #   Error: crun: chdir to `/usr/share/toolbox/test/system`: No such
      file or directory: OCI runtime attempted to invoke a command that
      was not found
  #   Error: directory /usr/share/toolbox/test/system not found in
      container fedora-toolbox-41
  #   Using /home/testuser instead.
  # --
  #
```

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2263968