### PR TITLE
images: Create the directory for configuring PKCS#11 modules

### DIFF
--- a/images/arch/Containerfile
+++ b/images/arch/Containerfile
@@ -23,3 +23,6 @@ RUN yes | pacman -Scc
 
 # Enable sudo permission for wheel users
 RUN echo "%wheel ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/toolbox
+
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules

--- a/images/ubuntu/18.04/Containerfile
+++ b/images/ubuntu/18.04/Containerfile
@@ -33,6 +33,9 @@ RUN rm /extra-packages
 # Allow authentication with empty password, promptless
 RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam.d/common-auth
 
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
 

--- a/images/ubuntu/20.04/Containerfile
+++ b/images/ubuntu/20.04/Containerfile
@@ -35,6 +35,9 @@ RUN rm /extra-packages
 # Allow authentication with empty password, promptless
 RUN sed -i '/^auth.*pam_unix.so/s/nullok_secure/try_first_pass nullok/' /etc/pam.d/common-auth
 
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
 

--- a/images/ubuntu/22.04/Containerfile
+++ b/images/ubuntu/22.04/Containerfile
@@ -32,6 +32,9 @@ RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages
 
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
 

--- a/images/ubuntu/24.04/Containerfile
+++ b/images/ubuntu/24.04/Containerfile
@@ -33,6 +33,9 @@ RUN apt-get update && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages
 
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
 

--- a/images/ubuntu/24.10/Containerfile
+++ b/images/ubuntu/24.10/Containerfile
@@ -27,6 +27,9 @@ RUN apt-get update && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages
 
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
 # Fix empty bind-mount to clear selinuxfs (see #337)
 RUN mkdir /usr/share/empty
 


### PR DESCRIPTION
It's better to ensure that the `/etc/pkcs11/modules` directory exists in the image, instead of having the Toolbx container's entry point create it at runtime, because it can be a confirmation that p11-kit was built to read the module configuration from this location.

https://github.com/containers/toolbox/issues/626