### PR TITLE
test/system: Optimize the resource limits tests

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -49,71 +49,141 @@
     run: playbooks/unit-test.yaml
 
 - job:
-    name: system-test-fedora-rawhide
-    description: Run Toolbx's system tests in Fedora Rawhide
-    timeout: 10800
+    name: system-test-fedora-rawhide-commands-options
+    description: Run Toolbx's commands-options system tests in Fedora Rawhide
+    timeout: 7200
     nodeset:
       nodes:
         - name: fedora-rawhide
           label: cloud-fedora-rawhide
     pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
+    run: playbooks/system-test-commands-options.yaml
 
 - job:
-    name: system-test-fedora-41
-    description: Run Toolbx's system tests in Fedora 41
-    timeout: 9000
+    name: system-test-fedora-rawhide-runtime-environment-arch-fedora
+    description: Run Toolbx's (arch-fedora,runtime-environment) system tests in Fedora Rawhide
+    timeout: 7200
+    nodeset:
+      nodes:
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
+    pre-run: playbooks/setup-env.yaml
+    run: playbooks/system-test-runtime-environment-arch-fedora.yaml
+
+- job:
+    name: system-test-fedora-rawhide-runtime-environment-ubuntu
+    description: Run Toolbx's (runtime-environment,ubuntu) system tests in Fedora Rawhide
+    timeout: 7200
+    nodeset:
+      nodes:
+        - name: fedora-rawhide
+          label: cloud-fedora-rawhide
+    pre-run: playbooks/setup-env.yaml
+    run: playbooks/system-test-runtime-environment-ubuntu.yaml
+
+- job:
+    name: system-test-fedora-41-commands-options
+    description: Run Toolbx's commands-options system tests in Fedora 41
+    timeout: 6300
     nodeset:
       nodes:
         - name: fedora-41
           label: cloud-fedora-41
     pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
+    run: playbooks/system-test-commands-options.yaml
 
 - job:
-    name: system-test-fedora-40
-    description: Run Toolbx's system tests in Fedora 40
-    timeout: 9000
+    name: system-test-fedora-41-runtime-environment
+    description: Run Toolbx's runtime-environment system tests in Fedora 41
+    timeout: 6300
+    nodeset:
+      nodes:
+        - name: fedora-41
+          label: cloud-fedora-41
+    pre-run: playbooks/setup-env.yaml
+    run: playbooks/system-test-runtime-environment.yaml
+
+- job:
+    name: system-test-fedora-40-commands-options
+    description: Run Toolbx's commands-options system tests in Fedora 40
+    timeout: 6300
     nodeset:
       nodes:
         - name: fedora-40
           label: cloud-fedora-40
     pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
+    run: playbooks/system-test-commands-options.yaml
 
 - job:
-    name: system-test-fedora-39
-    description: Run Toolbx's system tests in Fedora 39
-    timeout: 9000
+    name: system-test-fedora-40-runtime-environment
+    description: Run Toolbx's runtime-environment system tests in Fedora 40
+    timeout: 6300
+    nodeset:
+      nodes:
+        - name: fedora-40
+          label: cloud-fedora-40
+    pre-run: playbooks/setup-env.yaml
+    run: playbooks/system-test-runtime-environment.yaml
+
+- job:
+    name: system-test-fedora-39-commands-options
+    description: Run Toolbx's commands-options system tests in Fedora 39
+    timeout: 6300
     nodeset:
       nodes:
         - name: fedora-39
           label: cloud-fedora-39
     pre-run: playbooks/setup-env.yaml
-    run: playbooks/system-test.yaml
+    run: playbooks/system-test-commands-options.yaml
+
+- job:
+    name: system-test-fedora-39-runtime-environment
+    description: Run Toolbx's runtime-environment system tests in Fedora 39
+    timeout: 6300
+    nodeset:
+      nodes:
+        - name: fedora-39
+          label: cloud-fedora-39
+    pre-run: playbooks/setup-env.yaml
+    run: playbooks/system-test-runtime-environment.yaml
 
 - project:
     periodic:
       jobs:
