### PR TITLE
cmd/initContainer: Unbreak 'enter' if NVIDIA Persistence Daemon is used

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -786,7 +786,7 @@ func mountBind(containerPath, source, flags string) error {
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", containerPath, err)
 		}
-	} else if fileMode.IsRegular() {
+	} else if fileMode.IsRegular() || fileMode&os.ModeSocket != 0 {
 		logrus.Debugf("Creating regular file %s", containerPath)
 
 		containerPathDir := filepath.Dir(containerPath)


### PR DESCRIPTION
If the NVIDIA Persistence Daemon is used, then `enter` fails with:
```
  $ sudo systemctl start nvidia-persistenced.service
  $ toolbox enter
  Error: mount: /run/nvidia-persistenced/socket: mount point does not exist.
         dmesg(1) may have more information after failed mount system call.
  failed to apply mount from Container Device Interface for NVIDIA
```

This is due to the socket at `/run/nvidia-persistenced/socket` being listed in the Container Device Interface specification when the NVIDIA Persistence Daemon is used.

Fallout from 6e848b250b4cde98fb9a40b17421f1f54eacd8f3

https://github.com/containers/toolbox/issues/1572