### PR TITLE
test/system: Don't use XDG_CACHE_HOME or HOME for temporary files

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -4,14 +4,11 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 
 # Helpful globals
-readonly TEMP_BASE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/toolbx"
-readonly TEMP_STORAGE_DIR="${TEMP_BASE_DIR}/system-test-storage"
-
 readonly IMAGE_CACHE_DIR="${BATS_SUITE_TMPDIR}/image-cache"
-readonly ROOTLESS_PODMAN_STORE_DIR="${TEMP_STORAGE_DIR}/storage"
-readonly ROOTLESS_PODMAN_RUNROOT_DIR="${TEMP_STORAGE_DIR}/runroot"
-readonly PODMAN_STORE_CONFIG_FILE="${TEMP_STORAGE_DIR}/storage.conf"
-readonly DOCKER_REG_ROOT="${TEMP_STORAGE_DIR}/docker-registry-root"
+readonly ROOTLESS_PODMAN_STORE_DIR="${BATS_SUITE_TMPDIR}/storage"
+readonly ROOTLESS_PODMAN_RUNROOT_DIR="${BATS_SUITE_TMPDIR}/runroot"
+readonly PODMAN_STORE_CONFIG_FILE="${BATS_SUITE_TMPDIR}/storage.conf"
+readonly DOCKER_REG_ROOT="${BATS_SUITE_TMPDIR}/docker-registry-root"
 readonly DOCKER_REG_CERTS_DIR="${BATS_SUITE_TMPDIR}/certs"
 readonly DOCKER_REG_AUTH_DIR="${BATS_SUITE_TMPDIR}/auth"
 readonly DOCKER_REG_URI="localhost:50000"
@@ -43,20 +40,9 @@ function _setup_environment() {
 }
 
 function _setup_containers_storage() {
-  mkdir -p "${TEMP_STORAGE_DIR}"
   # Set up a storage config file for PODMAN
   echo -e "[storage]\n  driver = \"overlay\"\n  rootless_storage_path = \"${ROOTLESS_PODMAN_STORE_DIR}\"\n  runroot = \"${ROOTLESS_PODMAN_RUNROOT_DIR}\"\n" > "${PODMAN_STORE_CONFIG_FILE}"
   export CONTAINERS_STORAGE_CONF="${PODMAN_STORE_CONFIG_FILE}"
-}
-
-
-function _clean_temporary_storage() {
-  podman system reset --force >/dev/null
-
-  rm --force --recursive "${ROOTLESS_PODMAN_STORE_DIR}"
-  rm --force --recursive "${ROOTLESS_PODMAN_RUNROOT_DIR}"
-  rm --force --recursive "${PODMAN_STORE_CONFIG_FILE}"
-  rm --force --recursive "${TEMP_STORAGE_DIR}"
 }
 
 
@@ -202,19 +188,19 @@ function _setup_docker_registry() {
   assert_success
 
   run podman login \
-    --authfile "${TEMP_BASE_DIR}/authfile.json" \
+    --authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
     --username user \
     --password user \
     "${DOCKER_REG_URI}"
   assert_success
 
   # Add fedora-toolbox:34 image to the registry
-  run skopeo copy --dest-authfile "${TEMP_BASE_DIR}/authfile.json" \
+  run skopeo copy --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
     dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
     docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
   assert_success
 
-  run rm "${TEMP_BASE_DIR}/authfile.json"
+  run rm "${BATS_SUITE_TMPDIR}/authfile.json"
   assert_success
 }
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -120,12 +120,6 @@ function _pull_and_cache_distro_image() {
 }
 
 
-# Removes the folder with cached images
-function _clean_cached_images() {
-  rm --force --recursive "${IMAGE_CACHE_DIR}"
-}
-
-
 # Prepares a locally hosted image registry
 #
 # The registry is set up with Podman set to an alternative root. It won't

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -86,5 +86,5 @@ teardown_suite() {
   fi
 
   _clean_cached_images
-  _clean_temporary_storage
+  podman system reset --force >/dev/null
 }

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 #
-# Copyright © 2021 – 2024 Red Hat, Inc.
+# Copyright © 2021 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,6 +85,5 @@ teardown_suite() {
     _clean_docker_registry
   fi
 
-  _clean_cached_images
   podman system reset --force >/dev/null
 }


### PR DESCRIPTION
The `XDG_CACHE_HOME` environment variable is supposed to default to `$HOME/.cache` [1], just as it did in the test suite, and this location is meant to be used as a cache for 'normal' use by the user.  Test suites generally don't qualify as 'normal' use.

One expects that deleting the cache shouldn't affect 'normal' use other than degrading performance.  However, deleting these temporary files used by the test suite will cause actual breakage.  Even if the user doesn't manually delete the cache, two concurrent invocations of the test suite can do so or lead to other unexpected collisions, because the paths are constant across multiple invocations.

Therefore, it's better to limit the scope of the test suite's temporary files within the sandbox offered by Bats [2].  The sandbox is clearly labelled as being used by Bats, is unique for each invocation, and Bats takes care of cleaning everything up once it has finished running.

Note that there's no need for the `system-test-storage` sub-directory under `BATS_SUITE_TMPDIR`.  So it was left out.

[1] https://specifications.freedesktop.org/basedir-spec/latest/

[2] https://bats-core.readthedocs.io/en/stable/writing-tests.html