### PR TITLE
.github/workflows: Enable more tests on Ubuntu 22.04 by setting SHELL

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -144,8 +144,21 @@ jobs:
         working-directory: containers/toolbox
 
       - name: System tests
-        run: bats --timing test/system/001-version.bats test/system/002-help.bats test/system/108-completion.bats
+        run: |
+          bats --timing \
+            test/system/001-version.bats \
+            test/system/002-help.bats \
+            test/system/101-create.bats \
+            test/system/103-container.bats \
+            test/system/105-enter.bats \
+            test/system/106-rm.bats \
+            test/system/107-rmi.bats \
+            test/system/108-completion.bats \
+            test/system/201-ipc.bats \
+            test/system/203-network.bats \
+            test/system/220-environment-variables.bats
         env:
+          SHELL: /bin/bash
           TMPDIR: /var/tmp
           TOOLBX: /usr/local/bin/toolbox
         working-directory: containers/toolbox

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -203,16 +203,18 @@ teardown() {
 @test "run: 'sudo id' inside the default container" {
   create_default_container
 
-  output="$("$TOOLBX" run sudo id 2>"$BATS_TEST_TMPDIR/stderr")"
-  status="$?"
-
-  echo "# stderr"
-  cat "$BATS_TEST_TMPDIR/stderr"
-  echo "# stdout"
-  echo "$output"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run sudo id
 
   assert_success
-  assert_output --partial "uid=0(root)"
+  assert_line --index 0 "uid=0(root) gid=0(root) groups=0(root)"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "run: Ensure that /run/.containerenv exists" {

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -203,7 +203,7 @@ teardown() {
 @test "run: 'sudo id' inside the default container" {
   create_default_container
 
-  output="$("$TOOLBX" --verbose run sudo id 2>"$BATS_TEST_TMPDIR/stderr")"
+  output="$("$TOOLBX" run sudo id 2>"$BATS_TEST_TMPDIR/stderr")"
   status="$?"
 
   echo "# stderr"


### PR DESCRIPTION
The `SHELL` environment variable goes mysteriously missing from the
runtime environment of the GitHub Actions workflow [1].  This breaks the
`create` and `enter` commands with:
```
  Error: failed to get the current user's default shell
```

... and therefore tests involving them can't be run until this is
resolved.

It's been a year since this problem was first encountered and no
solution is in sight.  Therefore, it will be better to work around this
by explicitly setting the `SHELL` environment variable on Ubuntu 22.04 to
increase the number of tests run by the CI.

[1] https://github.com/orgs/community/discussions/59413