### PR TITLE
cmd/create, pkg/podman: Let 'create' use an image without a name

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -225,7 +225,7 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		return nil
 	}
 
-	imageFull, err := getFullyQualifiedImageFromRepoTags(image)
+	imageFull, err := podman.GetFullyQualifiedImageFromRepoTags(image)
 	if err != nil {
 		return err
 	}
@@ -534,47 +534,6 @@ func getEnterCommand(container string) string {
 	}
 
 	return enterCommand
-}
-
-func getFullyQualifiedImageFromRepoTags(image string) (string, error) {
-	logrus.Debugf("Resolving fully qualified name for image %s from RepoTags", image)
-
-	var imageFull string
-
-	if utils.ImageReferenceHasDomain(image) {
-		imageFull = image
-	} else {
-		info, err := podman.Inspect("image", image)
-		if err != nil {
-			return "", fmt.Errorf("failed to inspect image %s", image)
-		}
-
-		if info["RepoTags"] == nil {
-			return "", fmt.Errorf("missing RepoTag for image %s", image)
-		}
-
-		repoTags := info["RepoTags"].([]interface{})
-		if len(repoTags) == 0 {
-			return "", fmt.Errorf("empty RepoTag for image %s", image)
-		}
-
-		for _, repoTag := range repoTags {
-			repoTagString := repoTag.(string)
-			tag := utils.ImageReferenceGetTag(repoTagString)
-			if tag != "latest" {
-				imageFull = repoTagString
-				break
-			}
-		}
-
-		if imageFull == "" {
-			imageFull = repoTags[0].(string)
-		}
-	}
-
-	logrus.Debugf("Resolved image %s to %s", image, imageFull)
-
-	return imageFull, nil
 }
 
 func getImageSizeFromRegistry(ctx context.Context, imageFull string) (string, error) {

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ sources = files(
   'cmd/root_test.go',
   'cmd/run.go',
   'cmd/utils.go',
+  'pkg/podman/errors.go',
   'pkg/podman/podman.go',
   'pkg/shell/shell.go',
   'pkg/shell/shell_test.go',

--- a/src/pkg/podman/errors.go
+++ b/src/pkg/podman/errors.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2024 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podman
+
+import (
+	"fmt"
+)
+
+type ImageError struct {
+	Image string
+	Err   error
+}
+
+func (err *ImageError) Error() string {
+	errMsg := fmt.Sprintf("%s: %s", err.Image, err.Err)
+	return errMsg
+}
+
+func (err *ImageError) Unwrap() error {
+	return err.Err
+}

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -19,6 +19,7 @@ package podman
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -51,6 +52,10 @@ var (
 )
 
 var (
+	ErrImageRepoTagsEmpty = errors.New("image has empty RepoTags")
+
+	ErrImageRepoTagsMissing = errors.New("image has no RepoTags")
+
 	LogLevel = logrus.ErrorLevel
 )
 
@@ -317,12 +322,12 @@ func GetFullyQualifiedImageFromRepoTags(image string) (string, error) {
 		}
 
 		if info["RepoTags"] == nil {
-			return "", fmt.Errorf("missing RepoTag for image %s", image)
+			return "", &ImageError{image, ErrImageRepoTagsMissing}
 		}
 
 		repoTags := info["RepoTags"].([]interface{})
 		if len(repoTags) == 0 {
-			return "", fmt.Errorf("empty RepoTag for image %s", image)
+			return "", &ImageError{image, ErrImageRepoTagsEmpty}
 		}
 
 		for _, repoTag := range repoTags {

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -20,6 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.7.0
   _setup_environment
   cleanup_containers
 }

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -226,6 +226,75 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-20.04"
 }
 
+@test "create: With a custom image without a name" {
+  image="$(build_image_without_name)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image"
+
+  assert_success
+  assert_line --index 0 "Created container: $image"
+  assert_line --index 1 "Enter with: toolbox enter $image"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$image"
+}
+
+@test "create: With a custom image without a name, and container name (using positional argument)" {
+  image="$(build_image_without_name)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image" non-default
+
+  assert_success
+  assert_line --index 0 "Created container: non-default"
+  assert_line --index 1 "Enter with: toolbox enter non-default"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+non-default"
+}
+
+@test "create: With a custom image without a name, and container name (using option --container)" {
+  image="$(build_image_without_name)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image" --container non-default
+
+  assert_success
+  assert_line --index 0 "Created container: non-default"
+  assert_line --index 1 "Enter with: toolbox enter non-default"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 2 ]
+  else
+    assert [ ${#lines[@]} -eq 3 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+non-default"
+}
+
 @test "create: Try an unsupported distribution" {
   local distro="foo"
 


### PR DESCRIPTION
Currently, it's not possible to create a Toolbx container from an image
without a name:
```ShellSession
  $ podman build --squash images/fedora/f39
  STEP 1/21: FROM registry.fedoraproject.org/fedora:39
  STEP 2/21: ARG NAME=fedora-toolbox
  STEP 3/21: ARG VERSION=39
  ...
  --> 2f9bdf11c8d4
  2f9bdf11c8d4d7674dfb17d8edcfd13475d8636077f1a6208ecd616de77d7f80
  $ toolbox create --image 2f9bdf11c8d4
  Error: empty RepoTag for image 2f9bdf11c8d4
```

The image's fully qualified name is fetched from its `RepoTags` for purely
cosmetic reasons to show a human-readable name in the debug logs.
Therefore, there's no reason to fail the creation of a Toolbx container
in the absence of it.

Note that an image without a name will have an empty `RepoTags` array in
the JSON returned by `podman inspect --format json --type image`.  It's
different from not having a `RepoTags` array at all in the JSON.  This may
or may not be indicative of a more serious problem and will continue to
fail the creation of the Toolbx container as before.