### PR TITLE
profile.d: prepend purple hexagon to PS1 rather than overwriting it

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -48,8 +48,8 @@ fi
 
 if [ -f /run/.containerenv ] \
    && [ -f /run/.toolbxenv ]; then
-    [ "${BASH_VERSION:-}" != "" ] && PS1=$(printf "\[\033[35m\]⬢ \[\033[0m\]%s" "[\u@\h \W]\\$ ")
-    [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢ \033[0m%s" "[%n@%m]%~%# ")
+    [ "${BASH_VERSION:-}" != "" ] && PS1="\[\033[35m\]⬢ \[\033[0m\]$PS1"
+    [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢ \033[0m%s" "$PS1")
 
     if ! [ -f "$toolbox_welcome_stub" ]; then
         echo ""


### PR DESCRIPTION
Importantly this means the traditional Red Hat style prompt is not forced onto all other OS toolboxes as well.