### PR TITLE
test/system: Optimize the help, group and user tests

### DIFF
--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -21,14 +21,15 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
-setup() {
+setup_file() {
   bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
+  create_default_container
 }
 
-teardown() {
+teardown_file() {
   popd || return 1
   cleanup_all
 }
@@ -127,8 +128,6 @@ teardown() {
 }
 
 @test "help: Try unknown command (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox foo
 
   assert_failure
@@ -151,8 +150,6 @@ teardown() {
 }
 
 @test "help: Try unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox --foo
 
   assert_failure
@@ -175,8 +172,6 @@ teardown() {
 }
 
 @test "help: Try 'create' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox create --foo
 
   assert_failure
@@ -199,8 +194,6 @@ teardown() {
 }
 
 @test "help: Try 'enter' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox enter --foo
 
   assert_failure
@@ -223,8 +216,6 @@ teardown() {
 }
 
 @test "help: Try 'help' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox help --foo
 
   assert_failure
@@ -247,8 +238,6 @@ teardown() {
 }
 
 @test "help: Try 'init-container' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox init-container --foo
 
   assert_failure
@@ -271,8 +260,6 @@ teardown() {
 }
 
 @test "help: Try 'list' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox list --foo
 
   assert_failure
@@ -295,8 +282,6 @@ teardown() {
 }
 
 @test "help: Try 'rm' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox rm --foo
 
   assert_failure
@@ -319,8 +304,6 @@ teardown() {
 }
 
 @test "help: Try 'rmi' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox rmi --foo
 
   assert_failure
@@ -343,8 +326,6 @@ teardown() {
 }
 
 @test "help: Try 'run' with unknown flag (forwarded to host)" {
-  create_default_container
-
   run -1 --keep-empty-lines --separate-stderr "$TOOLBX" run toolbox run --foo
 
   assert_failure

--- a/test/system/206-user.bats
+++ b/test/system/206-user.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 – 2024 Red Hat, Inc.
+# Copyright © 2023 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,14 +21,30 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
-setup() {
+setup_file() {
   bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "arch" >/dev/null 2>/dev/null; then
+    create_distro_container arch latest arch-toolbox-latest
+  fi
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "fedora" >/dev/null 2>/dev/null; then
+    create_default_container
+    create_distro_container fedora 34 fedora-toolbox-34
+    create_distro_container rhel 8.10 rhel-toolbox-8.10
+  fi
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "ubuntu" >/dev/null 2>/dev/null; then
+    create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+    create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+    create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+  fi
 }
 
-teardown() {
+teardown_file() {
   popd || return 1
   cleanup_all
 }
@@ -37,8 +53,6 @@ teardown() {
 @test "user: Separate namespace" {
   local ns_host
   ns_host=$(readlink /proc/$$/ns/user)
-
-  create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run sh -c 'readlink /proc/$$/ns/user'
 
@@ -56,7 +70,6 @@ teardown() {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
 
-  create_default_container
   container_root_file_system="$(podman unshare podman mount "$default_container")"
 
   "$TOOLBX" run true
@@ -74,7 +87,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$(podman unshare podman mount arch-toolbox-latest)"
 
   "$TOOLBX" run --distro arch true
@@ -92,7 +104,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$(podman unshare podman mount fedora-toolbox-34)"
 
   "$TOOLBX" run --distro fedora --release 34 true
@@ -110,7 +121,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: root in shadow(5) inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
   container_root_file_system="$(podman unshare podman mount rhel-toolbox-8.10)"
 
   "$TOOLBX" run --distro rhel --release 8.10 true
@@ -128,7 +138,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-16.04)"
 
   "$TOOLBX" run --distro ubuntu --release 16.04 true
@@ -146,7 +155,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-18.04)"
 
   "$TOOLBX" run --distro ubuntu --release 18.04 true
@@ -164,7 +172,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: root in shadow(5) inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-20.04)"
 
   "$TOOLBX" run --distro ubuntu --release 20.04 true
@@ -188,8 +195,6 @@ teardown() {
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /etc/passwd
 
   assert_success
@@ -207,8 +212,6 @@ teardown() {
 
   local user_id_real
   user_id_real="$(id --real --user)"
-
-  create_distro_container arch latest arch-toolbox-latest
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch cat /etc/passwd
 
@@ -228,8 +231,6 @@ teardown() {
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_distro_container fedora 34 fedora-toolbox-34
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 cat /etc/passwd
 
   assert_success
@@ -247,8 +248,6 @@ teardown() {
 
   local user_id_real
   user_id_real="$(id --real --user)"
-
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 cat /etc/passwd
 
@@ -268,8 +267,6 @@ teardown() {
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/passwd
 
   assert_success
@@ -287,8 +284,6 @@ teardown() {
 
   local user_id_real
   user_id_real="$(id --real --user)"
-
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/passwd
 
@@ -308,8 +303,6 @@ teardown() {
   local user_id_real
   user_id_real="$(id --real --user)"
 
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/passwd
 
   assert_success
@@ -325,7 +318,6 @@ teardown() {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"
 
-  create_default_container
   container_root_file_system="$(podman unshare podman mount "$default_container")"
 
   "$TOOLBX" run true
@@ -343,7 +335,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
   container_root_file_system="$(podman unshare podman mount arch-toolbox-latest)"
 
   "$TOOLBX" run --distro arch true
@@ -361,7 +352,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
   container_root_file_system="$(podman unshare podman mount fedora-toolbox-34)"
 
   "$TOOLBX" run --distro fedora --release 34 true
@@ -379,7 +369,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in shadow(5) inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
   container_root_file_system="$(podman unshare podman mount rhel-toolbox-8.10)"
 
   "$TOOLBX" run --distro rhel --release 8.10 true
@@ -397,7 +386,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-16.04)"
 
   "$TOOLBX" run --distro ubuntu --release 16.04 true
@@ -415,7 +403,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-18.04)"
 
   "$TOOLBX" run --distro ubuntu --release 18.04 true
@@ -433,7 +420,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in shadow(5) inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
   container_root_file_system="$(podman unshare podman mount ubuntu-toolbox-20.04)"
 
   "$TOOLBX" run --distro ubuntu --release 20.04 true
@@ -451,8 +437,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside the default container" {
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run cat /etc/group
 
   assert_success
@@ -466,8 +450,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch cat /etc/group
 
   assert_success
@@ -481,8 +463,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 cat /etc/group
 
   assert_success
@@ -496,8 +476,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: $USER in group(5) inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 cat /etc/group
 
   assert_success
@@ -511,8 +489,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 cat /etc/group
 
   assert_success
@@ -526,8 +502,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 cat /etc/group
 
   assert_success
@@ -541,8 +515,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: $USER in group(5) inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 cat /etc/group
 
   assert_success
@@ -556,8 +528,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside the default container" {
-  create_default_container
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run id
 
   assert_success
@@ -580,8 +550,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch id
 
   assert_success
@@ -604,8 +572,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 id
 
   assert_success
@@ -628,8 +594,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "user: id(1) for $USER inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 id
 
   assert_success
@@ -652,8 +616,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 id
 
   assert_success
@@ -676,8 +638,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 id
 
   assert_success
@@ -700,8 +660,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "user: id(1) for $USER inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 id
 
   assert_success


### PR DESCRIPTION
The system tests can be very I/O intensive, because many of them copy
OCI images from the test suite's image cache directory to its local
container/storage store, create containers, and then delete everything
to run the next test with a clean slate.  This makes them slow.

A lot of disk I/O can be avoided by reducing the number of times this
happens.