### PR TITLE
cmd/initContainer: Log unknown Container Device Interface hook arguments

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -478,7 +478,7 @@ func applyCDISpecForNvidia(spec *specs.Spec) error {
 			hook.Args[0] != "nvidia-ctk" ||
 			hook.Args[1] != "hook" ||
 			hook.Args[2] != "update-ldcache" {
-			logrus.Debugf("Applying Container Device Interface for NVIDIA: unknown hook arguments")
+			logrus.Debug("Applying Container Device Interface for NVIDIA: unknown hook arguments")
 			continue
 		}
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -478,7 +478,11 @@ func applyCDISpecForNvidia(spec *specs.Spec) error {
 			hook.Args[0] != "nvidia-ctk" ||
 			hook.Args[1] != "hook" ||
 			hook.Args[2] != "update-ldcache" {
-			logrus.Debug("Applying Container Device Interface for NVIDIA: unknown hook arguments")
+			logrus.Debug("Applying Container Device Interface for NVIDIA: unknown hook arguments:")
+			for _, arg := range hook.Args {
+				logrus.Debugf("%s", arg)
+			}
+
 			continue
 		}
 


### PR DESCRIPTION
NVIDIA Container Toolkit 0.16.0 changed the hook arguments in the
Container Device Interface specification generated by it [1].  Having
the unknown hook arguments show up in the debug logs makes it easier to
understand what happened.

[1] NVIDIA Container Toolkit commit 179d8655f9b5fce6
    https://github.com/NVIDIA/nvidia-container-toolkit/commit/179d8655f9b5fce6
    https://github.com/NVIDIA/nvidia-container-toolkit/issues/435