### PR TITLE
pkg/utils: Support Fedora rawhide version name

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -742,6 +742,10 @@ func parseReleaseArch(release string) (string, error) {
 }
 
 func parseReleaseFedora(release string) (string, error) {
+	if release == "rawhide" {
+		return release, nil
+	}
+
 	if strings.HasPrefix(release, "F") || strings.HasPrefix(release, "f") {
 		release = release[1:]
 	}

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -102,6 +102,11 @@ func TestParseRelease(t *testing.T) {
 		},
 		{
 			inputDistro:  "fedora",
+			inputRelease: "rawhide",
+			output:       "rawhide",
+		},
+		{
+			inputDistro:  "fedora",
 			inputRelease: "f34",
 			output:       "34",
 		},

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -167,6 +167,20 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+fedora-toolbox-34"
 }
 
+@test "create: Fedora rawhide" {
+  pull_distro_image fedora rawhide
+
+  run "$TOOLBX" --assumeyes create --distro fedora --release rawhide
+
+  assert_success
+  assert_output --partial "Created container: fedora-toolbox-rawhide"
+  assert_output --partial "Enter with: toolbox enter fedora-toolbox-rawhide"
+
+  run podman ps -a
+
+  assert_output --regexp "Created[[:blank:]]+fedora-toolbox-rawhide"
+}
+
 @test "create: RHEL 8.10" {
   pull_distro_image rhel 8.10
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -124,6 +124,16 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "run: Smoke test with Fedora rawhide" {
+  create_distro_container fedora rawhide fedora-toolbox-rawhide
+
+  run --separate-stderr "$TOOLBX" run --distro fedora --release rawhide true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "run: Smoke test with RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -45,6 +45,7 @@ setup_suite() {
   # Cache all images that will be needed during the tests
   _pull_and_cache_distro_image arch latest || false
   _pull_and_cache_distro_image fedora 34 || false
+  _pull_and_cache_distro_image fedora rawhide || false
   _pull_and_cache_distro_image rhel 8.10 || false
   _pull_and_cache_distro_image ubuntu 16.04 || false
   _pull_and_cache_distro_image ubuntu 18.04 || false


### PR DESCRIPTION
Since pulling the Fedora Rawhide image from `registry.fedoraproject.org/fedora/rawhide` succeeds now, add support for the Fedora Rawhide version name by allowing `rawhide` to be passed as a release argument.

Fixes: #646.
