### PR TITLE
pkg/nvidia: Unbreak 'enter' if proprietary driver is there but not used

### DIFF
--- a/src/pkg/nvidia/nvidia.go
+++ b/src/pkg/nvidia/nvidia.go
@@ -68,7 +68,10 @@ func GenerateCDISpec() (*specs.Spec, error) {
 			logrus.Debugf("Generating Container Device Interface for NVIDIA: failed to initialize NVML: %s",
 				err)
 
-			if err == nvml.ERROR_LIB_RM_VERSION_MISMATCH {
+			if err == nvml.ERROR_DRIVER_NOT_LOADED {
+				logrus.Debug("Generating Container Device Interface for NVIDIA: skipping")
+				return nil, ErrPlatformUnsupported
+			} else if err == nvml.ERROR_LIB_RM_VERSION_MISMATCH {
 				return nil, ErrNVMLDriverLibraryVersionMismatch
 			} else {
 				return nil, errors.New("failed to initialize NVIDIA Management Library")


### PR DESCRIPTION
If the proprietary NVIDIA driver is installed, particularly `libnvidia-ml.so.1`, but the kernel driver is not being used, then `enter` fails with:
```
  $ toolbox enter
  Error: failed to initialize NVIDIA Management Library
```

This was tested on Fedora 39 Workstation with the proprietary NVIDIA driver from RPM Fusion, which makes it possible to easily disable the driver without uninstalling it [1].

Note that, with and without this change, there's a delay of a few seconds inside `nvmlInit()` from the NVIDIA Management Library.

[1] https://rpmfusion.org/Howto/NVIDIA

https://github.com/containers/toolbox/issues/1573