### PR TITLE
Replace `/usr/local/sbin/unminimize` with `unminimize` in apt

### DIFF
--- a/images/ubuntu/24.04/Containerfile
+++ b/images/ubuntu/24.04/Containerfile
@@ -21,9 +21,10 @@ RUN sed -Ei 's/^(hosts:.*)(\<files\>)\s*(.*)/\1\2 myhostname \3/' /etc/nsswitch.
 # Install ubuntu-minimal & ubuntu-standard
 # Install extra packages as well as libnss-myhostname
 COPY extra-packages /
-RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
-    apt-get update && \
-    yes | /usr/local/sbin/unminimize && \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install unminimize && \
+    sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/bin/unminimize && \
+    yes | /usr/bin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
         ubuntu-minimal ubuntu-standard \
         libnss-myhostname \


### PR DESCRIPTION
Fixes #1566

`/usr/local/sbin/unminimize` has been remove and has been replaced with `unminimize` in apt

https://github.com/docker-library/official-images/pull/17708#issuecomment-2407308768
https://discourse.ubuntu.com/t/oracular-oriole-release-notes/44878#unminimize-33