### PR TITLE
.github: Drop one "o" and rename the project as "Toolbx" (part 2)

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -146,5 +146,5 @@ jobs:
       - name: System tests
         run: bats --timing test/system/001-version.bats test/system/002-help.bats test/system/108-completion.bats
         env:
-          TOOLBOX: /usr/local/bin/toolbox
+          TOOLBX: /usr/local/bin/toolbox
         working-directory: containers/toolbox


### PR DESCRIPTION
The environment variable to explicitly set the path to the `toolbox(1)` binary was renamed to `TOOLBX`.

Fallout from c3403dae8cb0544ecaa94abdcd5eb3c896851b90