### PR TITLE
profile.d: don't try to source non-existent os-release file

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -13,7 +13,7 @@ toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 eval $(
           if [ -f /etc/os-release ]; then
               . /etc/os-release
-          else
+          elif [ -f /usr/lib/os-release ]; then
               . /usr/lib/os-release
           fi
 


### PR DESCRIPTION
When /etc/os-release does not exist we directly try to source /usr/lib/os-release. This causes a 'No such file or directory' error when entering a toolbox which has neither.

Fix this by checking for the presence of /usr/lib/os-release before sourcing it, just like what is done for /etc/os-release.