### PR TITLE
build: Bump github.com/NVIDIA/nvidia-container-toolkit to 1.17.4

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/HarryMichal/go-version v1.0.1
 	github.com/NVIDIA/go-nvlib v0.7.1
 	github.com/NVIDIA/go-nvml v0.12.4-1
-	github.com/NVIDIA/nvidia-container-toolkit v1.17.3
+	github.com/NVIDIA/nvidia-container-toolkit v1.17.4
 	github.com/acobaugh/osrelease v0.1.0
 	github.com/briandowns/spinner v1.23.2
 	github.com/docker/go-units v0.5.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -58,8 +58,8 @@ github.com/NVIDIA/go-nvlib v0.7.1 h1:7HHPZxoCjSLm1NgaRRjuhI8ffMCpc5Vgpg5yxQYUff8
 github.com/NVIDIA/go-nvlib v0.7.1/go.mod h1:2Kh2kYSP5IJ8EKf0/SYDzHiQKb9EJkwOf2LQzu6pXzY=
 github.com/NVIDIA/go-nvml v0.12.4-1 h1:WKUvqshhWSNTfm47ETRhv0A0zJyr1ncCuHiXwoTrBEc=
 github.com/NVIDIA/go-nvml v0.12.4-1/go.mod h1:8Llmj+1Rr+9VGGwZuRer5N/aCjxGuR5nPb/9ebBiIEQ=
-github.com/NVIDIA/nvidia-container-toolkit v1.17.3 h1:vCJ9IY/YNcwNiMv7anAWEmUW8Xocqdmv73V98MXTrxo=
-github.com/NVIDIA/nvidia-container-toolkit v1.17.3/go.mod h1:R6bNf6ca0IjjACa0ncKGvsrx6zSjsgz8QkFyBDk5szU=
+github.com/NVIDIA/nvidia-container-toolkit v1.17.4 h1:6S67r55wiPJm3GrfsSNJt0+qIbj1/X2OEgVoU05JrM0=
+github.com/NVIDIA/nvidia-container-toolkit v1.17.4/go.mod h1:noSlm+fO6wugg5Ku8tAdfFJeBf46ViCBpiH89ADispY=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/acobaugh/osrelease v0.1.0 h1:Yb59HQDGGNhCj4suHaFQQfBps5wyoKLSSX/J/+UifRE=
 github.com/acobaugh/osrelease v0.1.0/go.mod h1:4bFEs0MtgHNHBrmHCt67gNisnabCRAlzdVasCEGHTWY=


### PR DESCRIPTION
... for CVE-2025-23359 or GHSA-4hmh-pm5p-9j7j.

The `src/go.sum` file was updated with `go mod tidy`.