### PR TITLE
Optimize 'enter' and 'run' for a container getting initialized

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -287,7 +288,8 @@ func runCommand(container string,
 		return err
 	}
 
-	initializedStamp := fmt.Sprintf("%s/container-initialized-%d", toolboxRuntimeDirectory, entryPointPID)
+	initializedStampBase := fmt.Sprintf("container-initialized-%d", entryPointPID)
+	initializedStamp := filepath.Join(toolboxRuntimeDirectory, initializedStampBase)
 
 	logrus.Debugf("Checking if initialization stamp %s exists", initializedStamp)
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -40,6 +40,26 @@ teardown() {
   assert_output ""
 }
 
+@test "run: Smoke test with true(1) (using polling fallback)" {
+  local default_container_name
+  default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
+
+  create_default_container
+
+  export TOOLBX_RUN_USE_POLLING=1
+  run --separate-stderr "$TOOLBX" run --verbose true
+
+  assert_success
+  assert_output ""
+
+  # shellcheck disable=SC2154
+  output="$stderr"
+
+  assert_output --partial "Setting up polling ticker for container $default_container_name"
+  refute_output --partial "Setting up watches for file system events from container $default_container_name"
+  assert_output --partial "Handling polling tick"
+}
+
 @test "run: Smoke test with false(1)" {
   create_default_container
 


### PR DESCRIPTION
Currently, the `enter` and `run` commands poll at one second intervals
to check if the Toolbx container's entry point has created the
initialization stamp file to indicate that the container has been
initialized.  This came from the POSIX shell implementation [1], where
it was relatively easier to poll than to use `inotify(7)` to monitor the
file system.

The problem with polling is that the interval is always going to be
either too short and waste resources or too long and cause delays.  The
current one second interval is sufficiently long to add a noticeable
delay to the `enter` and `run` commands.

It will be better to use `inotify(7)` to monitor the file system, which is
quite easy to do with the Go implementation, so that the commands can
proceed as soon as the initialization stamp file is available, instead
of waiting for the polling interval to pass.

There's a fallback to polling, as before, when the operating system is
suffering from a shortage of resources needed for `inotify(7)`.  This code
path can be forced through the `TOOLBX_RUN_USE_POLLING` environment
variable for testing.  Setting this environment variable disables some
code to ensure that the polling ticker is actually used, because,
otherwise, the race between the creation and detection of the
initialization stamp file makes it difficult to test the fallback.

[1] Commit d3e0f3df06d3f5ac
    https://github.com/containers/toolbox/commit/d3e0f3df06d3f5ac
    https://github.com/containers/toolbox/pull/305

https://github.com/containers/toolbox/issues/1070