### PR TITLE
Add man pages and progress bars to Arch Linux image

### DIFF
--- a/images/arch/Containerfile
+++ b/images/arch/Containerfile
@@ -12,6 +12,12 @@ COPY extra-packages /
 RUN pacman -Syu --needed --noconfirm - < extra-packages
 RUN rm /extra-packages
 
+# Enable man pages, enable progress bars
+RUN sed -i -e 's/NoProgressBar/#NoProgressBar/' -e 's/NoExtract/#NoExtract/' /etc/pacman.conf
+
+# Force reinstall of packages which have man pages (shouldn't redownload any that were just upgraded)
+RUN mkdir -p /usr/share/man && pacman -Qo /usr/share/man | awk '{print $5}' | xargs pacman -S --noconfirm man-db
+
 # Clean up cache
 RUN yes | pacman -Scc
 


### PR DESCRIPTION
This pull request brings the Arch Linux toolbx image in line with the other toolbx-provided images by providing man pages with the default install.

As of right now, it seems like every well-supported Arch Linux image available is a minimized install without man pages or visual enhancements enabled for pacman. This is great for containerized applications and CI, but this isn't so great for frequent users of Arch Linux in toolbx or distrobox.

I've been working around this problem for a long while by maintaining my own local dockerfiles, but I kind of expected this issue to be solved upstream by now. Since it looks like we're not going to get any more Arch Linux docker images from upstream (at least for a very long while), I figured this is the best place to stick this fix.

EDIT: I should also mention, this disables all of the NoExtract lines in the config, including the following:
```
NoExtract  = usr/share/help/* !usr/share/help/en* !usr/share/help/C/*
NoExtract  = usr/share/gtk-doc/html/* usr/share/doc/*
NoExtract  = usr/share/locale/* usr/share/X11/locale/* usr/share/i18n/*
NoExtract   = !*locale*/en*/* !usr/share/i18n/charmaps/UTF-8.gz !usr/share/*locale*/locale.*
NoExtract   = !usr/share/*locales/en_?? !usr/share/*locales/i18n* !usr/share/*locales/iso*
NoExtract   = !usr/share/*locales/trans*
NoExtract   = !usr/share/X11/locale/C/*
NoExtract   = !usr/share/X11/locale/compose.dir !usr/share/X11/locale/iso8859-1/*
NoExtract  = !usr/share/*locales/C !usr/share/*locales/POSIX !usr/share/i18n/charmaps/ANSI_X3.4-1968.gz
NoExtract  = usr/share/man/* usr/share/info/*
NoExtract  = usr/share/vim/vim*/lang/*
NoExtract  = etc/pacman.conf etc/pacman.d/mirrorlist
```
I think this is generally fine as not much size is added, and I do frequently use toolboxes for graphical programs with gtk docs, or vim. Not sure what the difference is with the locales, but I could pretty easily make some changes to still exclude the locale files if that's what's needed to get this merged.