### PR TITLE
cmd/root, cmd/run: Handle printing all errors but the CLI parsing ones

### DIFF
--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -76,11 +76,14 @@ func (e *exitError) Error() string {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		if rootCmd.SilenceErrors {
+			if errMsg := err.Error(); errMsg != "" {
+				fmt.Fprintf(os.Stderr, "Error: %s\n", errMsg)
+			}
+		}
+
 		var errExit *exitError
 		if errors.As(err, &errExit) {
-			if errExit.err != nil {
-				fmt.Fprintf(os.Stderr, "Error: %s\n", errExit)
-			}
 			os.Exit(errExit.code)
 		}
 
@@ -128,6 +131,7 @@ func init() {
 }
 
 func preRun(cmd *cobra.Command, args []string) error {
+	cmd.Root().SilenceErrors = true
 	cmd.Root().SilenceUsage = true
 
 	if err := setUpLoggers(); err != nil {

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -62,7 +62,7 @@ var (
 )
 
 type exitError struct {
-	Code int
+	code int
 	err  error
 }
 
@@ -81,7 +81,7 @@ func Execute() {
 			if errExit.err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", errExit)
 			}
-			os.Exit(errExit.Code)
+			os.Exit(errExit.code)
 		}
 
 		os.Exit(1)

--- a/src/cmd/root_test.go
+++ b/src/cmd/root_test.go
@@ -66,7 +66,7 @@ func TestExitError(t *testing.T) {
 			var errExit *exitError
 
 			assert.ErrorAs(t, err, &errExit)
-			assert.Equal(t, tc.rc, errExit.Code)
+			assert.Equal(t, tc.rc, errExit.code)
 			if tc.err != nil {
 				assert.Equal(t, tc.err.Error(), errExit.Error())
 			}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -162,15 +162,6 @@ func run(cmd *cobra.Command, args []string) error {
 		false,
 		false,
 		true); err != nil {
-		// runCommand returns exitError for the executed commands to properly
-		// propagate return codes. Cobra prints all non-nil errors which in
-		// that case is not desirable. In that scenario silence the errors and
-		// leave the error handling to the root command.
-		var errExit *exitError
-		if errors.As(err, &errExit) {
-			cmd.SilenceErrors = true
-		}
-
 		return err
 	}
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -40,7 +40,7 @@ teardown() {
 @test "create: With a custom name (using option --container)" {
   pull_default_image
 
-  run "$TOOLBX" --assumeyes create --container "custom-containerName"
+  run "$TOOLBX" create --container "custom-containerName"
 
   assert_success
 }
@@ -48,7 +48,7 @@ teardown() {
 @test "create: With a custom image and name (using option --container)" {
   pull_distro_image fedora 34
 
-  run "$TOOLBX" --assumeyes create --container "fedora34" --image fedora-toolbox:34
+  run "$TOOLBX" create --container "fedora34" --image fedora-toolbox:34
 
   assert_success
 }

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -277,6 +277,31 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+non-default"
 }
 
+@test "create: Try the same name again" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  pull_default_image
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create
+
+  assert_success
+  assert_line --index 0 "Created container: $default_container"
+  assert_line --index 1 "Enter with: toolbox enter"
+  assert [ ${#lines[@]} -eq 2 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run -1 --keep-empty-lines --separate-stderr "$TOOLBX" create
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: container $default_container already exists"
+  assert_line --index 1 "Enter with: toolbox enter"
+  assert_line --index 2 "Run 'toolbox --help' for usage."
+  assert [ ${#stderr_lines[@]} -eq 3 ]
+}
+
 @test "create: Try an unsupported distribution" {
   local distro="foo"
 

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -30,11 +30,17 @@ teardown() {
 }
 
 @test "create: Smoke test" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
   pull_default_image
 
   run "$TOOLBX" --assumeyes create
 
   assert_success
+  assert_line --index 0 "Created container: $default_container"
+  assert_line --index 1 "Enter with: toolbox enter"
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "create: With a custom name (using option --container)" {
@@ -43,6 +49,9 @@ teardown() {
   run "$TOOLBX" create --container "custom-containerName"
 
   assert_success
+  assert_line --index 0 "Created container: custom-containerName"
+  assert_line --index 1 "Enter with: toolbox enter custom-containerName"
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "create: With a custom image and name (using option --container)" {
@@ -51,6 +60,9 @@ teardown() {
   run "$TOOLBX" create --container "fedora34" --image fedora-toolbox:34
 
   assert_success
+  assert_line --index 0 "Created container: fedora34"
+  assert_line --index 1 "Enter with: toolbox enter fedora34"
+  assert [ ${#lines[@]} -eq 2 ]
 }
 
 @test "create: Try without --assumeyes" {


### PR DESCRIPTION
This will make it easier to propagate the exit codes of subordinate
processes through an `exitError` instance, when `toolbox(1)` is invoked
inside a container, and invocation is forwarded to the host.

Cobra doesn't honour the root command's `SilenceErrors`, if an error
occurred when parsing the command line for a command, even though the
command was found.  However, Cobra does honour `SilenceErrors`, if the
error occurred afterwards.

Therefore, to avoid setting `SilenceErrors` in each and every command, it
was set in the `PersistentPreRunE` hook (ie., `preRun`), which is called
after all command line parsing has been successfully completed.

https://github.com/containers/toolbox/issues/957