### PR TITLE
.zuul: Drop testing on Fedora 38

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -81,24 +81,12 @@
     pre-run: playbooks/setup-env.yaml
     run: playbooks/system-test.yaml
 
-- job:
-    name: system-test-fedora-38
-    description: Run Toolbx's system tests in Fedora 38
-    timeout: 3600
-    nodeset:
-      nodes:
-        - name: fedora-38
-          label: cloud-fedora-38
-    pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
-
 - project:
     periodic:
       jobs:
         - system-test-fedora-rawhide
         - system-test-fedora-40
         - system-test-fedora-39
-        - system-test-fedora-38
     check:
       jobs:
         - unit-test
@@ -107,7 +95,6 @@
         - system-test-fedora-rawhide
         - system-test-fedora-40
         - system-test-fedora-39
-        - system-test-fedora-38
     gate:
       jobs:
         - unit-test
@@ -116,4 +103,3 @@
         - system-test-fedora-rawhide
         - system-test-fedora-40
         - system-test-fedora-39
-        - system-test-fedora-38


### PR DESCRIPTION
Fedora 38 reached End of Life on 21st May 2024:
https://docs.fedoraproject.org/en-US/releases/eol/