### PR TITLE
cmd/initContainer: Prevent passwd(1) from confusing the log parser

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -550,7 +550,6 @@ func getDBusSystemSocket() (string, error) {
 		logrus.Debugf("Resolving path to the D-Bus system socket: failed to evaluate symbolic links in %s: %s",
 			path,
 			err)
-
 		return "", errors.New("failed to resolve the path to the D-Bus system socket")
 	}
 
@@ -619,7 +618,6 @@ func getServiceSocket(serviceName string, unitName string) (string, error) {
 		logrus.Debugf("Resolving path to the %s socket: failed to connect to the D-Bus system instance: %s",
 			serviceName,
 			err)
-
 		return "", errors.New("failed to connect to the D-Bus system instance")
 	}
 
@@ -635,7 +633,6 @@ func getServiceSocket(serviceName string, unitName string) (string, error) {
 			serviceName,
 			unitName,
 			err)
-
 		return "", fmt.Errorf("failed to get the properties of %s", unitName)
 	}
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -462,7 +462,10 @@ func configureUsers(targetUserUid int, targetUser, targetUserHome, targetUserShe
 
 	logrus.Debug("Removing password for user root")
 
-	if err := shell.Run("passwd", nil, nil, nil, "--delete", "root"); err != nil {
+	var stderr strings.Builder
+	if err := shell.Run("passwd", nil, nil, &stderr, "--delete", "root"); err != nil {
+		errString := stderr.String()
+		logrus.Debugf("Removing password for user root: failed: %s", errString)
 		return fmt.Errorf("failed to remove password for root: %w", err)
 	}
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -248,7 +248,6 @@ func migrate(cmd *cobra.Command, args []string) error {
 		logrus.Debugf("Migrating to newer Podman: failed to create configuration directory %s: %s",
 			toolboxConfigDir,
 			err)
-
 		return errors.New("failed to create configuration directory")
 	}
 
@@ -314,7 +313,6 @@ func migrate(cmd *cobra.Command, args []string) error {
 		logrus.Debugf("Migrating to newer Podman: failed to update Podman version in migration stamp file %s: %s",
 			stampPath,
 			err)
-
 		return errors.New("failed to update Podman version in migration stamp file")
 	}
 


### PR DESCRIPTION
When a Toolbx container is started for the first time and the entry point invokes `passwd --delete root` to actually remove the password for root, `passwd(1)` writes the following to its standard error stream:
```
  passwd: Note: deleting a password also unlocks the password.
```

This doesn't happen when the same container is stopped and started once again.

Since, `passwd(1)` directly writes to its standard error stream without going through Logrus, the corresponding log entry in `podman logs` doesn't have a `level` key, and is assumed by the log parser in the `enter` and `run` commands to be an error.  If the entry point doesn't actually encounter an error, then this confusion doesn't have any user-visible effect.  However, if the entry point does encounter an error after this point, then the message from `passwd(1)` gets prepended to it and presented to the user:
```
  $ toolbox enter
  Error: passwd: Note: deleting a password also unlocks the password.
  failed to set KCM as the default Kerberos credential cache
```

Prevent this by intercepting the standard error stream of `passwd(1)` and make it go through Logrus when `passwd(1)` fails.  Losing this particular message when `passwd(1)` actually succeeds in removing the password is not a big problem, because it's somewhat redundant.

Fallout from 815d7f60354dad2d0ce675025b1e2856e64df8a3

https://github.com/containers/toolbox/issues/750