### PR TITLE
cmd/run, pkg/nvidia: Detect mismatched NVIDIA kernel & user space driver

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -269,7 +269,14 @@ func runCommand(container string,
 
 	cdiSpecForNvidia, err := nvidia.GenerateCDISpec()
 	if err != nil {
-		if !errors.Is(err, nvidia.ErrPlatformUnsupported) {
+		if errors.Is(err, nvidia.ErrNVMLDriverLibraryVersionMismatch) {
+			var builder strings.Builder
+			fmt.Fprintf(&builder, "the proprietary NVIDIA driver's kernel and user space don't match\n")
+			fmt.Fprintf(&builder, "Check the host operating system and systemd journal.")
+
+			errMsg := builder.String()
+			return errors.New(errMsg)
+		} else if !errors.Is(err, nvidia.ErrPlatformUnsupported) {
 			return err
 		}
 	} else {

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/HarryMichal/go-version v1.0.1
 	github.com/NVIDIA/go-nvlib v0.6.1
+	github.com/NVIDIA/go-nvml v0.12.4-0
 	github.com/NVIDIA/nvidia-container-toolkit v1.16.1
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/briandowns/spinner v1.18.0
@@ -23,7 +24,6 @@ require (
 )
 
 require (
-	github.com/NVIDIA/go-nvml v0.12.4-0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/src/pkg/nvidia/nvidia.go
+++ b/src/pkg/nvidia/nvidia.go
@@ -61,7 +61,8 @@ func GenerateCDISpec() (*specs.Spec, error) {
 
 	hasNvml, reason := info.HasNvml()
 	if !hasNvml {
-		logrus.Debugf("Generating Container Device Interface for NVIDIA: NVML not found: %s", reason)
+		logrus.Debugf("Generating Container Device Interface for NVIDIA: Management Library not found: %s",
+			reason)
 	}
 
 	isTegra, reason := info.IsTegraSystem()

--- a/src/pkg/nvidia/nvidia.go
+++ b/src/pkg/nvidia/nvidia.go
@@ -74,7 +74,7 @@ func GenerateCDISpec() (*specs.Spec, error) {
 		logger = logrus.StandardLogger()
 	}
 
-	cdi, err := nvcdi.New(nvcdi.WithLogger(logger))
+	cdi, err := nvcdi.New(nvcdi.WithInfoLib(info), nvcdi.WithLogger(logger))
 	if err != nil {
 		logrus.Debugf("Generating Container Device Interface for NVIDIA: failed to create library: %s", err)
 		return nil, errors.New("failed to create Container Device Interface library for NVIDIA")

--- a/src/pkg/nvidia/nvidia.go
+++ b/src/pkg/nvidia/nvidia.go
@@ -45,7 +45,14 @@ func createNullLogger() *logrus.Logger {
 func GenerateCDISpec() (*specs.Spec, error) {
 	logrus.Debugf("Generating Container Device Interface for NVIDIA")
 
-	info := info.New()
+	var logger *logrus.Logger
+	if logLevel < logrus.DebugLevel {
+		logger = createNullLogger()
+	} else {
+		logger = logrus.StandardLogger()
+	}
+
+	info := info.New(info.WithLogger(logger))
 
 	if ok, reason := info.HasDXCore(); ok {
 		logrus.Debugf("Generating Container Device Interface for NVIDIA: Windows is unsupported: %s", reason)
@@ -65,13 +72,6 @@ func GenerateCDISpec() (*specs.Spec, error) {
 	if !hasNvml && !isTegra {
 		logrus.Debug("Generating Container Device Interface for NVIDIA: skipping")
 		return nil, ErrPlatformUnsupported
-	}
-
-	var logger *logrus.Logger
-	if logLevel < logrus.DebugLevel {
-		logger = createNullLogger()
-	} else {
-		logger = logrus.StandardLogger()
 	}
 
 	cdi, err := nvcdi.New(nvcdi.WithInfoLib(info), nvcdi.WithLogger(logger))


### PR DESCRIPTION
The proprietary NVIDIA driver has a kernel space part and a user space
part, and they must always have the same matching version.  Sometimes,
the host operating system might end up with mismatched parts.  One
reason could be that the different third-party repositories used to
distribute the driver might be incompatible with each other.  eg., in
the case of Fedora it could be RPM Fusion and NVIDIA's own repository.

This shows up in the systemd journal as:
```
  $ journalctl --dmesg
  ...
  kernel: NVRM: API mismatch: the client has the version 555.58.02, but
          NVRM: this kernel module has the version 560.35.03.  Please
          NVRM: make sure that this kernel module and all NVIDIA driver
          NVRM: components have the same version.
  ...
```

Without any special handling of this scenario, users would be presented
with a very misleading error:
```
  $ toolbox enter
  Error: failed to get Container Device Interface containerEdits for
      NVIDIA
```

Instead, improve the error message to be more self-documenting:
```
  $ toolbox enter
  Error: the proprietary NVIDIA driver's kernel and user space don't
      match
  Check the host operating system and systemd journal.
```