-        - system-test-fedora-rawhide
-        - system-test-fedora-41
-        - system-test-fedora-40
-        - system-test-fedora-39
+        - system-test-fedora-rawhide-commands-options
+        - system-test-fedora-rawhide-runtime-environment-arch-fedora
+        - system-test-fedora-rawhide-runtime-environment-ubuntu
+        - system-test-fedora-41-commands-options
+        - system-test-fedora-41-runtime-environment
+        - system-test-fedora-40-commands-options
+        - system-test-fedora-40-runtime-environment
+        - system-test-fedora-39-commands-options
+        - system-test-fedora-39-runtime-environment
     check:
       jobs:
         - unit-test
         - unit-test-migration-path-for-coreos-toolbox
         - unit-test-restricted
-        - system-test-fedora-rawhide
-        - system-test-fedora-41
-        - system-test-fedora-40
-        - system-test-fedora-39
+        - system-test-fedora-rawhide-commands-options
+        - system-test-fedora-rawhide-runtime-environment-arch-fedora
+        - system-test-fedora-rawhide-runtime-environment-ubuntu
+        - system-test-fedora-41-commands-options
+        - system-test-fedora-41-runtime-environment
+        - system-test-fedora-40-commands-options
+        - system-test-fedora-40-runtime-environment
+        - system-test-fedora-39-commands-options
+        - system-test-fedora-39-runtime-environment
     gate:
       jobs:
         - unit-test
         - unit-test-migration-path-for-coreos-toolbox
         - unit-test-restricted
-        - system-test-fedora-rawhide
-        - system-test-fedora-41
-        - system-test-fedora-40
-        - system-test-fedora-39
+        - system-test-fedora-rawhide-commands-options
+        - system-test-fedora-rawhide-runtime-environment-arch-fedora
+        - system-test-fedora-rawhide-runtime-environment-ubuntu
+        - system-test-fedora-41-commands-options
+        - system-test-fedora-41-runtime-environment
+        - system-test-fedora-40-commands-options
+        - system-test-fedora-40-runtime-environment
+        - system-test-fedora-39-commands-options
+        - system-test-fedora-39-runtime-environment

--- a/playbooks/system-test-commands-options.yaml
+++ b/playbooks/system-test-commands-options.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright © 2021 – 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  tasks:
+    - include_tasks: build.yaml
+
+    - name: Run the commands-options system tests
+      command: bats --filter-tags commands-options ./test/system
+      environment:
+        PODMAN: '/usr/bin/podman'
+        TMPDIR: '/var/tmp'
+        TOOLBX: '/usr/local/bin/toolbox'
+        TOOLBX_TEST_SYSTEM_TAGS: 'arch-fedora,commands-options,custom-image,ubuntu'
+      args:
+        chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/system-test-runtime-environment-arch-fedora.yaml
+++ b/playbooks/system-test-runtime-environment-arch-fedora.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright © 2021 – 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  tasks:
+    - include_tasks: build.yaml
+
+    - name: Run the (arch-fedora,runtime-environment) system tests
+      command: bats --filter-tags arch-fedora,runtime-environment ./test/system
+      environment:
+        PODMAN: '/usr/bin/podman'
+        TMPDIR: '/var/tmp'
+        TOOLBX: '/usr/local/bin/toolbox'
+        TOOLBX_TEST_SYSTEM_TAGS: 'arch-fedora,runtime-environment'
+      args:
+        chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/system-test-runtime-environment-ubuntu.yaml
+++ b/playbooks/system-test-runtime-environment-ubuntu.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright © 2021 – 2024 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+- hosts: all
+  tasks:
+    - include_tasks: build.yaml
+
+    - name: Run the (runtime-environment,ubuntu) system tests
+      command: bats --filter-tags runtime-environment,ubuntu ./test/system
+      environment:
+        PODMAN: '/usr/bin/podman'
+        TMPDIR: '/var/tmp'
+        TOOLBX: '/usr/local/bin/toolbox'
+        TOOLBX_TEST_SYSTEM_TAGS: 'runtime-environment,ubuntu'
+      args:
+        chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/system-test-runtime-environment.yaml
+++ b/playbooks/system-test-runtime-environment.yaml
@@ -19,11 +19,12 @@
   tasks:
     - include_tasks: build.yaml
 
-    - name: Run system tests
-      command: bats ./test/system
+    - name: Run the runtime-environment system tests
+      command: bats --filter-tags runtime-environment ./test/system
       environment:
         PODMAN: '/usr/bin/podman'
         TMPDIR: '/var/tmp'
         TOOLBX: '/usr/local/bin/toolbox'
