### PR TITLE
test/system: Update Ubuntu versions used for tests (16.04, 18.04, 20.04 -> 20.04, 22.04, 24.04)

### DIFF
--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -181,36 +181,6 @@ teardown() {
   assert_output --regexp "Created[[:blank:]]+rhel-toolbox-8.10"
 }
 
-@test "create: Ubuntu 16.04" {
-  pull_distro_image ubuntu 16.04
-
-  run "$TOOLBX" --assumeyes create --distro ubuntu --release 16.04
-
-  assert_success
-  assert_output --partial "Created container: ubuntu-toolbox-16.04"
-  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-16.04"
-
-  run $PODMAN ps --all
-
-  assert_success
-  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-16.04"
-}
-
-@test "create: Ubuntu 18.04" {
-  pull_distro_image ubuntu 18.04
-
-  run "$TOOLBX" --assumeyes create --distro ubuntu --release 18.04
-
-  assert_success
-  assert_output --partial "Created container: ubuntu-toolbox-18.04"
-  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-18.04"
-
-  run $PODMAN ps --all
-
-  assert_success
-  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-18.04"
-}
-
 @test "create: Ubuntu 20.04" {
   pull_distro_image ubuntu 20.04
 
@@ -224,6 +194,36 @@ teardown() {
 
   assert_success
   assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-20.04"
+}
+
+@test "create: Ubuntu 22.04" {
+  pull_distro_image ubuntu 22.04
+
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 22.04
+
+  assert_success
+  assert_output --partial "Created container: ubuntu-toolbox-22.04"
+  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-22.04"
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-22.04"
+}
+
+@test "create: Ubuntu 24.04" {
+  pull_distro_image ubuntu 24.04
+
+  run "$TOOLBX" --assumeyes create --distro ubuntu --release 24.04
+
+  assert_success
+  assert_output --partial "Created container: ubuntu-toolbox-24.04"
+  assert_output --partial "Enter with: toolbox enter ubuntu-toolbox-24.04"
+
+  run $PODMAN ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+ubuntu-toolbox-24.04"
 }
 
 @test "create: With a custom image without a name" {

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -209,66 +209,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "list: Ubuntu 16.04 image" {
-  pull_distro_image ubuntu 16.04
-
-  local num_of_images
-  num_of_images="$(list_images)"
-  assert_equal "$num_of_images" 1
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" list
-
-  assert_success
-  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
-  assert [ ${#lines[@]} -eq 2 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "list: Ubuntu 16.04 image (using --images)" {
-  pull_distro_image ubuntu 16.04
-
-  local num_of_images
-  num_of_images="$(list_images)"
-  assert_equal "$num_of_images" 1
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
-
-  assert_success
-  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:16.04"
-  assert [ ${#lines[@]} -eq 2 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "list: Ubuntu 18.04 image" {
-  pull_distro_image ubuntu 18.04
-
-  local num_of_images
-  num_of_images="$(list_images)"
-  assert_equal "$num_of_images" 1
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" list
-
-  assert_success
-  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
-  assert [ ${#lines[@]} -eq 2 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "list: Ubuntu 18.04 image (using --images)" {
-  pull_distro_image ubuntu 18.04
-
-  local num_of_images
-  num_of_images="$(list_images)"
-  assert_equal "$num_of_images" 1
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
-
-  assert_success
-  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:18.04"
-  assert [ ${#lines[@]} -eq 2 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "list: Ubuntu 20.04 image" {
   pull_distro_image ubuntu 20.04
 
@@ -296,6 +236,66 @@ teardown() {
   assert_success
   assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:20.04"
   assert [ ${#lines[@]} -eq 2 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 22.04 image" {
+  pull_distro_image ubuntu 22.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:22.04"
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 22.04 image (using --images)" {
+  pull_distro_image ubuntu 22.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:22.04"
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 24.04 image" {
+  pull_distro_image ubuntu 24.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:24.04"
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "list: Ubuntu 24.04 image (using --images)" {
+  pull_distro_image ubuntu 24.04
+
+  local num_of_images
+  num_of_images="$(list_images)"
+  assert_equal "$num_of_images" 1
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" list --images
+
+  assert_success
+  assert_line --index 1 --partial "quay.io/toolbx/ubuntu-toolbox:24.04"
+
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -134,30 +134,30 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "run: Smoke test with Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 true
-
-  assert_success
-  assert [ ${#lines[@]} -eq 0 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "run: Smoke test with Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 true
-
-  assert_success
-  assert [ ${#lines[@]} -eq 0 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "run: Smoke test with Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   run --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Smoke test with Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 true
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -136,46 +136,46 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: /etc/resolv.conf inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 readlink /etc/resolv.conf
-
-  assert_success
-  assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "network: /etc/resolv.conf inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 readlink /etc/resolv.conf
-
-  assert_success
-  assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "network: /etc/resolv.conf inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 readlink /etc/resolv.conf
+
+  assert_success
+  assert_line --index 0 "/run/host/etc/resolv.conf"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: /etc/resolv.conf inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 readlink /etc/resolv.conf
+
+  assert_success
+  assert_line --index 0 "/run/host/etc/resolv.conf"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: /etc/resolv.conf inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 readlink /etc/resolv.conf
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
@@ -406,118 +406,6 @@ teardown() {
   fi
 }
 
-@test "network: DNS inside Ubuntu 16.04" {
-  local ipv4_skip=false
-  local ipv4_addr
-  if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
-    ipv4_skip=true
-  fi
-
-  local ipv6_skip=false
-  local ipv6_addr
-  if ! ipv6_addr="$(python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net)"; then
-    ipv6_skip=true
-  fi
-
-  if $ipv4_skip && $ipv6_skip; then
-    skip "DNS not working on host"
-  fi
-
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-      --distro ubuntu \
-      --release 16.04 \
-      python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
-
-    assert_success
-    assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
-
-  if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-      --distro ubuntu \
-      --release 16.04 \
-      python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
-
-    assert_success
-    assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
-}
-
-@test "network: DNS inside Ubuntu 18.04" {
-  local ipv4_skip=false
-  local ipv4_addr
-  if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
-    ipv4_skip=true
-  fi
-
-  local ipv6_skip=false
-  local ipv6_addr
-  if ! ipv6_addr="$(python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net)"; then
-    ipv6_skip=true
-  fi
-
-  if $ipv4_skip && $ipv6_skip; then
-    skip "DNS not working on host"
-  fi
-
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  if ! $ipv4_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-      --distro ubuntu \
-      --release 18.04 \
-      python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
-
-    assert_success
-    assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
-
-  if ! $ipv6_skip; then
-    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-      --distro ubuntu \
-      --release 18.04 \
-      python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
-
-    assert_success
-    assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
-    assert [ ${#stderr_lines[@]} -eq 0 ]
-  fi
-}
-
 @test "network: DNS inside Ubuntu 20.04" {
   local ipv4_skip=false
   local ipv4_addr
@@ -559,6 +447,118 @@ teardown() {
     run --keep-empty-lines --separate-stderr "$TOOLBX" run \
       --distro ubuntu \
       --release 20.04 \
+      python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
+
+    assert_success
+    assert_line --index 0 "$ipv6_addr"
+
+    if check_bats_version 1.10.0; then
+      assert [ ${#lines[@]} -eq 1 ]
+    else
+      assert [ ${#lines[@]} -eq 2 ]
+    fi
+
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+}
+
+@test "network: DNS inside Ubuntu 22.04" {
+  local ipv4_skip=false
+  local ipv4_addr
+  if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
+    ipv4_skip=true
+  fi
+
+  local ipv6_skip=false
+  local ipv6_addr
+  if ! ipv6_addr="$(python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net)"; then
+    ipv6_skip=true
+  fi
+
+  if $ipv4_skip && $ipv6_skip; then
+    skip "DNS not working on host"
+  fi
+
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  if ! $ipv4_skip; then
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+      --distro ubuntu \
+      --release 22.04 \
+      python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
+
+    assert_success
+    assert_line --index 0 "$ipv4_addr"
+
+    if check_bats_version 1.10.0; then
+      assert [ ${#lines[@]} -eq 1 ]
+    else
+      assert [ ${#lines[@]} -eq 2 ]
+    fi
+
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  if ! $ipv6_skip; then
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+      --distro ubuntu \
+      --release 22.04 \
+      python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
+
+    assert_success
+    assert_line --index 0 "$ipv6_addr"
+
+    if check_bats_version 1.10.0; then
+      assert [ ${#lines[@]} -eq 1 ]
+    else
+      assert [ ${#lines[@]} -eq 2 ]
+    fi
+
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+}
+
+@test "network: DNS inside Ubuntu 24.04" {
+  local ipv4_skip=false
+  local ipv4_addr
+  if ! ipv4_addr="$(python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net)"; then
+    ipv4_skip=true
+  fi
+
+  local ipv6_skip=false
+  local ipv6_addr
+  if ! ipv6_addr="$(python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net)"; then
+    ipv6_skip=true
+  fi
+
+  if $ipv4_skip && $ipv6_skip; then
+    skip "DNS not working on host"
+  fi
+
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  if ! $ipv4_skip; then
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+      --distro ubuntu \
+      --release 24.04 \
+      python3 -c "$RESOLVER_PYTHON3" A k.root-servers.net
+
+    assert_success
+    assert_line --index 0 "$ipv4_addr"
+
+    if check_bats_version 1.10.0; then
+      assert [ ${#lines[@]} -eq 1 ]
+    else
+      assert [ ${#lines[@]} -eq 2 ]
+    fi
+
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+
+  if ! $ipv6_skip; then
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+      --distro ubuntu \
+      --release 24.04 \
       python3 -c "$RESOLVER_PYTHON3" AAAA k.root-servers.net
 
     assert_success
@@ -638,24 +638,10 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: ping(8) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+@test "network: ping(8) inside Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
-  run -2 --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 ping -c 2 f.root-servers.net
-
-  assert_failure
-  assert [ ${#lines[@]} -eq 0 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -gt 0 ]
-
-  skip "doesn't use ICMP Echo sockets"
-}
-
-@test "network: ping(8) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"
@@ -668,10 +654,26 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "network: ping(8) inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+@test "network: ping(8) inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
 
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 ping -c 2 f.root-servers.net
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 ping -c 2 f.root-servers.net
+
+  if [ "$status" -eq 1 ]; then
+    skip "lost packets"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "network: ping(8) inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 ping -c 2 f.root-servers.net
 
   if [ "$status" -eq 1 ]; then
     skip "lost packets"

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -124,40 +124,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: root in shadow(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
-
-  "$TOOLBX" run --distro ubuntu --release 16.04 true
-
-  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-16.04
-
-  assert_success
-  assert_line --regexp '^root::.+$'
-  assert [ ${#lines[@]} -gt 0 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "user: root in shadow(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
-
-  "$TOOLBX" run --distro ubuntu --release 18.04 true
-
-  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-18.04
-
-  assert_success
-  assert_line --regexp '^root::.+$'
-  assert [ ${#lines[@]} -gt 0 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "user: root in shadow(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
@@ -166,6 +132,40 @@ teardown() {
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-20.04
+
+  assert_success
+  assert_line --regexp '^root::.+$'
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: root in shadow(5) inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-22.04)"
+
+  "$TOOLBX" run --distro ubuntu --release 22.04 true
+
+  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
+  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-22.04
+
+  assert_success
+  assert_line --regexp '^root::.+$'
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: root in shadow(5) inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-24.04)"
+
+  "$TOOLBX" run --distro ubuntu --release 24.04 true
+
+  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
+  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-24.04
 
   assert_success
   assert_line --regexp '^root::.+$'
@@ -251,44 +251,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in passwd(5) inside Ubuntu 16.04" {
-  local user_gecos
-  user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
-
-  local user_id_real
-  user_id_real="$(id --real --user)"
-
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/passwd
-
-  assert_success
-  assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
-  assert [ ${#lines[@]} -gt 1 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "user: $USER in passwd(5) inside Ubuntu 18.04" {
-  local user_gecos
-  user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
-
-  local user_id_real
-  user_id_real="$(id --real --user)"
-
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/passwd
-
-  assert_success
-  assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
-  assert [ ${#lines[@]} -gt 1 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "user: $USER in passwd(5) inside Ubuntu 20.04" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -299,6 +261,44 @@ teardown() {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/passwd
+
+  assert_success
+  assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
+  assert [ ${#lines[@]} -gt 1 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in passwd(5) inside Ubuntu 22.04" {
+  local user_gecos
+  user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
+
+  local user_id_real
+  user_id_real="$(id --real --user)"
+
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 cat /etc/passwd
+
+  assert_success
+  assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
+  assert [ ${#lines[@]} -gt 1 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in passwd(5) inside Ubuntu 24.04" {
+  local user_gecos
+  user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
+
+  local user_id_real
+  user_id_real="$(id --real --user)"
+
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 cat /etc/passwd
 
   assert_success
   assert_line --regexp "^$USER::$user_id_real:$user_id_real:$user_gecos:$HOME:$SHELL$"
@@ -379,40 +379,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in shadow(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
-
-  "$TOOLBX" run --distro ubuntu --release 16.04 true
-
-  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-16.04
-
-  assert_success
-  refute_line --regexp "^$USER:.*$"
-  assert [ ${#lines[@]} -gt 0 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "user: $USER in shadow(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
-
-  "$TOOLBX" run --distro ubuntu --release 18.04 true
-
-  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
-  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-18.04
-
-  assert_success
-  refute_line --regexp "^$USER:.*$"
-  assert [ ${#lines[@]} -gt 0 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "user: $USER in shadow(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
@@ -421,6 +387,40 @@ teardown() {
 
   run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
   "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-20.04
+
+  assert_success
+  refute_line --regexp "^$USER:.*$"
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in shadow(5) inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-22.04)"
+
+  "$TOOLBX" run --distro ubuntu --release 22.04 true
+
+  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
+  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-22.04
+
+  assert_success
+  refute_line --regexp "^$USER:.*$"
+  assert [ ${#lines[@]} -gt 0 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in shadow(5) inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+  container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-24.04)"
+
+  "$TOOLBX" run --distro ubuntu --release 24.04 true
+
+  run --keep-empty-lines --separate-stderr "$PODMAN" unshare cat "$container_root_file_system/etc/shadow"
+  "$PODMAN" unshare "$PODMAN" unmount ubuntu-toolbox-24.04
 
   assert_success
   refute_line --regexp "^$USER:.*$"
@@ -486,38 +486,38 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: $USER in group(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/group
-
-  assert_success
-  assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
-  assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
-  assert [ ${#lines[@]} -gt 1 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "user: $USER in group(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/group
-
-  assert_success
-  assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
-  assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
-  assert [ ${#lines[@]} -gt 1 ]
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "user: $USER in group(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/group
+
+  assert_success
+  assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
+  assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
+  assert [ ${#lines[@]} -gt 1 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in group(5) inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 cat /etc/group
+
+  assert_success
+  assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
+  assert_line --regexp "^sudo:x:[[:digit:]]+:$USER$"
+  assert [ ${#lines[@]} -gt 1 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: $USER in group(5) inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 cat /etc/group
 
   assert_success
   assert_line --regexp "^$USER:x:[[:digit:]]+:$USER$"
@@ -660,72 +660,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "user: id(1) for $USER inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 id
-
-  assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  local output_id="${lines[0]}"
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 id "$USER"
-
-  assert_success
-  assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "user: id(1) for $USER inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 id
-
-  assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  local output_id="${lines[0]}"
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 id "$USER"
-
-  assert_success
-  assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "user: id(1) for $USER inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -745,6 +679,72 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 id "$USER"
+
+  assert_success
+  assert_line --index 0 "$output_id"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: id(1) for $USER inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 id
+
+  assert_success
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  local output_id="${lines[0]}"
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 id "$USER"
+
+  assert_success
+  assert_line --index 0 "$output_id"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "user: id(1) for $USER inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 id
+
+  assert_success
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  local output_id="${lines[0]}"
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 id "$USER"
 
   assert_success
   assert_line --index 0 "$output_id"

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -155,44 +155,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: session bus inside Ubuntu 16.04" {
-  busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
-
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-    --distro ubuntu \
-    --release 16.04 \
-    busctl --user call \
-      org.freedesktop.DBus \
-      /org/freedesktop/DBus \
-      org.freedesktop.DBus.Peer \
-      Ping
-
-  assert_success
-  assert [ ${#lines[@]} -eq 0 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "dbus: session bus inside Ubuntu 18.04" {
-  busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
-
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-    --distro ubuntu \
-    --release 18.04 \
-    busctl --user call \
-      org.freedesktop.DBus \
-      /org/freedesktop/DBus \
-      org.freedesktop.DBus.Peer \
-      Ping
-
-  assert_success
-  assert [ ${#lines[@]} -eq 0 ]
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "dbus: session bus inside Ubuntu 20.04" {
   busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
 
@@ -201,6 +163,44 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 20.04 \
+    busctl --user call \
+      org.freedesktop.DBus \
+      /org/freedesktop/DBus \
+      org.freedesktop.DBus.Peer \
+      Ping
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "dbus: session bus inside Ubuntu 22.04" {
+  busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
+
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 22.04 \
+    busctl --user call \
+      org.freedesktop.DBus \
+      /org/freedesktop/DBus \
+      org.freedesktop.DBus.Peer \
+      Ping
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "dbus: session bus inside Ubuntu 24.04" {
+  busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
+
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 24.04 \
     busctl --user call \
       org.freedesktop.DBus \
       /org/freedesktop/DBus \
@@ -352,70 +352,6 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "dbus: system bus inside Ubuntu 16.04" {
-  local expected_response
-  expected_response="$(busctl --system get-property \
-                         org.freedesktop.systemd1 \
-                         /org/freedesktop/systemd1 \
-                         org.freedesktop.systemd1.Manager \
-                         Version)"
-
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-    --distro ubuntu \
-    --release 16.04 \
-    busctl --system get-property \
-      org.freedesktop.systemd1 \
-      /org/freedesktop/systemd1 \
-      org.freedesktop.systemd1.Manager \
-      Version
-
-  assert_success
-  assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "dbus: system bus inside Ubuntu 18.04" {
-  local expected_response
-  expected_response="$(busctl --system get-property \
-                         org.freedesktop.systemd1 \
-                         /org/freedesktop/systemd1 \
-                         org.freedesktop.systemd1.Manager \
-                         Version)"
-
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
-    --distro ubuntu \
-    --release 18.04 \
-    busctl --system get-property \
-      org.freedesktop.systemd1 \
-      /org/freedesktop/systemd1 \
-      org.freedesktop.systemd1.Manager \
-      Version
-
-  assert_success
-  assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "dbus: system bus inside Ubuntu 20.04" {
   local expected_response
   expected_response="$(busctl --system get-property \
@@ -429,6 +365,70 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run \
     --distro ubuntu \
     --release 20.04 \
+    busctl --system get-property \
+      org.freedesktop.systemd1 \
+      /org/freedesktop/systemd1 \
+      org.freedesktop.systemd1.Manager \
+      Version
+
+  assert_success
+  assert_line --index 0 "$expected_response"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "dbus: system bus inside Ubuntu 22.04" {
+  local expected_response
+  expected_response="$(busctl --system get-property \
+                         org.freedesktop.systemd1 \
+                         /org/freedesktop/systemd1 \
+                         org.freedesktop.systemd1.Manager \
+                         Version)"
+
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 22.04 \
+    busctl --system get-property \
+      org.freedesktop.systemd1 \
+      /org/freedesktop/systemd1 \
+      org.freedesktop.systemd1.Manager \
+      Version
+
+  assert_success
+  assert_line --index 0 "$expected_response"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "dbus: system bus inside Ubuntu 24.04" {
+  local expected_response
+  expected_response="$(busctl --system get-property \
+                         org.freedesktop.systemd1 \
+                         /org/freedesktop/systemd1 \
+                         org.freedesktop.systemd1.Manager \
+                         Version)"
+
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 24.04 \
     busctl --system get-property \
       org.freedesktop.systemd1 \
       /org/freedesktop/systemd1 \

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -146,71 +146,12 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTFILESIZE inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 \
-                                             bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HISTFILESIZE inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTFILESIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTFILESIZE=1001
-  else
-    ((HISTFILESIZE++))
-  fi
-
-  export HISTFILESIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 \
-                                             bash -c 'echo "$HISTFILESIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HISTFILESIZE inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
     HISTFILESIZE=1001
   else
     ((HISTFILESIZE++))
@@ -220,6 +161,66 @@ teardown() {
 
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 \
+                                             bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 \
+                                             bash -c 'echo "$HISTFILESIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTFILESIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTFILESIZE inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTFILESIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTFILESIZE=1001
+  else
+    ((HISTFILESIZE++))
+  fi
+
+  export HISTFILESIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 \
                                              bash -c 'echo "$HISTFILESIZE"'
 
   assert_success
@@ -356,69 +357,12 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HISTSIZE inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTSIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTSIZE=1001
-  else
-    ((HISTSIZE++))
-  fi
-
-  export HISTSIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$HISTSIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HISTSIZE inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2031
-  if [ "$HISTSIZE" = "" ]; then
-    # shellcheck disable=SC2030
-    HISTSIZE=1001
-  else
-    ((HISTSIZE++))
-  fi
-
-  export HISTSIZE
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$HISTSIZE"'
-
-  assert_success
-  assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HISTSIZE inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
+    # shellcheck disable=SC2030
     HISTSIZE=1001
   else
     ((HISTSIZE++))
@@ -428,6 +372,64 @@ teardown() {
 
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$HISTSIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTSIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTSIZE inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTSIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTSIZE=1001
+  else
+    ((HISTSIZE++))
+  fi
+
+  export HISTSIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 bash -c 'echo "$HISTSIZE"'
+
+  assert_success
+  assert_line --index 0 "$HISTSIZE"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HISTSIZE inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  # shellcheck disable=SC2031
+  if [ "$HISTSIZE" = "" ]; then
+    # shellcheck disable=SC2030
+    HISTSIZE=1001
+  else
+    ((HISTSIZE++))
+  fi
+
+  export HISTSIZE
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 bash -c 'echo "$HISTSIZE"'
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
@@ -514,47 +516,47 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: HOSTNAME inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$HOSTNAME"'
-
-  assert_success
-  assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: HOSTNAME inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$HOSTNAME"'
-
-  assert_success
-  assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: HOSTNAME inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbx"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 bash -c 'echo "$HOSTNAME"'
+
+  assert_success
+  assert_line --index 0 "toolbx"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: HOSTNAME inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 bash -c 'echo "$HOSTNAME"'
 
   assert_success
   assert_line --index 0 "toolbx"
@@ -667,66 +669,67 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: KONSOLE_VERSION inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2031
-  if [ "$KONSOLE_VERSION" = "" ]; then
-    # shellcheck disable=SC2030
-    export KONSOLE_VERSION=230804
-  fi
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$KONSOLE_VERSION"'
-
-  assert_success
-  assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: KONSOLE_VERSION inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2031
-  if [ "$KONSOLE_VERSION" = "" ]; then
-    # shellcheck disable=SC2030
-    export KONSOLE_VERSION=230804
-  fi
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$KONSOLE_VERSION"'
-
-  assert_success
-  assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
     export KONSOLE_VERSION=230804
   fi
 
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$KONSOLE_VERSION"'
+
+  assert_success
+  assert_line --index 0 "$KONSOLE_VERSION"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: KONSOLE_VERSION inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  # shellcheck disable=SC2031
+  if [ "$KONSOLE_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
+    export KONSOLE_VERSION=230804
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 bash -c 'echo "$KONSOLE_VERSION"'
+
+  assert_success
+  assert_line --index 0 "$KONSOLE_VERSION"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: KONSOLE_VERSION inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  # shellcheck disable=SC2031
+  if [ "$KONSOLE_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
+    export KONSOLE_VERSION=230804
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 bash -c 'echo "$KONSOLE_VERSION"'
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
@@ -840,66 +843,67 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "environment variables: XTERM_VERSION inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
-  # shellcheck disable=SC2031
-  if [ "$XTERM_VERSION" = "" ]; then
-    # shellcheck disable=SC2030
-    export XTERM_VERSION="XTerm(385)"
-  fi
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$XTERM_VERSION"'
-
-  assert_success
-  assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
-@test "environment variables: XTERM_VERSION inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
-  # shellcheck disable=SC2031
-  if [ "$XTERM_VERSION" = "" ]; then
-    # shellcheck disable=SC2030
-    export XTERM_VERSION="XTerm(385)"
-  fi
-
-  # shellcheck disable=SC2016
-  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$XTERM_VERSION"'
-
-  assert_success
-  assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
-  # shellcheck disable=SC2154
-  assert [ ${#stderr_lines[@]} -eq 0 ]
-}
-
 @test "environment variables: XTERM_VERSION inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
     export XTERM_VERSION="XTerm(385)"
   fi
 
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$XTERM_VERSION"'
+
+  assert_success
+  assert_line --index 0 "$XTERM_VERSION"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: XTERM_VERSION inside Ubuntu 22.04" {
+  create_distro_container ubuntu 22.04 ubuntu-toolbox-22.04
+
+  # shellcheck disable=SC2031
+  if [ "$XTERM_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
+    export XTERM_VERSION="XTerm(385)"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 22.04 bash -c 'echo "$XTERM_VERSION"'
+
+  assert_success
+  assert_line --index 0 "$XTERM_VERSION"
+
+  if check_bats_version 1.10.0; then
+    assert [ ${#lines[@]} -eq 1 ]
+  else
+    assert [ ${#lines[@]} -eq 2 ]
+  fi
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "environment variables: XTERM_VERSION inside Ubuntu 24.04" {
+  create_distro_container ubuntu 24.04 ubuntu-toolbox-24.04
+
+  # shellcheck disable=SC2031
+  if [ "$XTERM_VERSION" = "" ]; then
+    # shellcheck disable=SC2030
+    export XTERM_VERSION="XTerm(385)"
+  fi
+
+  # shellcheck disable=SC2016
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 24.04 bash -c 'echo "$XTERM_VERSION"'
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -46,9 +46,9 @@ setup_suite() {
   _pull_and_cache_distro_image arch latest || false
   _pull_and_cache_distro_image fedora 34 || false
   _pull_and_cache_distro_image rhel 8.10 || false
-  _pull_and_cache_distro_image ubuntu 16.04 || false
-  _pull_and_cache_distro_image ubuntu 18.04 || false
   _pull_and_cache_distro_image ubuntu 20.04 || false
+  _pull_and_cache_distro_image ubuntu 22.04 || false
+  _pull_and_cache_distro_image ubuntu 24.04 || false
   _pull_and_cache_distro_image busybox || false
   # If run on Fedora Rawhide, cache 2 extra images (previous Fedora versions)
   if is_fedora_rawhide; then


### PR DESCRIPTION
The Ubuntu versions used for testing are updated from 16.04, 18.04, and 20.04 to 20.04, 22.04, and 24.04. This brings all Ubuntu releases used into the current standard support window, and removes tests using Ubuntu 16.04 and 18.04 which have failed on every machine I've tried them on. 

It may also/alternatively make sense to reduce the number of Ubuntu versions tested (probably to just 24.04), as no other distro is tested with multiple releases. Other distros could also have the versions used updated, for example Fedora 34 is used which is far out of date.