### PR TITLE
pkg/utils: Optimize getting the runtime directory

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2024 Red Hat Inc.
+ * Copyright © 2019 – 2025 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,8 @@ var (
 	}
 
 	releaseDefault string
+
+	runtimeDirectories map[string]string
 
 	supportedDistros = map[string]Distro{
 		"arch": {
@@ -536,6 +538,14 @@ func GetMountOptions(target string) (string, error) {
 }
 
 func GetRuntimeDirectory(targetUser *user.User) (string, error) {
+	if runtimeDirectories == nil {
+		runtimeDirectories = make(map[string]string)
+	}
+
+	if toolboxRuntimeDirectory, ok := runtimeDirectories[targetUser.Uid]; ok {
+		return toolboxRuntimeDirectory, nil
+	}
+
 	gid, err := strconv.Atoi(targetUser.Gid)
 	if err != nil {
 		return "", fmt.Errorf("failed to convert group ID to integer: %w", err)
@@ -568,6 +578,7 @@ func GetRuntimeDirectory(targetUser *user.User) (string, error) {
 		return "", wrappedErr
 	}
 
+	runtimeDirectories[targetUser.Uid] = toolboxRuntimeDirectory
 	return toolboxRuntimeDirectory, nil
 }
 


### PR DESCRIPTION
The runtime directory is needed a few times during the course of commonly used Toolbx commands.  It's used at start-up for all commands except `completion` and `init-container` to synchronize the invocation of `podman system migrate`.  The entry point (ie., `init-container`) uses it to read the generated Container Device Interface specification and create the initialization stamp file.  The `enter` and `run` commands use it to write the CDI specification and twice to detect the creation of the initialization stamp file.

Since the runtime directory is always the same within a process, there's no need to repeatedly go through all the steps of parsing the user and group IDs, creating the directory, setting its ownership, and logging the name of directory.  Once the directory is successfully created, it's path can be cached and returned for subsequent use.

In case an error occurred while setting up the runtime directory, subsequent attempts to get it will go through all the steps again.  This doesn't matter much in practice because `toolbox(1)` can't continue in the absence of a working runtime directory.