### PR TITLE
test/system: Replace the RHEL toolbox:8.9 image with toolbox:8.10

### DIFF
--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -167,18 +167,18 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+fedora-toolbox-34"
 }
 
-@test "create: RHEL 8.9" {
-  pull_distro_image rhel 8.9
+@test "create: RHEL 8.10" {
+  pull_distro_image rhel 8.10
 
-  run "$TOOLBX" --assumeyes create --distro rhel --release 8.9
+  run "$TOOLBX" --assumeyes create --distro rhel --release 8.10
 
   assert_success
-  assert_output --partial "Created container: rhel-toolbox-8.9"
-  assert_output --partial "Enter with: toolbox enter rhel-toolbox-8.9"
+  assert_output --partial "Created container: rhel-toolbox-8.10"
+  assert_output --partial "Enter with: toolbox enter rhel-toolbox-8.10"
 
   run podman ps -a
 
-  assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.9"
+  assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.10"
 }
 
 @test "create: Ubuntu 16.04" {

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -215,8 +215,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "list: RHEL 8.9 image" {
-  pull_distro_image rhel 8.9
+@test "list: RHEL 8.10 image" {
+  pull_distro_image rhel 8.10
 
   local num_of_images
   num_of_images="$(list_images)"
@@ -225,7 +225,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" list
 
   assert_success
-  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
+  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.10"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 2 ]
@@ -236,8 +236,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "list: RHEL 8.9 image (using --images)" {
-  pull_distro_image rhel 8.9
+@test "list: RHEL 8.10 image (using --images)" {
+  pull_distro_image rhel 8.10
 
   local num_of_images
   num_of_images="$(list_images)"
@@ -246,7 +246,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
 
   assert_success
-  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.9"
+  assert_line --index 1 --partial "registry.access.redhat.com/ubi8/toolbox:8.10"
 
   if check_bats_version 1.10.0; then
     assert [ ${#lines[@]} -eq 2 ]

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -124,10 +124,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "run: Smoke test with RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "run: Smoke test with RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 true
+  run --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -118,10 +118,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: /etc/resolv.conf inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "network: /etc/resolv.conf inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 readlink /etc/resolv.conf
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -350,7 +350,7 @@ teardown() {
   fi
 }
 
-@test "network: DNS inside RHEL 8.9" {
+@test "network: DNS inside RHEL 8.10" {
   local ipv4_skip=false
   local ipv4_addr
   if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
@@ -367,12 +367,12 @@ teardown() {
     skip "DNS not working on host"
   fi
 
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   if ! $ipv4_skip; then
     run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro rhel \
-      --release 8.9 \
+      --release 8.10 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" A k.root-servers.net
 
     assert_success
@@ -390,7 +390,7 @@ teardown() {
   if ! $ipv6_skip; then
     run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro rhel \
-      --release 8.9 \
+      --release 8.10 \
       /usr/libexec/platform-python3.6 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
 
     assert_success
@@ -622,10 +622,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: ping(8) inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "network: ping(8) inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -107,14 +107,14 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: root in shadow(5) inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
+@test "user: root in shadow(5) inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.10)"
 
-  "$TOOLBX" run --distro rhel --release 8.9 true
+  "$TOOLBX" run --distro rhel --release 8.10 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
+  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.10
 
   assert_success
   assert_line --regexp '^root::.+$'
@@ -232,16 +232,16 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in passwd(5) inside RHEL 8.9" {
+@test "user: $USER in passwd(5) inside RHEL 8.10" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
 
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 cat /etc/passwd
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -362,14 +362,14 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in shadow(5) inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.9)"
+@test "user: $USER in shadow(5) inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.10)"
 
-  "$TOOLBX" run --distro rhel --release 8.9 true
+  "$TOOLBX" run --distro rhel --release 8.10 true
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.9
+  "$PODMAN" unshare "$PODMAN" unmount rhel-toolbox-8.10
 
   assert_success
   refute_line --regexp "^$USER:.*$"
@@ -472,10 +472,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in group(5) inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "user: $USER in group(5) inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 cat /etc/group
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 cat /etc/group
 
   assert_success
   assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
@@ -627,10 +627,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: id(1) for $USER inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "user: id(1) for $USER inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 id
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 id
 
   assert_success
 
@@ -645,7 +645,7 @@ teardown() {
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 id "$USER"
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 id "$USER"
 
   assert_success
   assert_line --index 0 "$output_id"

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -123,7 +123,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: session bus inside RHEL 8.9" {
+@test "dbus: session bus inside RHEL 8.10" {
   local expected_response
   expected_response="$(gdbus call \
                          --session \
@@ -131,11 +131,11 @@ teardown() {
                          --object-path /org/freedesktop/DBus \
                          --method org.freedesktop.DBus.Peer.Ping)"
 
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro rhel \
-    --release 8.9 \
+    --release 8.10 \
     gdbus call \
       --session \
       --dest org.freedesktop.DBus \
@@ -316,7 +316,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: system bus inside RHEL 8.9" {
+@test "dbus: system bus inside RHEL 8.10" {
   local expected_response
   expected_response="$(gdbus call \
                          --system \
@@ -326,11 +326,11 @@ teardown() {
                          org.freedesktop.systemd1.Manager \
                          Version)"
 
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro rhel \
-    --release 8.9 \
+    --release 8.10 \
     gdbus call \
       --system \
       --dest org.freedesktop.systemd1 \

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -117,8 +117,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "environment variables: HISTFILESIZE inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
@@ -131,7 +131,7 @@ teardown() {
   export HISTFILESIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HISTFILESIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
@@ -325,10 +325,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTSIZE inside RHEL 8.9" {
+@test "environment variables: HISTSIZE inside RHEL 8.10" {
   skip "https://pagure.io/setup/pull-request/48"
 
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
@@ -341,7 +341,7 @@ teardown() {
   export HISTSIZE
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HISTSIZE"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -496,11 +496,11 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HOSTNAME inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "environment variables: HOSTNAME inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$HOSTNAME"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$HOSTNAME"'
 
   assert_success
   assert_line --index 0 "toolbx"
@@ -642,8 +642,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: KONSOLE_VERSION inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "environment variables: KONSOLE_VERSION inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
@@ -652,7 +652,7 @@ teardown() {
   fi
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$KONSOLE_VERSION"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$KONSOLE_VERSION"'
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
@@ -815,8 +815,8 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: XTERM_VERSION inside RHEL 8.9" {
-  create_distro_container rhel 8.9 rhel-toolbox-8.9
+@test "environment variables: XTERM_VERSION inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
@@ -825,7 +825,7 @@ teardown() {
   fi
 
   # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.9 bash -c 'echo "$XTERM_VERSION"'
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$XTERM_VERSION"'
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -45,7 +45,7 @@ setup_suite() {
   # Cache all images that will be needed during the tests
   _pull_and_cache_distro_image arch latest || false
   _pull_and_cache_distro_image fedora 34 || false
-  _pull_and_cache_distro_image rhel 8.9 || false
+  _pull_and_cache_distro_image rhel 8.10 || false
   _pull_and_cache_distro_image ubuntu 16.04 || false
   _pull_and_cache_distro_image ubuntu 18.04 || false
   _pull_and_cache_distro_image ubuntu 20.04 || false


### PR DESCRIPTION
Red Hat Enterprise Linux 8.9 reached End of Life when RHEL 8.10 was released on 22nd May 2024:
https://access.redhat.com/articles/3078
https://access.redhat.com/support/policy/updates/errata

For what it's worth, RHEL 8's full support phase ended on the 31st of May 2024 and it wil be in maintenance support, as RHEL 8.10, until the corresponding day in 2029.