### PR TITLE
cmd: Simplify string building

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -552,7 +552,7 @@ func configureKerberos() error {
 	}
 
 	kcmConfigString := `# Written by Toolbx
-# https://github.com/containers/toolbox
+# https://containertoolbx.org/
 #
 # # To disable the KCM credential cache, comment out the following lines.
 
@@ -577,7 +577,7 @@ func configureRPM() error {
 
 	var builder strings.Builder
 	builder.WriteString("# Written by Toolbx\n")
-	builder.WriteString("# https://github.com/containers/toolbox\n")
+	builder.WriteString("# https://containertoolbx.org/\n")
 	builder.WriteString("\n")
 	builder.WriteString("%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt\n")
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -179,10 +179,10 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 	if toolbxFailEntryPoint, ok := getFailEntryPoint(); ok {
 		var builder strings.Builder
-		fmt.Fprintf(&builder, "TOOLBX_FAIL_ENTRY_POINT is set")
+		builder.WriteString("TOOLBX_FAIL_ENTRY_POINT is set")
 		if toolbxFailEntryPoint > 1 {
-			fmt.Fprintf(&builder, "\n")
-			fmt.Fprintf(&builder, "This environment variable should only be set when testing.")
+			builder.WriteString("\n")
+			builder.WriteString("This environment variable should only be set when testing.")
 		}
 
 		errMsg := builder.String()
@@ -576,11 +576,10 @@ func configureRPM() error {
 	logrus.Debug("Configuring RPM to ignore bind mounts")
 
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "# Written by Toolbx\n")
-	fmt.Fprintf(&builder, "# https://github.com/containers/toolbox\n")
-	fmt.Fprintf(&builder, "\n")
-	fmt.Fprintf(&builder,
-		"%%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt\n")
+	builder.WriteString("# Written by Toolbx\n")
+	builder.WriteString("# https://github.com/containers/toolbox\n")
+	builder.WriteString("\n")
+	builder.WriteString("%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt\n")
 
 	rpmConfigString := builder.String()
 	rpmConfigBytes := []byte(rpmConfigString)

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -1,5 +1,5 @@
 //
-// Copyright © 2021 – 2024 Red Hat Inc.
+// Copyright © 2021 – 2025 Red Hat Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 
@@ -32,9 +31,9 @@ import (
 func preRunIsCoreOSBug() error {
 	if containerType := os.Getenv("container"); containerType == "" {
 		var builder strings.Builder
-		fmt.Fprintf(&builder, "/run/.containerenv found on what looks like the host\n")
-		fmt.Fprintf(&builder, "If this is the host, then remove /run/.containerenv and try again.\n")
-		fmt.Fprintf(&builder, "Otherwise, contact your system administrator or file a bug.")
+		builder.WriteString("/run/.containerenv found on what looks like the host\n")
+		builder.WriteString("If this is the host, then remove /run/.containerenv and try again.\n")
+		builder.WriteString("Otherwise, contact your system administrator or file a bug.")
 
 		errMsg := builder.String()
 		return errors.New(errMsg)

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019 – 2024 Red Hat Inc.
+ * Copyright © 2019 – 2025 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -271,8 +271,8 @@ func runCommand(container string,
 	if err != nil {
 		if errors.Is(err, nvidia.ErrNVMLDriverLibraryVersionMismatch) {
 			var builder strings.Builder
-			fmt.Fprintf(&builder, "the proprietary NVIDIA driver's kernel and user space don't match\n")
-			fmt.Fprintf(&builder, "Check the host operating system and systemd journal.")
+			builder.WriteString("the proprietary NVIDIA driver's kernel and user space don't match\n")
+			builder.WriteString("Check the host operating system and systemd journal.")
 
 			errMsg := builder.String()
 			return errors.New(errMsg)

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -475,7 +475,7 @@ func showManual(manual string) error {
 			fmt.Printf("%s", usage)
 
 			fmt.Printf("\n")
-			fmt.Printf("Go to https://github.com/containers/toolbox for further information.\n")
+			fmt.Printf("Go to https://containertoolbx.org/ for further information.\n")
 			return nil
 		}
 

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 – 2024 Red Hat Inc.
+ * Copyright © 2020 – 2025 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -343,9 +343,9 @@ func getCDIFileForNvidia(targetUser *user.User) (string, error) {
 
 func getUsageForCommonCommands() string {
 	var builder strings.Builder
-	fmt.Fprintf(&builder, "create    Create a new Toolbx container\n")
-	fmt.Fprintf(&builder, "enter     Enter an existing Toolbx container\n")
-	fmt.Fprintf(&builder, "list      List all existing Toolbx containers and images\n")
+	builder.WriteString("create    Create a new Toolbx container\n")
+	builder.WriteString("enter     Enter an existing Toolbx container\n")
+	builder.WriteString("list      List all existing Toolbx containers and images\n")
 
 	usage := builder.String()
 	return usage

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2020 – 2024 Red Hat, Inc.
+# Copyright © 2020 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ teardown() {
   assert_line --index 3 "create    Create a new Toolbx container"
   assert_line --index 4 "enter     Enter an existing Toolbx container"
   assert_line --index 5 "list      List all existing Toolbx containers and images"
-  assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
+  assert_line --index 7 "Go to https://containertoolbx.org/ for further information."
   assert [ ${#lines[@]} -eq 8 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
@@ -108,7 +108,7 @@ teardown() {
   assert_line --index 3 "create    Create a new Toolbx container"
   assert_line --index 4 "enter     Enter an existing Toolbx container"
   assert_line --index 5 "list      List all existing Toolbx containers and images"
-  assert_line --index 7 "Go to https://github.com/containers/toolbox for further information."
+  assert_line --index 7 "Go to https://containertoolbx.org/ for further information."
   assert [ ${#lines[@]} -eq 8 ]
 
   # shellcheck disable=SC2154

--- a/test/system/250-kerberos.bats
+++ b/test/system/250-kerberos.bats
@@ -64,7 +64,7 @@ teardown() {
 
     assert_success
     assert_line --index 0 "# Written by Toolbx"
-    assert_line --index 1 "# https://github.com/containers/toolbox"
+    assert_line --index 1 "# https://containertoolbx.org/"
     assert_line --index 2 "#"
     assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
     assert_line --index 4 ""
@@ -112,7 +112,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "# Written by Toolbx"
-  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 "#"
   assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
   assert_line --index 4 ""
@@ -145,7 +145,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "# Written by Toolbx"
-  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 "#"
   assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
   assert_line --index 4 ""

--- a/test/system/270-rpm.bats
+++ b/test/system/270-rpm.bats
@@ -57,7 +57,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "# Written by Toolbx"
-  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 ""
   assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
   assert [ ${#lines[@]} -eq 4 ]
@@ -91,7 +91,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "# Written by Toolbx"
-  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 ""
   assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
   assert [ ${#lines[@]} -eq 4 ]
@@ -128,7 +128,7 @@ teardown() {
 
   assert_success
   assert_line --index 0 "# Written by Toolbx"
-  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 1 "# https://containertoolbx.org/"
   assert_line --index 2 ""
   assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
   assert [ ${#lines[@]} -eq 4 ]


### PR DESCRIPTION
When the `fmt.Fprintf()` [1] function is used to write to a
`strings.Builder` [2] instance, it uses the `io.Writer` [3] interface, which
is the `strings.Builder.Write()` method.  This method is practically the
same as the `strings.Builder.WriteString()` method, other than the fact
that the former accepts a slice of bytes and the latter accepts a
string.  So, the difference is the initial call to `fmt.Fprintf()`.

Therefore, unless format verbs [4] are needed to build the string,
`fmt.Fprintf()` can be replaced with `strings.Builder.WriteString()`.  It
reduces one function call and is shorter to type.

Fallout from the following:
  * e390f15469959a4b7458fd37069f4a2c8e0b9a4c
  * 7542f5fc867b57bf3dc67bbae02cc09ccc0b5df2
  * e58992066f6a576b943987789b84a01894ef6193
  * 8dd2f8e80aad1b76659b44f20c346f75e647d65d
  * 063bdf965fe42468b6b69a333b28b475fa05436f

[1] https://pkg.go.dev/fmt#Fprintf

[2] https://pkg.go.dev/strings#Builder

[3] https://pkg.go.dev/io#Writer

[4] https://pkg.go.dev/fmt