+        TOOLBX_TEST_SYSTEM_TAGS: 'arch-fedora,runtime-environment,ubuntu'
       args:
         chdir: '{{ zuul.project.src_dir }}'

--- a/playbooks/system-test.yaml
+++ b/playbooks/system-test.yaml
@@ -20,7 +20,7 @@
     - include_tasks: build.yaml
 
     - name: Run system tests
-      command: bats --timing ./test/system
+      command: bats ./test/system
       environment:
         PODMAN: '/usr/bin/podman'
         TMPDIR: '/var/tmp'

--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
 }
 

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers.bash'

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'

--- a/test/system/102-list.bats
+++ b/test/system/102-list.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/106-rm.bats
+++ b/test/system/106-rm.bats
@@ -15,11 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/108-completion.bats
+++ b/test/system/108-completion.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
 }
 

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -41,12 +41,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$ns_host"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/201-ipc.bats
+++ b/test/system/201-ipc.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -31,6 +33,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "ipc: No namespace" {
   local ns_host
   ns_host=$(readlink /proc/$$/ns/ipc)

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -32,7 +32,7 @@ readonly RESOLVER_SH='resolvectl --legend false --no-pager --type "$0" query "$1
                       | cut --delimiter " " --fields 4'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -53,12 +53,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$ns_host"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -71,12 +66,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -89,12 +79,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -107,12 +92,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -125,12 +105,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -143,12 +118,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -161,12 +131,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -179,12 +144,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "/run/host/etc/resolv.conf"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -214,13 +174,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -229,13 +183,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -266,13 +214,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -283,13 +225,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -321,13 +257,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -339,13 +269,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -377,13 +301,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -395,13 +313,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -433,13 +345,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -451,13 +357,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -489,13 +389,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -507,13 +401,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }
@@ -545,13 +433,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv4_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 
@@ -563,13 +445,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "$ipv6_addr"
-
-    if check_bats_version 1.10.0; then
-      assert [ ${#lines[@]} -eq 1 ]
-    else
-      assert [ ${#lines[@]} -eq 2 ]
-    fi
-
+    assert [ ${#lines[@]} -eq 1 ]
     assert [ ${#stderr_lines[@]} -eq 0 ]
   fi
 }

--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -43,6 +45,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "network: No namespace" {
   local ns_host
   ns_host=$(readlink /proc/$$/ns/net)
@@ -59,6 +62,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: /etc/resolv.conf inside the default container" {
   create_default_container
 
@@ -72,6 +76,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: /etc/resolv.conf inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -85,6 +90,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: /etc/resolv.conf inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -98,6 +104,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: /etc/resolv.conf inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -111,6 +118,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "network: /etc/resolv.conf inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -124,6 +132,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "network: /etc/resolv.conf inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -137,6 +146,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "network: /etc/resolv.conf inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -150,6 +160,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: DNS inside the default container" {
   local ipv4_skip=false
   local ipv4_addr
@@ -188,6 +199,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=arch-fedora
 @test "network: DNS inside Arch Linux" {
   local ipv4_skip=false
   local ipv4_addr
@@ -230,6 +242,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=arch-fedora
 @test "network: DNS inside Fedora 34" {
   local ipv4_skip=false
   local ipv4_addr
@@ -274,6 +287,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=arch-fedora
 @test "network: DNS inside RHEL 8.10" {
   local ipv4_skip=false
   local ipv4_addr
@@ -318,6 +332,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=ubuntu
 @test "network: DNS inside Ubuntu 16.04" {
   local ipv4_skip=false
   local ipv4_addr
@@ -362,6 +377,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=ubuntu
 @test "network: DNS inside Ubuntu 18.04" {
   local ipv4_skip=false
   local ipv4_addr
@@ -406,6 +422,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=ubuntu
 @test "network: DNS inside Ubuntu 20.04" {
   local ipv4_skip=false
   local ipv4_addr
@@ -450,6 +467,7 @@ teardown() {
   fi
 }
 
+# bats test_tags=arch-fedora
 @test "network: ping(8) inside the default container" {
   create_default_container
 
@@ -466,6 +484,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: ping(8) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -482,6 +501,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: ping(8) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -498,6 +518,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "network: ping(8) inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -514,6 +535,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "network: ping(8) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -528,6 +550,7 @@ teardown() {
   skip "doesn't use ICMP Echo sockets"
 }
 
+# bats test_tags=ubuntu
 @test "network: ping(8) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -544,6 +567,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "network: ping(8) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -42,12 +42,7 @@ teardown() {
   assert_success
   assert_line --index 0 --regexp '^user:\[[[:digit:]]+\]$'
   refute_line --index 0 "$ns_host"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -534,12 +529,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -550,12 +540,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -567,12 +552,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -583,12 +563,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -600,12 +575,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -616,12 +586,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -633,12 +598,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -649,12 +609,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -666,12 +621,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -682,12 +632,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -699,12 +644,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -715,12 +655,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -732,12 +667,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 id
 
   assert_success
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   local output_id="${lines[0]}"
 
@@ -748,12 +678,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$output_id"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -31,6 +33,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "user: Separate namespace" {
   local ns_host
   ns_host=$(readlink /proc/$$/ns/user)
@@ -48,6 +51,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside the default container" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -68,6 +72,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount arch-toolbox-latest)"
@@ -85,6 +90,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount fedora-toolbox-34)"
@@ -102,6 +108,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.10)"
@@ -119,6 +126,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
@@ -136,6 +144,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
@@ -153,6 +162,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
@@ -170,6 +180,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in passwd(5) inside the default container" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -189,6 +200,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in passwd(5) inside Arch Linux" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -208,6 +220,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in passwd(5) inside Fedora 34" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -227,6 +240,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in passwd(5) inside RHEL 8.10" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -246,6 +260,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in passwd(5) inside Ubuntu 16.04" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -265,6 +280,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in passwd(5) inside Ubuntu 18.04" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -284,6 +300,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in passwd(5) inside Ubuntu 20.04" {
   local user_gecos
   user_gecos="$(getent passwd "$USER" | cut --delimiter : --fields 5)"
@@ -303,6 +320,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside the default container" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -323,6 +341,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount arch-toolbox-latest)"
@@ -340,6 +359,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount fedora-toolbox-34)"
@@ -357,6 +377,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount rhel-toolbox-8.10)"
@@ -374,6 +395,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-16.04)"
@@ -391,6 +413,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-18.04)"
@@ -408,6 +431,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$("$PODMAN" unshare "$PODMAN" mount ubuntu-toolbox-20.04)"
@@ -425,6 +449,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside the default container" {
   create_default_container
 
@@ -439,6 +464,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -453,6 +479,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -467,6 +494,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -481,6 +509,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -495,6 +524,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -509,6 +539,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -523,6 +554,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside the default container" {
   create_default_container
 
@@ -546,6 +578,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -569,6 +602,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -592,6 +626,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -615,6 +650,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -638,6 +674,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -661,6 +698,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -21,14 +21,15 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
-setup() {
+setup_file() {
   bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
+  create_default_container
 }
 
-teardown() {
+teardown_file() {
   popd || return 1
   cleanup_all
 }
@@ -37,8 +38,6 @@ teardown() {
 @test "ulimit: real-time non-blocking time (hard)" {
   local limit
   limit=$(ulimit -H -R)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -R
 
@@ -55,8 +54,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -R)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -R
 
   assert_success
@@ -71,8 +68,6 @@ teardown() {
 @test "ulimit: core file size (hard)" {
   local limit
   limit=$(ulimit -H -c)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -c
 
@@ -89,8 +84,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -c)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -c
 
   assert_success
@@ -105,8 +98,6 @@ teardown() {
 @test "ulimit: data segment size (hard)" {
   local limit
   limit=$(ulimit -H -d)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -d
 
@@ -123,8 +114,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -d)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -d
 
   assert_success
@@ -139,8 +128,6 @@ teardown() {
 @test "ulimit: scheduling priority (hard)" {
   local limit
   limit=$(ulimit -H -e)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -e
 
@@ -157,8 +144,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -e)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -e
 
   assert_success
@@ -173,8 +158,6 @@ teardown() {
 @test "ulimit: file size (hard)" {
   local limit
   limit=$(ulimit -H -f)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -f
 
@@ -191,8 +174,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -f)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -f
 
   assert_success
@@ -207,8 +188,6 @@ teardown() {
 @test "ulimit: number of pending signals (hard)" {
   local limit
   limit=$(ulimit -H -i)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -i
 
@@ -225,8 +204,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -i)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -i
 
   assert_success
@@ -241,8 +218,6 @@ teardown() {
 @test "ulimit: locked memory size (hard)" {
   local limit
   limit=$(ulimit -H -l)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -l
 
@@ -259,8 +234,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -l)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -l
 
   assert_success
@@ -275,8 +248,6 @@ teardown() {
 @test "ulimit: resident memory size (hard)" {
   local limit
   limit=$(ulimit -H -m)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -m
 
@@ -293,8 +264,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -m)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -m
 
   assert_success
@@ -309,8 +278,6 @@ teardown() {
 @test "ulimit: number of open files (hard)" {
   local limit
   limit=$(ulimit -H -n)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -n
 
@@ -327,8 +294,6 @@ teardown() {
   local limit
   limit=$(ulimit -H -n)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -n
 
   assert_success
@@ -343,8 +308,6 @@ teardown() {
 @test "ulimit: pipe size (hard)" {
   local limit
   limit=$(ulimit -H -p)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -p
 
@@ -361,8 +324,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -p)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -p
 
   assert_success
@@ -377,8 +338,6 @@ teardown() {
 @test "ulimit: POSIX message queue size (hard)" {
   local limit
   limit=$(ulimit -H -q)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -q
 
@@ -395,8 +354,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -q)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -q
 
   assert_success
@@ -411,8 +368,6 @@ teardown() {
 @test "ulimit: real-time scheduling priority (hard)" {
   local limit
   limit=$(ulimit -H -r)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -r
 
@@ -429,8 +384,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -r)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -r
 
   assert_success
@@ -445,8 +398,6 @@ teardown() {
 @test "ulimit: stack size (hard)" {
   local limit
   limit=$(ulimit -H -s)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -s
 
@@ -463,8 +414,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -s)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -s
 
   assert_success
@@ -479,8 +428,6 @@ teardown() {
 @test "ulimit: CPU time (hard)" {
   local limit
   limit=$(ulimit -H -t)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -t
 
@@ -497,8 +444,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -t)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -t
 
   assert_success
@@ -513,8 +458,6 @@ teardown() {
 @test "ulimit: number of user processes (hard)" {
   local limit
   limit=$(ulimit -H -u)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -u
 
@@ -531,8 +474,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -u)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -u
 
   assert_success
@@ -547,8 +488,6 @@ teardown() {
 @test "ulimit: virtual memory size (hard)" {
   local limit
   limit=$(ulimit -H -v)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -v
 
@@ -565,8 +504,6 @@ teardown() {
   local limit
   limit=$(ulimit -S -v)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -v
 
   assert_success
@@ -582,8 +519,6 @@ teardown() {
   local limit
   limit=$(ulimit -H -x)
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -H -x
 
   assert_success
@@ -598,8 +533,6 @@ teardown() {
 @test "ulimit: number of file locks (soft)" {
   local limit
   limit=$(ulimit -S -x)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run ulimit -S -x
 

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -41,12 +41,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -62,12 +57,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -83,12 +73,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -104,12 +89,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -125,12 +105,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -146,12 +121,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -167,12 +137,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -188,12 +153,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -209,12 +169,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -230,12 +185,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -251,12 +201,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -272,12 +217,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -293,12 +233,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -314,12 +249,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -335,12 +265,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -356,12 +281,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -377,12 +297,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -398,12 +313,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -419,12 +329,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -440,12 +345,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -461,12 +361,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -482,12 +377,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -503,12 +393,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -524,12 +409,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -545,12 +425,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -566,12 +441,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -587,12 +457,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -608,12 +473,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -629,12 +489,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -650,12 +505,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -671,12 +521,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -692,12 +537,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -713,12 +553,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -734,12 +569,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$limit"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/210-ulimit.bats
+++ b/test/system/210-ulimit.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -31,6 +33,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: real-time non-blocking time (hard)" {
   local limit
   limit=$(ulimit -H -R)
@@ -47,6 +50,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: real-time non-blocking time (soft)" {
   local limit
   limit=$(ulimit -S -R)
@@ -63,6 +67,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: core file size (hard)" {
   local limit
   limit=$(ulimit -H -c)
@@ -79,6 +84,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: core file size (soft)" {
   local limit
   limit=$(ulimit -S -c)
@@ -95,6 +101,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: data segment size (hard)" {
   local limit
   limit=$(ulimit -H -d)
@@ -111,6 +118,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: data segment size (soft)" {
   local limit
   limit=$(ulimit -S -d)
@@ -127,6 +135,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: scheduling priority (hard)" {
   local limit
   limit=$(ulimit -H -e)
@@ -143,6 +152,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: scheduling priority (soft)" {
   local limit
   limit=$(ulimit -S -e)
@@ -159,6 +169,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: file size (hard)" {
   local limit
   limit=$(ulimit -H -f)
@@ -175,6 +186,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: file size (soft)" {
   local limit
   limit=$(ulimit -S -f)
@@ -191,6 +203,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of pending signals (hard)" {
   local limit
   limit=$(ulimit -H -i)
@@ -207,6 +220,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of pending signals (soft)" {
   local limit
   limit=$(ulimit -S -i)
@@ -223,6 +237,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: locked memory size (hard)" {
   local limit
   limit=$(ulimit -H -l)
@@ -239,6 +254,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: locked memory size (soft)" {
   local limit
   limit=$(ulimit -S -l)
@@ -255,6 +271,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: resident memory size (hard)" {
   local limit
   limit=$(ulimit -H -m)
@@ -271,6 +288,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: resident memory size (soft)" {
   local limit
   limit=$(ulimit -S -m)
@@ -287,6 +305,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of open files (hard)" {
   local limit
   limit=$(ulimit -H -n)
@@ -303,6 +322,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of open files (soft)" {
   local limit
   limit=$(ulimit -H -n)
@@ -319,6 +339,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: pipe size (hard)" {
   local limit
   limit=$(ulimit -H -p)
@@ -335,6 +356,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: pipe size (soft)" {
   local limit
   limit=$(ulimit -S -p)
@@ -351,6 +373,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: POSIX message queue size (hard)" {
   local limit
   limit=$(ulimit -H -q)
@@ -367,6 +390,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: POSIX message queue size (soft)" {
   local limit
   limit=$(ulimit -S -q)
@@ -383,6 +407,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: real-time scheduling priority (hard)" {
   local limit
   limit=$(ulimit -H -r)
@@ -399,6 +424,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: real-time scheduling priority (soft)" {
   local limit
   limit=$(ulimit -S -r)
@@ -415,6 +441,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: stack size (hard)" {
   local limit
   limit=$(ulimit -H -s)
@@ -431,6 +458,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: stack size (soft)" {
   local limit
   limit=$(ulimit -S -s)
@@ -447,6 +475,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: CPU time (hard)" {
   local limit
   limit=$(ulimit -H -t)
@@ -463,6 +492,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: CPU time (soft)" {
   local limit
   limit=$(ulimit -S -t)
@@ -479,6 +509,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of user processes (hard)" {
   local limit
   limit=$(ulimit -H -u)
@@ -495,6 +526,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of user processes (soft)" {
   local limit
   limit=$(ulimit -S -u)
@@ -511,6 +543,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: virtual memory size (hard)" {
   local limit
   limit=$(ulimit -H -v)
@@ -527,6 +560,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: virtual memory size (soft)" {
   local limit
   limit=$(ulimit -S -v)
@@ -543,6 +577,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of file locks (hard)" {
   local limit
   limit=$(ulimit -H -x)
@@ -559,6 +594,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "ulimit: number of file locks (soft)" {
   local limit
   limit=$(ulimit -S -x)

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -49,12 +49,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -80,12 +75,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -112,12 +102,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -144,12 +129,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -234,12 +214,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -269,12 +244,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -305,12 +275,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -341,12 +306,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -373,12 +333,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -405,12 +360,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -437,12 +387,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$expected_response"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/211-dbus.bats
+++ b/test/system/211-dbus.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -31,6 +33,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: session bus inside the default container" {
   local expected_response
   expected_response="$(gdbus call \
@@ -55,6 +58,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: session bus inside Arch Linux" {
   local expected_response
   expected_response="$(gdbus call \
@@ -81,6 +85,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: session bus inside Fedora 34" {
   local expected_response
   expected_response="$(gdbus call \
@@ -108,6 +113,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: session bus inside RHEL 8.10" {
   local expected_response
   expected_response="$(gdbus call \
@@ -135,6 +141,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: session bus inside Ubuntu 16.04" {
   busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
 
@@ -154,6 +161,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: session bus inside Ubuntu 18.04" {
   busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
 
@@ -173,6 +181,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: session bus inside Ubuntu 20.04" {
   busctl --user call org.freedesktop.DBus /org/freedesktop/DBus org.freedesktop.DBus.Peer Ping
 
@@ -192,6 +201,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: system bus inside the default container" {
   local expected_response
   expected_response="$(gdbus call \
@@ -220,6 +230,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: system bus inside Arch Linux" {
   local expected_response
   expected_response="$(gdbus call \
@@ -250,6 +261,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: system bus inside Fedora 34" {
   local expected_response
   expected_response="$(gdbus call \
@@ -281,6 +293,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "dbus: system bus inside RHEL 8.10" {
   local expected_response
   expected_response="$(gdbus call \
@@ -312,6 +325,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: system bus inside Ubuntu 16.04" {
   local expected_response
   expected_response="$(busctl --system get-property \
@@ -339,6 +353,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: system bus inside Ubuntu 18.04" {
   local expected_response
   expected_response="$(busctl --system get-property \
@@ -366,6 +381,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "dbus: system bus inside Ubuntu 20.04" {
   local expected_response
   expected_response="$(busctl --system get-property \

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -20,7 +20,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
@@ -48,12 +48,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -77,12 +72,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -106,12 +96,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -135,12 +120,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -165,12 +145,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -195,12 +170,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -224,12 +194,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTFILESIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -254,12 +219,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -283,12 +243,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -314,12 +269,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -345,12 +295,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -374,12 +319,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -403,12 +343,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -431,12 +366,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HISTSIZE"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -450,13 +380,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 --regexp "^(toolbx|$HOSTNAME)$"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -468,13 +392,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -486,13 +404,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$HOSTNAME"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -504,13 +416,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -522,13 +428,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -540,13 +440,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -558,13 +452,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "toolbx"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
-
+  assert [ ${#lines[@]} -eq 1 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -581,12 +469,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -606,12 +489,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -631,12 +509,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -656,12 +529,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -681,12 +549,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -706,12 +569,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -730,12 +588,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$KONSOLE_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -754,12 +607,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -779,12 +627,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -804,12 +647,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -829,12 +667,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -854,12 +687,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -879,12 +707,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]
@@ -903,12 +726,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "$XTERM_VERSION"
-
-  if check_bats_version 1.10.0; then
-    assert [ ${#lines[@]} -eq 1 ]
-  else
-    assert [ ${#lines[@]} -eq 2 ]
-  fi
+  assert [ ${#lines[@]} -eq 1 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -31,6 +33,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside the default container" {
   create_default_container
 
@@ -54,6 +57,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -78,6 +82,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -102,6 +107,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -126,6 +132,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -151,6 +158,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -176,6 +184,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -200,6 +209,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside the default container" {
   skip "https://pagure.io/setup/pull-request/48"
 
@@ -225,6 +235,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -249,6 +260,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside Fedora 34" {
   skip "https://pagure.io/setup/pull-request/48"
 
@@ -275,6 +287,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside RHEL 8.10" {
   skip "https://pagure.io/setup/pull-request/48"
 
@@ -301,6 +314,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -325,6 +339,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -349,6 +364,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -372,6 +388,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside the default container" {
   create_default_container
 
@@ -384,6 +401,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -396,6 +414,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -408,6 +427,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -420,6 +440,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -432,6 +453,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -444,6 +466,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -456,6 +479,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside the default container" {
   create_default_container
 
@@ -475,6 +499,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -495,6 +520,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -515,6 +541,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -535,6 +562,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -555,6 +583,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -575,6 +604,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 
@@ -594,6 +624,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside the default container" {
   create_default_container
 
@@ -613,6 +644,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside Arch Linux" {
   create_distro_container arch latest arch-toolbox-latest
 
@@ -633,6 +665,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside Fedora 34" {
   create_distro_container fedora 34 fedora-toolbox-34
 
@@ -653,6 +686,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside RHEL 8.10" {
   create_distro_container rhel 8.10 rhel-toolbox-8.10
 
@@ -673,6 +707,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 16.04" {
   create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
 
@@ -693,6 +728,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 18.04" {
   create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
@@ -713,6 +749,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 20.04" {
   create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
 

--- a/test/system/230-cdi.bats
+++ b/test/system/230-cdi.bats
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# bats file_tags=runtime-environment
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
@@ -33,6 +35,7 @@ teardown() {
   cleanup_all
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Smoke test" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -70,6 +73,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with no link" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-00.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -93,6 +97,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, different parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-01.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -123,6 +128,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, different parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -171,6 +177,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, missing parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-02.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -201,6 +208,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, missing parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -249,6 +257,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, same parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-03.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -279,6 +288,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (absolute target, same parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -327,6 +337,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with three links (absolute targets, mixed parents)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-04.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -383,6 +394,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with three links (absolute targets, mixed parents, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -483,6 +495,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, different parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-05.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -513,6 +526,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, different parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -561,6 +575,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, missing parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-06.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -591,6 +606,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, missing parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -639,6 +655,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, same parent)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-07.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -669,6 +686,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with one link (relative target, same parent, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -717,6 +735,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with three links (relative targets, mixed parents)" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-08.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -773,6 +792,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: create-symlinks with three links (relative targets, mixed parents, restart)" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
@@ -873,6 +893,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: ldconfig(8) with no folder" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -902,6 +923,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: ldconfig(8) with one folder" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -935,6 +957,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: ldconfig(8) with two folders" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -969,6 +992,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try invalid JSON" {
   local invalid_json="This is not JSON"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -994,6 +1018,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try an empty file" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1018,6 +1043,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with invalid path" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-30.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1043,6 +1069,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with unknown path" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-31.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1066,6 +1093,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with missing --link argument" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-32.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1091,6 +1119,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with relative link in --link argument" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-33.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1116,6 +1145,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with wrongly formatted --link argument ('foo')" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-34.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1141,6 +1171,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with wrongly formatted --link argument ('foo::bar::baz')" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-35.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1166,6 +1197,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with invalid name" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-36.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1191,6 +1223,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try create-symlinks with unknown name" {
   local test_cdi_file="$BATS_TEST_DIRNAME/data/cdi-hooks-create-symlinks-37.json"
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
@@ -1214,6 +1247,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try hook with invalid path" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1238,6 +1272,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try hook with unknown path" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1267,6 +1302,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try hook with unknown args" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1296,6 +1332,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try hook with invalid name" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1320,6 +1357,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try hook with unknown name" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1349,6 +1387,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try mount with invalid container path" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1373,6 +1412,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try mount with invalid host path" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 
@@ -1397,6 +1437,7 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 1 ]
 }
 
+# bats test_tags=arch-fedora
 @test "cdi: Try mount with non-existent paths" {
   local toolbx_runtime_directory="$XDG_RUNTIME_DIR/toolbox"
 

--- a/test/system/501-create.bats
+++ b/test/system/501-create.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/504-run.bats
+++ b/test/system/504-run.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/505-enter.bats
+++ b/test/system/505-enter.bats
@@ -15,12 +15,14 @@
 # limitations under the License.
 #
 
+# bats file_tags=commands-options
+
 load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
 }

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -20,6 +20,8 @@ readonly DOCKER_REG_NAME="docker-registry"
 # Podman and Toolbx commands to run
 readonly PODMAN="${PODMAN:-$(command -v podman)}"
 readonly TOOLBX="${TOOLBX:-$(command -v toolbox)}"
+readonly TOOLBX_TEST_SYSTEM_TAGS_ALL="arch-fedora,commands-options,custom-image,runtime-environment,ubuntu"
+readonly TOOLBX_TEST_SYSTEM_TAGS="${TOOLBX_TEST_SYSTEM_TAGS:-$TOOLBX_TEST_SYSTEM_TAGS_ALL}"
 readonly SKOPEO="${SKOPEO:-$(command -v skopeo)}"
 
 # Images


### PR DESCRIPTION
The system tests can be very I/O intensive, because many of them copy
OCI images from the test suite's image cache directory to its local
container/storage store, create containers, and then delete everything
to run the next test with a clean slate.  This makes them slow.

The runtime environment tests, which includes the resource limit tests,
are particularly slow because they don't skip the I/O even when testing
error handling.  This makes them a good target for optimizations.

The resource limit tests query the values for different resources from
the same default container without changing its state.  Therefore, a lot
of disk I/O can be avoided by creating the default container only once
for all the tests.

This can save even 30 minutes.