### PR TITLE
playbooks: Show the Bats version

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -54,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck bats codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -54,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck bash bats codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version


### PR DESCRIPTION
Ansible's built-in 'package' module doesn't show any details when installing the RPMs.  All that can be seen is:
```
  TASK [Install RPM packages]
  fedora-rawhide | changed
```

Therefore, there's no way to know what version of the packages got installed.

In this case, not knowing the Bats version being used by the CI makes it difficult to know why the tests are generating this spew on Fedora Rawhide [1]:
```
  TASK [Run system tests]
  test/system/libs/helpers.bash: line 7: TEMP_BASE_DIR: readonly variable
  test/system/libs/helpers.bash: line 8: TEMP_STORAGE_DIR: readonly variable
  test/system/libs/helpers.bash: line 10: IMAGE_CACHE_DIR: readonly variable
  test/system/libs/helpers.bash: line 11: ROOTLESS_PODMAN_STORE_DIR: readonly variable
  test/system/libs/helpers.bash: line 12: ROOTLESS_PODMAN_RUNROOT_DIR: readonly variable
  test/system/libs/helpers.bash: line 13: PODMAN_STORE_CONFIG_FILE: readonly variable
  test/system/libs/helpers.bash: line 14: DOCKER_REG_ROOT: readonly variable
  test/system/libs/helpers.bash: line 15: DOCKER_REG_CERTS_DIR: readonly variable
  test/system/libs/helpers.bash: line 16: DOCKER_REG_AUTH_DIR: readonly variable
  test/system/libs/helpers.bash: line 17: DOCKER_REG_URI: readonly variable
  test/system/libs/helpers.bash: line 18: DOCKER_REG_NAME: readonly variable
  test/system/libs/helpers.bash: line 21: PODMAN: readonly variable
  test/system/libs/helpers.bash: line 22: TOOLBX: readonly variable
  test/system/libs/helpers.bash: line 23: SKOPEO: readonly variable
  ...
  fedora-rawhide | 1..340
```

[1] https://github.com/bats-core/bats-core/pull/904