### PR TITLE
playbooks/system-test, test/system: Avoid running out of storage space

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/NEWS
+++ b/NEWS
@@ -527,7 +527,7 @@ Overview of changes in 0.0.1
 
 ----
 
-Copyright © 2018 – 2023 Red Hat, Inc.
+Copyright © 2018 – 2024 Red Hat, Inc.
 All rights reserved.
 
 Copying and distribution of this file, with or without modification,

--- a/gen-docs-list
+++ b/gen-docs-list
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2019 – 2022 Red Hat, Inc.
+# Copyright © 2019 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/meson_post_install.py
+++ b/meson_post_install.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright © 2021 – 2022 Red Hat Inc.
+# Copyright © 2021 – 2024 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Red Hat, Inc.
+# Copyright © 2022 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
+++ b/playbooks/setup-env-migration-path-for-coreos-toolbox.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2022 Red Hat, Inc.
+# Copyright © 2022 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/setup-env-restricted.yaml
+++ b/playbooks/setup-env-restricted.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2023 Red Hat, Inc.
+# Copyright © 2023 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/setup-env.yaml
+++ b/playbooks/setup-env.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -23,6 +23,7 @@
       command: bats --timing ./test/system
       environment:
         PODMAN: '/usr/bin/podman'
+        TMPDIR: '/var/tmp'
         TOOLBX: '/usr/local/bin/toolbox'
       args:
         chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/unit-test.yaml
+++ b/playbooks/unit-test.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2021 – 2022 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 – 2022 Red Hat Inc.
+ * Copyright © 2021 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/cmd/rootDefault.go
+++ b/src/cmd/rootDefault.go
@@ -1,5 +1,5 @@
 //
-// Copyright © 2021 – 2022 Red Hat Inc.
+// Copyright © 2021 – 2024 Red Hat Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright © 2020 – 2022 Red Hat Inc.
+# Copyright © 2020 – 2024 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/meson_generate_completions.py
+++ b/src/meson_generate_completions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #
 # Copyright © 2022 Ondřej Míchal
-# Copyright © 2022 Red Hat Inc.
+# Copyright © 2022 – 2024 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/meson_go_fmt.py
+++ b/src/meson_go_fmt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright © 2022 Red Hat Inc.
+# Copyright © 2022 – 2024 Red Hat Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/pkg/shell/shell.go
+++ b/src/pkg/shell/shell.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/skopeo/skopeo.go
+++ b/src/pkg/skopeo/skopeo.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Red Hat Inc.
+ * Copyright © 2023 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/term/term.go
+++ b/src/pkg/term/term.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Red Hat Inc.
+ * Copyright © 2023 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/term/term_test.go
+++ b/src/pkg/term/term_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Red Hat Inc.
+ * Copyright © 2023 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/errors.go
+++ b/src/pkg/utils/errors.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 Red Hat Inc.
+ * Copyright © 2022 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/libsubid-wrappers.c
+++ b/src/pkg/utils/libsubid-wrappers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 – 2023 Red Hat Inc.
+ * Copyright © 2022 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/libsubid-wrappers.h
+++ b/src/pkg/utils/libsubid-wrappers.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 Red Hat Inc.
+ * Copyright © 2023 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2023 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/utils_cgo.go
+++ b/src/pkg/utils/utils_cgo.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2022 – 2023 Red Hat Inc.
+ * Copyright © 2022 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2021 – 2023 Red Hat Inc.
+ * Copyright © 2021 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/toolbox.go
+++ b/src/toolbox.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2022 Red Hat Inc.
+ * Copyright © 2019 – 2024 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2023 Red Hat, Inc.
+# Copyright © 2021 – 2024 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -43,6 +43,12 @@ location then you can use the `PODMAN`, `SKOPEO` and `TOOLBX` environmental
 variables to set the path to the binaries. So the command to invoke the test
 suite could look something like this: `PODMAN=/usr/libexec/podman TOOLBX=./toolbox bats ./test/system/`.
 
+It's recommended to set the [TMPDIR](https://systemd.io/TEMPORARY_DIRECTORIES/)
+environment variable to `/var/tmp` when running the tests.  Otherwise, the
+images downloaded during the tests will be cached in `/tmp`, which is
+typically on tmpfs backed by RAM or swap and should be used for smaller
+size-bounded files only.
+
 When running the tests, make sure the `test suite: [job]` jobs are successful.
 These jobs set up the whole environment and are a strict requirement for other
 jobs to run correctly.


### PR DESCRIPTION
The system tests download several images when setting up the test suite, and cache them for later use by the tests [1].  This saves time and avoids hitting rate limits imposed by OCI registries by not downloading the same images repeatedly for several tests, but at the cost of increased use of storage space to cache the images.

The images are cached under `BATS_TMPDIR`.  It defaults to the `TMPDIR` environment variable, and if that's not set then to `/tmp` [2].  Normally, `TMPDIR` isn't set, and the images end up getting cached under `/tmp`.  Now, `/tmp` is typically on `tmpfs` backed by RAM or swap, which means that it should be used for smaller size-bounded files only, and `/var/tmp` should be used for everything else [3].

The images are big enough that a collection of them can't be described as smaller and size-bounded, and it led to:
```
  1..306
  # test suite: Set up
  # test suite: Tear down
  not ok 1 setup_suite
  # (from function `setup_suite' in test file ./setup_suite.bash, line
      55)
  #   `_pull_and_cache_distro_image fedora "$((system_version-1))" ||
      false' failed
  # Failed to cache image registry.fedoraproject.org/fedora-toolbox:40
      to /tmp/bats-run-IPz4Cn/image-cache/fedora-toolbox-40
  # time="2024-02-19T11:41:43Z" level=fatal msg="copying system image
      from manifest list: writing blob: write
      /tmp/bats-run-IPz4Cn/image-cache/fedora-toolbox-40/dir-put-blob607392514:
      no space left on device"
  # bats warning: Executed 1 instead of expected 306 tests
```

So, change the default location of the `BATS_TMPDIR` environment variable to `/var/tmp` by setting `TMPDIR`.

[1] Commit 50683c9d9a78adc9
    https://github.com/containers/toolbox/commit/50683c9d9a78adc9
    https://github.com/containers/toolbox/pull/375

[2] https://bats-core.readthedocs.io/en/stable/writing-tests.html

[3] https://systemd.io/TEMPORARY_DIRECTORIES/