### PR TITLE
test/system: Unbreak the downstream Fedora CI

### DIFF
--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -25,9 +25,11 @@ setup() {
   bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_all
 }
 

--- a/test/system/501-create.bats
+++ b/test/system/501-create.bats
@@ -25,9 +25,11 @@ setup() {
   bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_all
 }
 

--- a/test/system/504-run.bats
+++ b/test/system/504-run.bats
@@ -25,9 +25,11 @@ setup() {
   bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_all
 }
 

--- a/test/system/505-enter.bats
+++ b/test/system/505-enter.bats
@@ -25,9 +25,11 @@ setup() {
   bats_require_minimum_version 1.8.0
   _setup_environment
   cleanup_all
+  pushd "$HOME" || return 1
 }
 
 teardown() {
+  popd || return 1
   cleanup_all
 }
 


### PR DESCRIPTION
The working directory from which `bats(1)` is invoked might not be part of the Toolbx container.  eg., the downstream Fedora CI invokes the tests as:
```
  $ cd /path/to/toolbox/test/system
  $ bats .
```

... and it led to:
```
  not ok 8 help: Try unknown command (forwarded to host)
  # tags: commands-options
  # (from function `assert_line' in file
      ./libs/bats-assert/src/assert.bash, line 488,
  #  in test file ./002-help.bats, line 135)
  #   `assert_line --index 0
        "Error: unknown command \"foo\" for \"toolbox\""' failed
  #
  # -- line differs --
  # index    : 0
  # expected : Error: unknown command "foo" for "toolbox"
  # actual   : Error: crun: chdir to `/usr/share/toolbox/test/system`:
      No such file or directory: OCI runtime attempted to invoke a
      command that was not found
  # --
  #
```