### PR TITLE
[WIP] build: Exclude the meson.build files when installing the system tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -98,10 +98,8 @@ install_subdir(
     'system/libs/bats-support/package.json'
     ],
   exclude_directories: [
-    'system/libs/bats-assert/.git',
     'system/libs/bats-assert/script',
     'system/libs/bats-assert/test',
-    'system/libs/bats-support/.git',
     'system/libs/bats-support/script',
     'system/libs/bats-support/test'
   ]

--- a/meson.build
+++ b/meson.build
@@ -88,6 +88,7 @@ install_subdir(
   'test',
   install_dir: get_option('datadir') / meson.project_name(),
   exclude_files: [
+    'meson.build',
     'system/libs/bats-assert/.git',
     'system/libs/bats-assert/.gitignore',
     'system/libs/bats-assert/.travis.yml',
@@ -95,7 +96,8 @@ install_subdir(
     'system/libs/bats-support/.git',
     'system/libs/bats-support/.gitignore',
     'system/libs/bats-support/.travis.yml',
-    'system/libs/bats-support/package.json'
+    'system/libs/bats-support/package.json',
+    'system/meson.build',
     ],
   exclude_directories: [
     'system/libs/bats-assert/script',


### PR DESCRIPTION
... because they serve no purpose.