### PR TITLE
profile.d/toolbox.sh: set PS1 as explicit string constants

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -48,7 +48,7 @@ fi
 
 if [ -f /run/.containerenv ] \
    && [ -f /run/.toolboxenv ]; then
-    [ "${BASH_VERSION:-}" != "" ] && PS1=$(printf "\[\033[35m\]⬢\[\033[0m\]%s" "[\u@\h \W]\\$ ")
+    [ "${BASH_VERSION:-}" != "" ] && PS1='\[\e[35m\]⬢\[\e[0m\][\u@\h \W]\$ '
     [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢\033[0m%s" "[%n@%m]%~%# ")
 
     if ! [ -f "$toolbox_welcome_stub" ]; then


### PR DESCRIPTION
Since the PS1 strings are constants there is no need to use printf and
embed binary color codes, which also makes it hard to match on toolbox PS1.

I tested these in bash and zsh locally and they seem to work fine.