### PR TITLE
pkg/utils: Update fallback release to 40 for non-fedora hosts

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -64,7 +64,7 @@ const (
 	containerNamePrefixFallback = "fedora-toolbox"
 	distroFallback              = "fedora"
 	idTruncLength               = 12
-	releaseFallback             = "38"
+	releaseFallback             = "40"
 )
 
 const (


### PR DESCRIPTION
Fedora 38 reached End of Life on 21st May 2024:
https://docs.fedoraproject.org/en-US/releases/eol/

https://bugzilla.redhat.com/show_bug.cgi?id=2316312