### PR TITLE
test/system: Drop unnecessary port configuration from registry container

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -190,20 +190,21 @@ function _setup_docker_registry() {
   assert_success
 
   # Create a Docker registry
-  run "$PODMAN" --root "${DOCKER_REG_ROOT}" run -d \
+  run "$PODMAN" --root "${DOCKER_REG_ROOT}" run \
+    --detach \
     --rm \
     --name "${DOCKER_REG_NAME}" \
     --privileged \
-    -v "${DOCKER_REG_AUTH_DIR}":/auth \
-    -e REGISTRY_AUTH=htpasswd \
-    -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
-    -e REGISTRY_AUTH_HTPASSWD_PATH="/auth/htpasswd" \
-    -v "${DOCKER_REG_CERTS_DIR}":/certs \
-    -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
-    -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
-    -e REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+    --volume "${DOCKER_REG_AUTH_DIR}":/auth \
+    --env REGISTRY_AUTH=htpasswd \
+    --env REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
+    --env REGISTRY_AUTH_HTPASSWD_PATH="/auth/htpasswd" \
+    --volume "${DOCKER_REG_CERTS_DIR}":/certs \
+    --env REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+    --env REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
+    --env REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
     --network slirp4netns \
-    -p 50000:443 \
+    --publish 50000:443 \
     "${IMAGES[docker-reg]}"
   assert_success
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -195,13 +195,12 @@ function _setup_docker_registry() {
     --env REGISTRY_AUTH=htpasswd \
     --env REGISTRY_AUTH_HTPASSWD_PATH="/auth/htpasswd" \
     --env REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
-    --env REGISTRY_HTTP_ADDR=0.0.0.0:443 \
     --env REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
     --env REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
     --name "${DOCKER_REG_NAME}" \
     --network slirp4netns \
     --privileged \
-    --publish 50000:443 \
+    --publish 50000:5000 \
     --rm \
     --volume "${DOCKER_REG_AUTH_DIR}":/auth \
     --volume "${DOCKER_REG_CERTS_DIR}":/certs \

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -192,19 +192,19 @@ function _setup_docker_registry() {
   # Create a Docker registry
   run "$PODMAN" --root "${DOCKER_REG_ROOT}" run \
     --detach \
-    --rm \
-    --name "${DOCKER_REG_NAME}" \
-    --privileged \
-    --volume "${DOCKER_REG_AUTH_DIR}":/auth \
     --env REGISTRY_AUTH=htpasswd \
-    --env REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
     --env REGISTRY_AUTH_HTPASSWD_PATH="/auth/htpasswd" \
-    --volume "${DOCKER_REG_CERTS_DIR}":/certs \
+    --env REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm" \
     --env REGISTRY_HTTP_ADDR=0.0.0.0:443 \
     --env REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
     --env REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
+    --name "${DOCKER_REG_NAME}" \
     --network slirp4netns \
+    --privileged \
     --publish 50000:443 \
+    --rm \
+    --volume "${DOCKER_REG_AUTH_DIR}":/auth \
+    --volume "${DOCKER_REG_CERTS_DIR}":/certs \
     "${IMAGES[docker-reg]}"
   assert_success
 


### PR DESCRIPTION
The specific port used by the local temporary Docker registry inside the
container doesn't matter.  The container is running only one service and
its users only see the corresponding port on the host operating system.
The default port within the container is 5000 [1] and there's no reason
to change it.

[1] https://github.com/distribution/distribution-library-image