### PR TITLE
Move the distro-specific support code into their own separate files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,4 @@
 /images/rhel       @debarshiray @olivergs
 /images/ubuntu     @Jmennius
 /src/pkg/utils/arch.go                    @Foxboron
+/src/pkg/utils/ubuntu.go                  @Jmennius

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,4 @@
 /images/arch       @Foxboron
 /images/rhel       @debarshiray @olivergs
 /images/ubuntu     @Jmennius
+/src/pkg/utils/arch.go                    @Foxboron

--- a/src/meson.build
+++ b/src/meson.build
@@ -33,6 +33,7 @@ sources = files(
   'pkg/utils/libsubid-wrappers.c',
   'pkg/utils/arch.go',
   'pkg/utils/errors.go',
+  'pkg/utils/fedora.go',
   'pkg/utils/utils.go',
   'pkg/utils/utils_cgo.go',
   'pkg/utils/utils_test.go',

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,7 @@ sources = files(
   'pkg/term/term.go',
   'pkg/term/term_test.go',
   'pkg/utils/libsubid-wrappers.c',
+  'pkg/utils/arch.go',
   'pkg/utils/errors.go',
   'pkg/utils/utils.go',
   'pkg/utils/utils_cgo.go',

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,7 @@ sources = files(
   'pkg/utils/arch.go',
   'pkg/utils/errors.go',
   'pkg/utils/fedora.go',
+  'pkg/utils/rhel.go',
   'pkg/utils/utils.go',
   'pkg/utils/utils_cgo.go',
   'pkg/utils/utils_test.go',

--- a/src/pkg/utils/arch.go
+++ b/src/pkg/utils/arch.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2023 – 2025 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+func getDefaultReleaseArch() (string, error) {
+	return "latest", nil
+}
+
+func getFullyQualifiedImageArch(image, release string) string {
+	imageFull := "quay.io/toolbx/" + image
+	return imageFull
+}
+
+func parseReleaseArch(release string) (string, error) {
+	if release != "latest" && release != "rolling" && release != "" {
+		return "", &ParseReleaseError{"The release must be 'latest'."}
+	}
+
+	return "latest", nil
+}

--- a/src/pkg/utils/fedora.go
+++ b/src/pkg/utils/fedora.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2021 – 2025 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func getDefaultReleaseFedora() (string, error) {
+	release, err := getHostVersionID()
+	if err != nil {
+		return "", err
+	}
+
+	return release, nil
+}
+
+func getFullyQualifiedImageFedora(image, release string) string {
+	imageFull := "registry.fedoraproject.org/" + image
+	return imageFull
+}
+
+func parseReleaseFedora(release string) (string, error) {
+	if strings.HasPrefix(release, "F") || strings.HasPrefix(release, "f") {
+		release = release[1:]
+	}
+
+	releaseN, err := strconv.Atoi(release)
+	if err != nil {
+		logrus.Debugf("Parsing release %s as an integer failed: %s", release, err)
+		return "", &ParseReleaseError{"The release must be a positive integer."}
+	}
+
+	if releaseN <= 0 {
+		return "", &ParseReleaseError{"The release must be a positive integer."}
+	}
+
+	return release, nil
+}

--- a/src/pkg/utils/rhel.go
+++ b/src/pkg/utils/rhel.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2021 – 2025 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+func getDefaultReleaseRHEL() (string, error) {
+	release, err := getHostVersionID()
+	if err != nil {
+		return "", err
+	}
+
+	return release, nil
+}
+
+func getFullyQualifiedImageRHEL(image, release string) string {
+	i := strings.IndexRune(release, '.')
+	if i == -1 {
+		panicMsg := fmt.Sprintf("release %s not in '<major>.<minor>' format", release)
+		panic(panicMsg)
+	}
+
+	releaseMajor := release[:i]
+	imageFull := "registry.access.redhat.com/ubi" + releaseMajor + "/" + image
+	return imageFull
+}
+
+func parseReleaseRHEL(release string) (string, error) {
+	if i := strings.IndexRune(release, '.'); i == -1 {
+		return "", &ParseReleaseError{"The release must be in the '<major>.<minor>' format."}
+	}
+
+	releaseN, err := strconv.ParseFloat(release, 32)
+	if err != nil {
+		logrus.Debugf("Parsing release %s as a float failed: %s", release, err)
+		return "", &ParseReleaseError{"The release must be in the '<major>.<minor>' format."}
+	}
+
+	if releaseN <= 0 {
+		return "", &ParseReleaseError{"The release must be a positive number."}
+	}
+
+	return release, nil
+}

--- a/src/pkg/utils/ubuntu.go
+++ b/src/pkg/utils/ubuntu.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2023 – 2025 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/sirupsen/logrus"
+)
+
+func getDefaultReleaseUbuntu() (string, error) {
+	release, err := getHostVersionID()
+	if err != nil {
+		return "", err
+	}
+
+	return release, nil
+}
+
+func getFullyQualifiedImageUbuntu(image, release string) string {
+	imageFull := "quay.io/toolbx/" + image
+	return imageFull
+}
+
+func parseReleaseUbuntu(release string) (string, error) {
+	releaseParts := strings.Split(release, ".")
+	if len(releaseParts) != 2 {
+		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
+	}
+
+	releaseYear, err := strconv.Atoi(releaseParts[0])
+	if err != nil {
+		logrus.Debugf("Parsing release year %s as an integer failed: %s", releaseParts[0], err)
+		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
+	}
+
+	if releaseYear < 4 {
+		return "", &ParseReleaseError{"The release year must be 4 or more."}
+	}
+
+	releaseYearLen := utf8.RuneCountInString(releaseParts[0])
+	if releaseYearLen > 2 {
+		return "", &ParseReleaseError{"The release year cannot have more than two digits."}
+	} else if releaseYear < 10 && releaseYearLen == 2 {
+		return "", &ParseReleaseError{"The release year cannot have a leading zero."}
+	}
+
+	releaseMonth, err := strconv.Atoi(releaseParts[1])
+	if err != nil {
+		logrus.Debugf("Parsing release month %s as an integer failed: %s", releaseParts[1], err)
+		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
+	}
+
+	if releaseMonth < 1 {
+		return "", &ParseReleaseError{"The release month must be between 01 and 12."}
+	} else if releaseMonth > 12 {
+		return "", &ParseReleaseError{"The release month must be between 01 and 12."}
+	}
+
+	releaseMonthLen := utf8.RuneCountInString(releaseParts[1])
+	if releaseMonthLen != 2 {
+		return "", &ParseReleaseError{"The release month must have two digits."}
+	}
+
+	return release, nil
+}

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"syscall"
 	"time"
-	"unicode/utf8"
 
 	"github.com/acobaugh/osrelease"
 	"github.com/containers/toolbox/pkg/shell"
@@ -328,15 +327,6 @@ func getDefaultReleaseForDistro(distro string) (string, error) {
 	return release, nil
 }
 
-func getDefaultReleaseUbuntu() (string, error) {
-	release, err := getHostVersionID()
-	if err != nil {
-		return "", err
-	}
-
-	return release, nil
-}
-
 func GetEnvOptionsForPreservedVariables() []string {
 	logrus.Debug("Creating list of environment variables to forward")
 
@@ -395,11 +385,6 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to resolve image %s", image)
-}
-
-func getFullyQualifiedImageUbuntu(image, release string) string {
-	imageFull := "quay.io/toolbx/" + image
-	return imageFull
 }
 
 // GetGroupForSudo returns the name of the sudoers group.
@@ -710,49 +695,6 @@ func parseRelease(distro, release string) (string, error) {
 	parseReleaseImpl := distroObj.ParseRelease
 	release, err := parseReleaseImpl(release)
 	return release, err
-}
-
-func parseReleaseUbuntu(release string) (string, error) {
-	releaseParts := strings.Split(release, ".")
-	if len(releaseParts) != 2 {
-		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
-	}
-
-	releaseYear, err := strconv.Atoi(releaseParts[0])
-	if err != nil {
-		logrus.Debugf("Parsing release year %s as an integer failed: %s", releaseParts[0], err)
-		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
-	}
-
-	if releaseYear < 4 {
-		return "", &ParseReleaseError{"The release year must be 4 or more."}
-	}
-
-	releaseYearLen := utf8.RuneCountInString(releaseParts[0])
-	if releaseYearLen > 2 {
-		return "", &ParseReleaseError{"The release year cannot have more than two digits."}
-	} else if releaseYear < 10 && releaseYearLen == 2 {
-		return "", &ParseReleaseError{"The release year cannot have a leading zero."}
-	}
-
-	releaseMonth, err := strconv.Atoi(releaseParts[1])
-	if err != nil {
-		logrus.Debugf("Parsing release month %s as an integer failed: %s", releaseParts[1], err)
-		return "", &ParseReleaseError{"The release must be in the 'YY.MM' format."}
-	}
-
-	if releaseMonth < 1 {
-		return "", &ParseReleaseError{"The release month must be between 01 and 12."}
-	} else if releaseMonth > 12 {
-		return "", &ParseReleaseError{"The release month must be between 01 and 12."}
-	}
-
-	releaseMonthLen := utf8.RuneCountInString(releaseParts[1])
-	if releaseMonthLen != 2 {
-		return "", &ParseReleaseError{"The release month must have two digits."}
-	}
-
-	return release, nil
 }
 
 // PathExists wraps around os.Stat providing a nice interface for checking an existence of a path.

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -328,15 +328,6 @@ func getDefaultReleaseForDistro(distro string) (string, error) {
 	return release, nil
 }
 
-func getDefaultReleaseFedora() (string, error) {
-	release, err := getHostVersionID()
-	if err != nil {
-		return "", err
-	}
-
-	return release, nil
-}
-
 func getDefaultReleaseRHEL() (string, error) {
 	release, err := getHostVersionID()
 	if err != nil {
@@ -413,11 +404,6 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to resolve image %s", image)
-}
-
-func getFullyQualifiedImageFedora(image, release string) string {
-	imageFull := "registry.fedoraproject.org/" + image
-	return imageFull
 }
 
 func getFullyQualifiedImageRHEL(image, release string) string {
@@ -745,24 +731,6 @@ func parseRelease(distro, release string) (string, error) {
 	parseReleaseImpl := distroObj.ParseRelease
 	release, err := parseReleaseImpl(release)
 	return release, err
-}
-
-func parseReleaseFedora(release string) (string, error) {
-	if strings.HasPrefix(release, "F") || strings.HasPrefix(release, "f") {
-		release = release[1:]
-	}
-
-	releaseN, err := strconv.Atoi(release)
-	if err != nil {
-		logrus.Debugf("Parsing release %s as an integer failed: %s", release, err)
-		return "", &ParseReleaseError{"The release must be a positive integer."}
-	}
-
-	if releaseN <= 0 {
-		return "", &ParseReleaseError{"The release must be a positive integer."}
-	}
-
-	return release, nil
 }
 
 func parseReleaseRHEL(release string) (string, error) {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -328,15 +328,6 @@ func getDefaultReleaseForDistro(distro string) (string, error) {
 	return release, nil
 }
 
-func getDefaultReleaseRHEL() (string, error) {
-	release, err := getHostVersionID()
-	if err != nil {
-		return "", err
-	}
-
-	return release, nil
-}
-
 func getDefaultReleaseUbuntu() (string, error) {
 	release, err := getHostVersionID()
 	if err != nil {
@@ -404,18 +395,6 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to resolve image %s", image)
-}
-
-func getFullyQualifiedImageRHEL(image, release string) string {
-	i := strings.IndexRune(release, '.')
-	if i == -1 {
-		panicMsg := fmt.Sprintf("release %s not in '<major>.<minor>' format", release)
-		panic(panicMsg)
-	}
-
-	releaseMajor := release[:i]
-	imageFull := "registry.access.redhat.com/ubi" + releaseMajor + "/" + image
-	return imageFull
 }
 
 func getFullyQualifiedImageUbuntu(image, release string) string {
@@ -731,24 +710,6 @@ func parseRelease(distro, release string) (string, error) {
 	parseReleaseImpl := distroObj.ParseRelease
 	release, err := parseReleaseImpl(release)
 	return release, err
-}
-
-func parseReleaseRHEL(release string) (string, error) {
-	if i := strings.IndexRune(release, '.'); i == -1 {
-		return "", &ParseReleaseError{"The release must be in the '<major>.<minor>' format."}
-	}
-
-	releaseN, err := strconv.ParseFloat(release, 32)
-	if err != nil {
-		logrus.Debugf("Parsing release %s as a float failed: %s", release, err)
-		return "", &ParseReleaseError{"The release must be in the '<major>.<minor>' format."}
-	}
-
-	if releaseN <= 0 {
-		return "", &ParseReleaseError{"The release must be a positive number."}
-	}
-
-	return release, nil
 }
 
 func parseReleaseUbuntu(release string) (string, error) {

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -328,10 +328,6 @@ func getDefaultReleaseForDistro(distro string) (string, error) {
 	return release, nil
 }
 
-func getDefaultReleaseArch() (string, error) {
-	return "latest", nil
-}
-
 func getDefaultReleaseFedora() (string, error) {
 	release, err := getHostVersionID()
 	if err != nil {
@@ -417,11 +413,6 @@ func GetFullyQualifiedImageFromDistros(image, release string) (string, error) {
 	}
 
 	return "", fmt.Errorf("failed to resolve image %s", image)
-}
-
-func getFullyQualifiedImageArch(image, release string) string {
-	imageFull := "quay.io/toolbx/" + image
-	return imageFull
 }
 
 func getFullyQualifiedImageFedora(image, release string) string {
@@ -754,14 +745,6 @@ func parseRelease(distro, release string) (string, error) {
 	parseReleaseImpl := distroObj.ParseRelease
 	release, err := parseReleaseImpl(release)
 	return release, err
-}
-
-func parseReleaseArch(release string) (string, error) {
-	if release != "latest" && release != "rolling" && release != "" {
-		return "", &ParseReleaseError{"The release must be 'latest'."}
-	}
-
-	return "latest", nil
 }
 
 func parseReleaseFedora(release string) (string, error) {


### PR DESCRIPTION
This will reduce the size of the `src/pkg/utils/utils.go` file and make it easier to specify which part of the code base is maintained by whom.