### PR TITLE
test/system: Consolidate teardown() to remove both containers & images

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -51,7 +51,7 @@
 - job:
     name: system-test-fedora-rawhide
     description: Run Toolbx's system tests in Fedora Rawhide
-    timeout: 4800
+    timeout: 7800
     nodeset:
       nodes:
         - name: fedora-rawhide
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-40
     description: Run Toolbx's system tests in Fedora 40
-    timeout: 3600
+    timeout: 6600
     nodeset:
       nodes:
         - name: fedora-40
@@ -73,7 +73,7 @@
 - job:
     name: system-test-fedora-39
     description: Run Toolbx's system tests in Fedora 39
-    timeout: 3600
+    timeout: 6600
     nodeset:
       nodes:
         - name: fedora-39

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -22,7 +22,7 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
 }
 
 teardown() {

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -21,11 +21,11 @@ load 'libs/helpers'
 
 setup() {
   _setup_environment
-  cleanup_containers
+  cleanup_all
 }
 
 teardown() {
-  cleanup_containers
+  cleanup_all
 }
 
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "run: Smoke test with true(1)" {

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -21,11 +21,11 @@ load 'libs/helpers'
 
 setup() {
   _setup_environment
-  cleanup_containers
+  cleanup_all
 }
 
 teardown() {
-  cleanup_containers
+  cleanup_all
 }
 
 @test "enter: Try to enter the default container with no containers created" {

--- a/test/system/106-rm.bats
+++ b/test/system/106-rm.bats
@@ -21,11 +21,11 @@ load 'libs/helpers'
 
 setup() {
   _setup_environment
-  cleanup_containers
+  cleanup_all
 }
 
 teardown() {
-  cleanup_containers
+  cleanup_all
 }
 
 

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "ipc: No namespace" {

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -34,13 +34,13 @@ readonly RESOLVER_SH='resolvectl --legend false --no-pager --type "$0" query "$1
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "network: No namespace" {

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "user: Separate namespace" {

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "ulimit: real-time non-blocking time (hard)" {

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "dbus: session bus inside the default container" {

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -22,13 +22,13 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
 }
 
 teardown() {
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "environment variables: HISTFILESIZE inside the default container" {

--- a/test/system/230-cdi.bats
+++ b/test/system/230-cdi.bats
@@ -22,7 +22,7 @@ load 'libs/helpers'
 setup() {
   bats_require_minimum_version 1.7.0
   _setup_environment
-  cleanup_containers
+  cleanup_all
   pushd "$HOME" || return 1
   rm --force "$XDG_RUNTIME_DIR/toolbox/cdi-nvidia.json" || return 1
 }
@@ -30,7 +30,7 @@ setup() {
 teardown() {
   rm --force "$XDG_RUNTIME_DIR/toolbox/cdi-nvidia.json" || return 1
   popd || return 1
-  cleanup_containers
+  cleanup_all
 }
 
 @test "cdi: Smoke test" {

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -37,11 +37,6 @@ function cleanup_all() {
 }
 
 
-function cleanup_containers() {
-  "$PODMAN" rm --all --force >/dev/null
-}
-
-
 function _setup_environment() {
   _setup_containers_storage
   check_xdg_runtime_dir


### PR DESCRIPTION
It's far more consistent and understandable if all tests start with a
clean state without any containers or images present.  Otherwise, the
subtle side-effects of having some image left behind from a previous
test can lead to surprises, and there's no need to spend time wondering
whether some tests should only clean up the containers or both
containers and images.