### PR TITLE
playbooks: Avoid using potentially broken DNF5

### DIFF
--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -45,6 +45,7 @@
       - udisks2
     state: present
     update_cache: "{{ true if zuul.attempts > 1 else false }}"
+    use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
 - name: Ensure that podman(1) is absent
   become: yes
@@ -53,6 +54,7 @@
       - podman
     state: absent
     update_cache: "{{ true if zuul.attempts > 1 else false }}"
+    use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
 - name: Ensure that skopeo(1) is absent
   become: yes
@@ -61,6 +63,7 @@
       - skopeo
     state: absent
     update_cache: "{{ true if zuul.attempts > 1 else false }}"
+    use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
 - name: Download Go modules
   command: go mod download -x

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -38,6 +38,7 @@
       - slirp4netns
       - systemd
       - udisks2
+    use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
 - name: Download Go modules
   command: go mod download -x


### PR DESCRIPTION
The Zuul executor got updated from Ansible 2.13.7 to 2.15.10, which now
has support for DNF5 [1] and the previous DNF5 Change [2] for Fedora 39
is now aiming at Fedora 41 (and Rawhide) [3].  Unfortunately, Ansible's
`dnf5` module is still under development and doesn't seem to match the
state of DNF5 in Fedora Rawhide, which causes:
```
  TASK [Install RPM packages]
  fedora-rawhide | ERROR
  fedora-rawhide | {
  fedora-rawhide |   "failures": [],
  fedora-rawhide |   "msg": "Could not import the libdnf5 python module
      using /usr/bin/python3 (3.12.3 (main, Apr 17 2024, 00:00:00) [GCC
      14.0.1 20240411 (Red Hat 14.0.1-0)]). Please install
      python3-libdnf5 package or ensure you have specified the correct
      ansible_python_interpreter. (attempted
      ['/usr/libexec/platform-python', '/usr/bin/python3',
      '/usr/bin/python2', '/usr/bin/python'])"
  fedora-rawhide | }
```

Trying to explicitly install `python3-libdnf5`, as suggested above, using
Ansible's `command` module before using the `package` module to install
the Toolbx dependencies, still ends up with:
```
  TASK [Install RPM packages]
  fedora-rawhide | MODULE FAILURE:
  fedora-rawhide | Traceback (most recent call last):
  fedora-rawhide |   File "<stdin>", line 107, in <module>
  fedora-rawhide |   File "<stdin>", line 99, in _ansiballz_main
  fedora-rawhide |   File "<stdin>", line 47, in invoke_module
  fedora-rawhide |   File "<frozen runpy>", line 226, in run_module
  fedora-rawhide |   File "<frozen runpy>", line 98, in _run_module_code
  fedora-rawhide |   File "<frozen runpy>", line 88, in _run_code
  fedora-rawhide |   File "/tmp/ansible_ansible.legacy.dnf5_payload_kecazv78/ansible_ansible.legacy.dnf5_payload.zip/ansible/modules/dnf5.py",
      line 708, in <module>
  fedora-rawhide |   File "/tmp/ansible_ansible.legacy.dnf5_payload_kecazv78/ansible_ansible.legacy.dnf5_payload.zip/ansible/modules/dnf5.py",
      line 704, in main
  fedora-rawhide |   File "/tmp/ansible_ansible.legacy.dnf5_payload_kecazv78/ansible_ansible.legacy.dnf5_payload.zip/ansible/modules/dnf5.py",
      line 487, in run
  fedora-rawhide | AttributeError: 'Base' object has no attribute
      'load_config_from_file'
```

Therefore, force the use of DNF4 when an Ansible job is being attempted
more than once [4].

[1] Ansible commit a81b787a05100986
    https://github.com/ansible/ansible/commit/a81b787a05100986
    https://github.com/ansible/ansible/issues/78898

[2] https://fedoraproject.org/wiki/Changes/ReplaceDnfWithDnf5

[3] https://fedoraproject.org/wiki/Changes/SwitchToDnf5

[4] https://zuul-ci.org/docs/zuul/latest/job-content.html#var-zuul.attempts
