### PR TITLE
initContainer: also create mount points for sockets

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -786,7 +786,7 @@ func mountBind(containerPath, source, flags string) error {
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", containerPath, err)
 		}
-	} else if fileMode.IsRegular() {
+	} else if fileMode.IsRegular() || fileMode&os.ModeSocket != 0 {
 		logrus.Debugf("Creating regular file %s", containerPath)
 
 		containerPathDir := filepath.Dir(containerPath)


### PR DESCRIPTION
When a socket is bind-mounted to the container, also create a file mount point for it. Nvidia CDI on the proprietary driver added a socket for `nvidia-persistence.service` which was failing to be mounted in the container as no mount point existed.

More logs in the issue below.
Fixes https://github.com/containers/toolbox/issues/1572