### PR TITLE
.zuul, test/system: Simplify line count checks by using Bats >= 1.10.0

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -62,7 +62,7 @@
 - job:
     name: system-test-fedora-40
     description: Run Toolbx's system tests in Fedora 40
-    timeout: 6600
+    timeout: 7200
     nodeset:
       nodes:
         - name: fedora-40
@@ -73,7 +73,7 @@
 - job:
     name: system-test-fedora-39
     description: Run Toolbx's system tests in Fedora 39
-    timeout: 6600
+    timeout: 7200
     nodeset:
       nodes:
         - name: fedora-39

--- a/test/system/230-cdi.bats
+++ b/test/system/230-cdi.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -128,13 +128,7 @@ teardown() {
   assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 ""
   assert_line --index 3 "/usr/lib64"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 4 ]
-  else
-    assert [ ${#lines[@]} -eq 5 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 4 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -168,13 +162,7 @@ teardown() {
   assert_line --index 2 ""
   assert_line --index 3 "/usr/lib"
   assert_line --index 4 "/usr/lib64"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 5 ]
-  else
-    assert [ ${#lines[@]} -eq 6 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 5 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 


### PR DESCRIPTION
Commit 87eaeea6f0c2b245 already added a dependency on Bats >= 1.10.0,
which is present on Fedora >= 39.  Therefore, it should be exploited
wherever possible to simplify things.

Currently, the CI has been frequently timing out on stable Fedora nodes.
So, increase the timeout from 1 hour 50 minutes to 2 hours to avoid
that.

For what it's worth, the timeout for Fedora Rawhide nodes is 2 hours 10
minutes and it seems enough.