### PR TITLE
[WIP] cmd/initContainer, test/system: Handle NVIDIA's create-symlinks CDI hook

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-40
     description: Run Toolbx's system tests in Fedora 40
-    timeout: 6600
+    timeout: 7200
     nodeset:
       nodes:
         - name: fedora-40
@@ -73,7 +73,7 @@
 - job:
     name: system-test-fedora-39
     description: Run Toolbx's system tests in Fedora 39
-    timeout: 6600
+    timeout: 7200
     nodeset:
       nodes:
         - name: fedora-39

--- a/test/system/230-cdi.bats
+++ b/test/system/230-cdi.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -128,13 +128,7 @@ teardown() {
   assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 ""
   assert_line --index 3 "/usr/lib64"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 4 ]
-  else
-    assert [ ${#lines[@]} -eq 5 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 4 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -168,13 +162,7 @@ teardown() {
   assert_line --index 2 ""
   assert_line --index 3 "/usr/lib"
   assert_line --index 4 "/usr/lib64"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 5 ]
-  else
-    assert [ ${#lines[@]} -eq 6 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 5 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 

--- a/test/system/230-cdi.bats
+++ b/test/system/230-cdi.bats
@@ -70,6 +70,809 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "cdi: create-symlinks with no link" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-00.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, different parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-01.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, different parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-01.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, missing parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-02.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, missing parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-02.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, same parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-03.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (absolute target, same parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-03.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with three links (absolute targets, mixed parents)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-04.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with three links (absolute targets, mixed parents, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-04.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "/usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, different parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-05.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, different parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-05.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, missing parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-06.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, missing parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-06.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, same parent)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-07.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with one link (relative target, same parent, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-07.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with three links (relative targets, mixed parents)" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-08.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: create-symlinks with three links (relative targets, mixed parents, restart)" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-08.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  "$PODMAN" stop "$default_container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /run/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /run/toolbox.1
+
+  assert_success
+  assert_line --index 0 "../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /opt/bin/toolbox
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /opt/bin/toolbox
+
+  assert_success
+  assert_line --index 0 "../../usr/bin/toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run readlink /usr/bin/toolbox.1
+
+  assert_success
+  assert_line --index 0 "toolbox"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
 @test "cdi: ldconfig(8) with no folder" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -213,6 +1016,202 @@ teardown() {
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: failed to load Container Device Interface for NVIDIA"
   assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with invalid path" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-30.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: invalid hook in Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with unknown path" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-31.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "cdi: Try create-symlinks with missing --link argument" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-32.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: failed to create symlinks for Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with relative link in --link argument" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-33.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: failed to create symlinks for Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with wrongly formatted --link argument ('foo')" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-34.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: failed to create symlinks for Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with wrongly formatted --link argument ('foo::bar::baz')" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-35.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: failed to create symlinks for Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with invalid name" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-36.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run true
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Error: invalid hook in Container Device Interface for NVIDIA"
+  assert [ ${#stderr_lines[@]} -eq 1 ]
+}
+
+@test "cdi: Try create-symlinks with unknown name" {
+  local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-37.json"
+  local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
+
+  create_default_container
+
+  # shellcheck disable=SC2174
+  mkdir --mode 700 --parents "$toolbx_runtime_directory"
+
+  cp "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"
+  chmod 644 "$toolbx_runtime_directory/cdi-nvidia.json"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /usr/bin/toolbox.1
+
+  if ! cmp --silent "$test_cdi_file" "$toolbx_runtime_directory/cdi-nvidia.json"; then
+    skip "found NVIDIA hardware"
+  fi
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
 @test "cdi: Try hook with invalid path" {

--- a/test/system/data/cdi-hooks-create-symlinks-00.json
+++ b/test/system/data/cdi-hooks-create-symlinks-00.json
@@ -1,0 +1,14 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-01.json
+++ b/test/system/data/cdi-hooks-create-symlinks-01.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "/usr/bin/toolbox::/run/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-02.json
+++ b/test/system/data/cdi-hooks-create-symlinks-02.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "/usr/bin/toolbox::/opt/bin/toolbox"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-03.json
+++ b/test/system/data/cdi-hooks-create-symlinks-03.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "/usr/bin/toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-04.json
+++ b/test/system/data/cdi-hooks-create-symlinks-04.json
@@ -1,0 +1,20 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "/usr/bin/toolbox::/run/toolbox.1",
+          "--link",
+          "/usr/bin/toolbox::/opt/bin/toolbox",
+          "--link",
+          "/usr/bin/toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-05.json
+++ b/test/system/data/cdi-hooks-create-symlinks-05.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "../usr/bin/toolbox::/run/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-06.json
+++ b/test/system/data/cdi-hooks-create-symlinks-06.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "../../usr/bin/toolbox::/opt/bin/toolbox"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-07.json
+++ b/test/system/data/cdi-hooks-create-symlinks-07.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-08.json
+++ b/test/system/data/cdi-hooks-create-symlinks-08.json
@@ -1,0 +1,20 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "../usr/bin/toolbox::/run/toolbox.1",
+          "--link",
+          "../../usr/bin/toolbox::/opt/bin/toolbox",
+          "--link",
+          "toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-30.json
+++ b/test/system/data/cdi-hooks-create-symlinks-30.json
@@ -1,0 +1,14 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks"
+        ],
+        "hookName": "createContainer",
+        "path": ""
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-31.json
+++ b/test/system/data/cdi-hooks-create-symlinks-31.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "unknown",
+          "create-symlinks",
+          "--link",
+          "toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/unknown"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-32.json
+++ b/test/system/data/cdi-hooks-create-symlinks-32.json
@@ -1,0 +1,15 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-33.json
+++ b/test/system/data/cdi-hooks-create-symlinks-33.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "toolbox::toolbox.1"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-34.json
+++ b/test/system/data/cdi-hooks-create-symlinks-34.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "foo"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-35.json
+++ b/test/system/data/cdi-hooks-create-symlinks-35.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "foo::bar::baz"
+        ],
+        "hookName": "createContainer",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-36.json
+++ b/test/system/data/cdi-hooks-create-symlinks-36.json
@@ -1,0 +1,14 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks"
+        ],
+        "hookName": "invalid",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}

--- a/test/system/data/cdi-hooks-create-symlinks-37.json
+++ b/test/system/data/cdi-hooks-create-symlinks-37.json
@@ -1,0 +1,16 @@
+{
+  "containerEdits": {
+    "hooks": [
+      {
+        "args": [
+          "nvidia-cdi-hook",
+          "create-symlinks",
+          "--link",
+          "toolbox::/usr/bin/toolbox.1"
+        ],
+        "hookName": "createRuntime",
+        "path": "/usr/bin/nvidia-cdi-hook"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
NVIDIA Container Toolkit 0.16.0 started using `create-symlinks` hooks in
the Container Device Interface specification generated by it [1].  For
example:
```
  "hookName": "createContainer",
  "path": "/usr/bin/nvidia-cdi-hook",
  "args": [
    "nvidia-cdi-hook",
    "create-symlinks",
    "--link",
    "libnvidia-allocator.so.560.35.03::/usr/lib64/libnvidia-allocator.so.1",
    "--link",
    "../libnvidia-allocator.so.1::/usr/lib64/gbm/nvidia-drm_gbm.so"
  ]
```

Fallout from 649d02f8a6e1d3531324b571ce8a683b6989c41f

[1] NVIDIA Container Toolkit commit aae3da88c33d9cf2
    https://github.com/NVIDIA/nvidia-container-toolkit/commit/aae3da88c33d9cf2
    https://github.com/NVIDIA/nvidia-container-toolkit/pull/548