### PR TITLE
playbooks: Restore the generation & installation of the Bash completions

### DIFF
--- a/playbooks/dependencies-centos-9-stream.yaml
+++ b/playbooks/dependencies-centos-9-stream.yaml
@@ -2,7 +2,6 @@
   become: yes
   package:
     name:
-      - bash-completion
       - flatpak-session-helper
       - gcc
       - golang
@@ -10,6 +9,7 @@
       - meson
       - ninja-build
       - openssl
+      - pkgconfig(bash-completion)
       - podman
       - shadow-utils-subid-devel
       - skopeo
@@ -54,7 +54,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck bash bats codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck bash bash-completion bats codespell *kernel* gcc *glibc* golang golang-github-cpuguy83-md2man shadow-utils-subid-devel podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version

--- a/playbooks/dependencies-fedora-restricted.yaml
+++ b/playbooks/dependencies-fedora-restricted.yaml
@@ -31,7 +31,6 @@
   package:
     name:
       - ShellCheck
-      - bash-completion
       - codespell
       - fish
       - flatpak-session-helper
@@ -40,6 +39,7 @@
       - golang-github-cpuguy83-md2man
       - meson
       - ninja-build
+      - pkgconfig(bash-completion)
       - shadow-utils-subid-devel
       - systemd
       - udisks2
@@ -81,4 +81,4 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man flatpak-session-helper
+  command: rpm -qa ShellCheck bash-completion codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man flatpak-session-helper

--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -20,7 +20,6 @@
     update_cache: "{{ true if zuul.attempts > 1 else false }}"
     name:
       - ShellCheck
-      - bash-completion
       - bats
       - codespell
       - fish
@@ -32,6 +31,7 @@
       - meson
       - ninja-build
       - openssl
+      - pkgconfig(bash-completion)
       - podman
       - shadow-utils-subid-devel
       - skopeo
@@ -55,7 +55,7 @@
     chdir: '{{ zuul.project.src_dir }}'
 
 - name: Check versions of crucial packages
-  command: rpm -qa ShellCheck bash bats codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
+  command: rpm -qa ShellCheck bash bash-completion bats codespell *kernel* gcc *glibc* shadow-utils-subid-devel golang golang-github-cpuguy83-md2man podman conmon containernetworking-plugins containers-common container-selinux crun fuse-overlayfs flatpak-session-helper skopeo
 
 - name: Show podman versions
   command: podman version


### PR DESCRIPTION
The package providing `/usr/share/pkgconfig/bash-completion.pc` changed
from `bash-completion` to `bash-completion-devel` in Fedora 41 onwards [1].
This meant that the Bash completions were no longer being generated and
installed by the CI.

[1] Fedora bash-completion commit d1f5dc48c0440cc6
    https://src.fedoraproject.org/rpms/bash-completion/c/d1f5dc48c0440cc6
    https://bugzilla.redhat.com/show_bug.cgi?id=1457164