### PR TITLE
Show the size in list like podman does it

### DIFF
--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -192,17 +192,18 @@ func getImages(fillNameWithID bool) ([]podman.Image, error) {
 func listOutput(images []podman.Image, containers []podman.Container) {
 	if len(images) != 0 {
 		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-		fmt.Fprintf(writer, "%s\t%s\t%s\n", "IMAGE ID", "IMAGE NAME", "CREATED")
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n", "IMAGE ID", "IMAGE NAME", "CREATED", "SIZE")
 
 		for _, image := range images {
 			if len(image.Names) != 1 {
 				panic("cannot list unflattened Image")
 			}
 
-			fmt.Fprintf(writer, "%s\t%s\t%s\n",
+			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\n",
 				utils.ShortID(image.ID),
 				image.Names[0],
-				image.Created)
+				image.Created,
+				image.Size)
 		}
 
 		writer.Flush()

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -34,6 +34,7 @@ import (
 
 type Image struct {
 	Created string
+	Size    string
 	ID      string
 	Labels  map[string]string
 	Names   []string
@@ -84,6 +85,7 @@ func (image *Image) FlattenNames(fillNameWithID bool) []Image {
 func (image *Image) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		Created interface{}
+		Size    float64
 		ID      string
 		Labels  map[string]string
 		Names   []string
@@ -102,6 +104,7 @@ func (image *Image) UnmarshalJSON(data []byte) error {
 	case float64:
 		image.Created = utils.HumanDuration(int64(value))
 	}
+	image.Size = utils.HumanSize(int64(raw.Size))
 
 	image.ID = raw.ID
 	image.Labels = raw.Labels

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/acobaugh/osrelease"
@@ -586,6 +587,15 @@ func GetSupportedDistros() []string {
 // Examples: "5 minutes ago", "2 hours ago", "3 days ago"
 func HumanDuration(duration int64) string {
 	return units.HumanDuration(time.Since(time.Unix(duration, 0))) + " ago"
+}
+
+// HumanSize accepts a bytes value and converts it into a human readable string.
+//
+// Examples: "500 MB", "1.23 GB"
+func HumanSize(size int64) string {
+	s := units.HumanSizeWithPrecision(float64(size), 3)
+	j := strings.LastIndexFunc(s, unicode.IsNumber)
+	return s[:j+1] + " " + s[j+1:]
 }
 
 // ImageReferenceCanBeID checks if 'image' might be the ID of an image


### PR DESCRIPTION

Make the output more similar to `podman images`

It still uses 1000-based units, so no mebibytes here.