### PR TITLE
Revert "playbooks, test/system: Work around bug in pasta(1) networks"

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -13,7 +13,6 @@
       - podman
       - shadow-utils-subid-devel
       - skopeo
-      - slirp4netns
       - systemd
       - udisks2
 
@@ -55,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck bats codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo slirp4netns
+  command: rpm -qa ShellCheck bats codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -35,7 +35,6 @@
       - podman
       - shadow-utils-subid-devel
       - skopeo
-      - slirp4netns
       - systemd
       - udisks2
     use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
@@ -56,7 +55,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck bash bats codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo slirp4netns
+  command: rpm -qa ShellCheck bash bats codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -195,7 +195,6 @@ function _setup_docker_registry() {
     --env REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt \
     --env REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
     --name "${DOCKER_REG_NAME}" \
-    --network slirp4netns \
     --privileged \
     --publish 50000:5000 \
     --rm \


### PR DESCRIPTION
The bug in pasta(1) that necessitated this workaround has since been fixed in passt 2024_05_10.7288448 [1].  Some host operating systems like CentOS Stream 10 no longer have slirp4netns(1), and it's generally better to test the defaults.

This reverts commit b58f9a51088afbfc22edb0b25776cfa2c4d8cc40.

[1] https://github.com/containers/podman/issues/22575
    https://archives.passt.top/passt-dev/20240508090338.2735208-1-sbrivio@redhat.com/
    https://archives.passt.top/passt-user/20240510225714.6aa8e6c0@elisabeth/