### PR TITLE
Ubuntu workflow: Disable 16.04 and 18.04 builds, do not fail early

### DIFF
--- a/.github/workflows/ubuntu-images.yaml
+++ b/.github/workflows/ubuntu-images.yaml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         release: ['16.04', '18.04', '20.04', '22.04', '24.04', '24.10']
+      fail-fast: false
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ubuntu-images.yaml
+++ b/.github/workflows/ubuntu-images.yaml
@@ -36,7 +36,7 @@ jobs:
   build-push-images:
     strategy:
       matrix:
-        release: ['16.04', '18.04', '20.04', '22.04', '24.04', '24.10']
+        release: ['20.04', '22.04', '24.04', '24.10']
       fail-fast: false
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
16.04 and 18.04 are not updated anymore (2 years and over 1 year respectively) so there is no point in rebuilding them all the time. Keep image recipes.

With changes by @tom-reinders from #1567 to not stop the workflow early in case one of the versions fails.