### PR TITLE
cmd, pkg/utils: Split out the code to get the initialization stamp path

### DIFF
--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -161,6 +161,7 @@ jobs:
             test/system/201-ipc.bats \
             test/system/203-network.bats \
             test/system/220-environment-variables.bats \
+            test/system/270-rpm.bats \
             test/system/501-create.bats \
             test/system/505-enter.bats
         env:

--- a/.github/workflows/ubuntu-tests.yaml
+++ b/.github/workflows/ubuntu-tests.yaml
@@ -161,6 +161,7 @@ jobs:
             test/system/201-ipc.bats \
             test/system/203-network.bats \
             test/system/220-environment-variables.bats \
+            test/system/250-kerberos.bats \
             test/system/270-rpm.bats \
             test/system/501-create.bats \
             test/system/505-enter.bats

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -538,15 +538,20 @@ func applyCDISpecForNvidiaHookUpdateLDCache(hookArgs []string) error {
 }
 
 func configureKerberos() error {
-	if !utils.PathExists("/etc/krb5.conf.d") {
+	const logPrefix = "Configuring Kerberos to use KCM as the default credential cache"
+	logrus.Debugf("%s", logPrefix)
+
+	if path := "/etc/krb5.conf.d"; !utils.PathExists(path) {
+		logrus.Debugf("%s: directory %s not found", logPrefix, path)
+		logrus.Debugf("%s: skipping", logPrefix)
 		return nil
 	}
 
-	if utils.PathExists("/etc/krb5.conf.d/kcm_default_ccache") {
+	if path := "/etc/krb5.conf.d/kcm_default_ccache"; utils.PathExists(path) {
+		logrus.Debugf("%s: file %s already exists", logPrefix, path)
+		logrus.Debugf("%s: skipping", logPrefix)
 		return nil
 	}
-
-	logrus.Debug("Configuring Kerberos to use KCM as the default credential cache")
 
 	kcmConfigString := `# Written by Toolbx
 # https://github.com/containers/toolbox

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -342,13 +342,11 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 	logrus.Debug("Finished initializing container")
 
-	toolboxRuntimeDirectory, err := utils.GetRuntimeDirectory(targetUser)
+	pid := os.Getpid()
+	initializedStamp, err := utils.GetInitializedStamp(pid, targetUser)
 	if err != nil {
 		return err
 	}
-
-	pid := os.Getpid()
-	initializedStamp := fmt.Sprintf("%s/container-initialized-%d", toolboxRuntimeDirectory, pid)
 
 	logrus.Debugf("Creating initialization stamp %s", initializedStamp)
 

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -503,6 +503,17 @@ func getHostVersionID() (string, error) {
 	return osRelease["VERSION_ID"], nil
 }
 
+func GetInitializedStamp(entryPointPID int, targetUser *user.User) (string, error) {
+	toolbxRuntimeDirectory, err := GetRuntimeDirectory(targetUser)
+	if err != nil {
+		return "", err
+	}
+
+	initializedStampBase := fmt.Sprintf("container-initialized-%d", entryPointPID)
+	initializedStamp := filepath.Join(toolbxRuntimeDirectory, initializedStampBase)
+	return initializedStamp, nil
+}
+
 // GetMountPoint returns the mount point of a target.
 func GetMountPoint(target string) (string, error) {
 	var stdout strings.Builder

--- a/test/system/250-kerberos.bats
+++ b/test/system/250-kerberos.bats
@@ -1,0 +1,228 @@
+# shellcheck shell=bats
+#
+# Copyright © 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# bats file_tags=runtime-environment
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'libs/helpers'
+
+setup() {
+  bats_require_minimum_version 1.10.0
+  _setup_environment
+  cleanup_all
+  pushd "$HOME" || return 1
+}
+
+teardown() {
+  popd || return 1
+  cleanup_all
+}
+
+# bats test_tags=arch-fedora
+@test "kerberos: Smoke test" {
+  local kerberos_skip=false
+
+  local system_id
+  system_id="$(get_system_id)"
+
+  if [ "$system_id" != "fedora" ]; then
+    kerberos_skip=true
+  fi
+
+  create_default_container
+
+  if $kerberos_skip; then
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /etc/krb5.conf.d
+
+    assert_failure
+    assert [ ${#lines[@]} -eq 0 ]
+    # shellcheck disable=SC2154
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run test -e /etc/krb5.conf.d/kcm_default_ccache
+
+    assert_failure
+    assert [ ${#lines[@]} -eq 0 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  else
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /etc/krb5.conf.d/kcm_default_ccache
+
+    assert_success
+    assert_line --index 0 "# Written by Toolbx"
+    assert_line --index 1 "# https://github.com/containers/toolbox"
+    assert_line --index 2 "#"
+    assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
+    assert_line --index 4 ""
+    assert_line --index 5 "[libdefaults]"
+    assert_line --index 6 "    default_ccache_name = KCM:"
+    assert [ ${#lines[@]} -eq 7 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+
+    run --keep-empty-lines --separate-stderr "$TOOLBX" run stat \
+                                                             --format "%A %U:%G" \
+                                                             /etc/krb5.conf.d/kcm_default_ccache
+
+    assert_success
+    assert_line --index 0 "-rw-r--r-- root:root"
+    assert [ ${#lines[@]} -eq 1 ]
+    assert [ ${#stderr_lines[@]} -eq 0 ]
+  fi
+}
+
+# bats test_tags=arch-fedora
+@test "kerberos: Smoke test with Arch Linux" {
+  create_distro_container arch latest arch-toolbox-latest
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch test -e /etc/krb5.conf.d
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch test -e /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=arch-fedora
+@test "kerberos: Smoke test with Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro fedora \
+    --release 34 \
+    cat /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_success
+  assert_line --index 0 "# Written by Toolbx"
+  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 2 "#"
+  assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
+  assert_line --index 4 ""
+  assert_line --index 5 "[libdefaults]"
+  assert_line --index 6 "    default_ccache_name = KCM:"
+  assert [ ${#lines[@]} -eq 7 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro fedora \
+    --release 34 \
+    stat \
+      --format "%A %U:%G" \
+      /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_success
+  assert_line --index 0 "-rw-r--r-- root:root"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=arch-fedora
+@test "kerberos: Smoke test with RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro rhel \
+    --release 8.10 \
+    cat /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_success
+  assert_line --index 0 "# Written by Toolbx"
+  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 2 "#"
+  assert_line --index 3 "# # To disable the KCM credential cache, comment out the following lines."
+  assert_line --index 4 ""
+  assert_line --index 5 "[libdefaults]"
+  assert_line --index 6 "    default_ccache_name = KCM:"
+  assert [ ${#lines[@]} -eq 7 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro rhel \
+    --release 8.10 \
+    stat \
+      --format "%A %U:%G" \
+      /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_success
+  assert_line --index 0 "-rw-r--r-- root:root"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=ubuntu
+@test "kerberos: Smoke test with Ubuntu 16.04" {
+  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 test -e /etc/krb5.conf.d
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 16.04 \
+    test -e /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=ubuntu
+@test "kerberos: Smoke test with Ubuntu 18.04" {
+  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 test -e /etc/krb5.conf.d
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 18.04 \
+    test -e /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=ubuntu
+@test "kerberos: Smoke test with Ubuntu 20.04" {
+  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 test -e /etc/krb5.conf.d
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro ubuntu \
+    --release 20.04 \
+    test -e /etc/krb5.conf.d/kcm_default_ccache
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/270-rpm.bats
+++ b/test/system/270-rpm.bats
@@ -1,0 +1,148 @@
+# shellcheck shell=bats
+#
+# Copyright © 2025 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# bats file_tags=runtime-environment
+
+load 'libs/bats-support/load'
+load 'libs/bats-assert/load'
+load 'libs/helpers'
+
+setup() {
+  bats_require_minimum_version 1.10.0
+  _setup_environment
+  cleanup_all
+  pushd "$HOME" || return 1
+}
+
+teardown() {
+  popd || return 1
+  cleanup_all
+}
+
+# bats test_tags=arch-fedora
+@test "rpm: %_netsharedpath inside the default container" {
+  local system_id
+  system_id="$(get_system_id)"
+
+  if [ "$system_id" != "fedora" ]; then
+    skip "doesn't use RPM"
+  fi
+
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run rpm --eval %_netsharedpath
+
+  assert_success
+  assert_line --index 0 "/dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  # shellcheck disable=SC2154
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "# Written by Toolbx"
+  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 2 ""
+  assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 4 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run stat \
+                                                           --format "%A %U:%G" \
+                                                           /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "-rw-r--r-- root:root"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=arch-fedora
+@test "rpm: %_netsharedpath inside Fedora 34" {
+  create_distro_container fedora 34 fedora-toolbox-34
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 rpm --eval %_netsharedpath
+
+  assert_success
+  assert_line --index 0 "/dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro fedora \
+    --release 34 \
+    cat /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "# Written by Toolbx"
+  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 2 ""
+  assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 4 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro fedora \
+    --release 34 \
+    stat \
+      --format "%A %U:%G" \
+      /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "-rw-r--r-- root:root"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+# bats test_tags=arch-fedora
+@test "rpm: %_netsharedpath inside RHEL 8.10" {
+  create_distro_container rhel 8.10 rhel-toolbox-8.10
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 rpm --eval %_netsharedpath
+
+  assert_success
+  assert_line --index 0 "/dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro rhel \
+    --release 8.10 \
+    cat /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "# Written by Toolbx"
+  assert_line --index 1 "# https://github.com/containers/toolbox"
+  assert_line --index 2 ""
+  assert_line --index 3 "%_netsharedpath /dev:/media:/mnt:/proc:/sys:/tmp:/var/lib/flatpak:/var/lib/libvirt"
+  assert [ ${#lines[@]} -eq 4 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run \
+    --distro rhel \
+    --release 8.10 \
+    stat \
+      --format "%A %U:%G" \
+      /usr/lib/rpm/macros.d/macros.toolbox
+
+  assert_success
+  assert_line --index 0 "-rw-r--r-- root:root"
+  assert [ ${#lines[@]} -eq 1 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}

--- a/test/system/meson.build
+++ b/test/system/meson.build
@@ -16,6 +16,7 @@ test_system = files(
   '211-dbus.bats',
   '220-environment-variables.bats',
   '230-cdi.bats',
+  '250-kerberos.bats',
   '270-rpm.bats',
   '501-create.bats',
   '504-run.bats',

--- a/test/system/meson.build
+++ b/test/system/meson.build
@@ -16,6 +16,7 @@ test_system = files(
   '211-dbus.bats',
   '220-environment-variables.bats',
   '230-cdi.bats',
+  '270-rpm.bats',
   '501-create.bats',
   '504-run.bats',
   '505-enter.bats',


### PR DESCRIPTION
This will prevent any silly bug in getting the initialization stamp path
from breaking the communication protocol between the `enter` or `run`
commands on the host and the Toolbx container's entry point process.