### PR TITLE
pkg/nvidia: Clean up NVIDIA Management Library when no longer in use

### DIFF
--- a/src/pkg/nvidia/nvidia.go
+++ b/src/pkg/nvidia/nvidia.go
@@ -74,6 +74,13 @@ func GenerateCDISpec() (*specs.Spec, error) {
 				return nil, errors.New("failed to initialize NVIDIA Management Library")
 			}
 		}
+
+		defer func() {
+			if err := nvmLib.Shutdown(); err != nvml.SUCCESS {
+				logrus.Debugf("Generating Container Device Interface for NVIDIA: failed to shutdown NVML: %s",
+					err)
+			}
+		}()
 	} else {
 		logrus.Debugf("Generating Container Device Interface for NVIDIA: Management Library not found: %s",
 			reason)


### PR DESCRIPTION
The NVIDIA Management Library API expects nvmlShutdown() to be called once it's no longer in use [1].

Fallout from 8dd2f8e80aad1b76659b44f20c346f75e647d65d

[1] https://docs.nvidia.com/deploy/nvml-api/group__nvmlInitializationAndCleanup.html