### PR TITLE
test/system: Fix issue with python resolver IP type

### DIFF
--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -24,9 +24,8 @@ load 'libs/helpers'
 readonly RESOLVER_PYTHON3='\
 import socket; \
 import sys; \
-family = socket.AddressFamily.AF_INET if sys.argv[1] == "A" else 0; \
-family = socket.AddressFamily.AF_INET6 if sys.argv[1] == "AAAA" else 0; \
-addr = socket.getaddrinfo(sys.argv[2], None, family, socket.SocketKind.SOCK_RAW)[0][4][0]; \
+family = {"A": socket.AddressFamily.AF_INET, "AAAA": socket.AddressFamily.AF_INET6}; \
+addr = socket.getaddrinfo(sys.argv[2], None, family[sys.argv[1]], socket.SocketKind.SOCK_RAW)[0][4][0]; \
 print(addr)'
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
The existing code would never properly select the IPv4 address instead a fallback value was selected when the IPv4 option was used, the script is updated to that both IPv4 and IPv6 will be properly selected.