### PR TITLE
test/system: Optimize the environment variable tests

### DIFF
--- a/test/system/220-environment-variables.bats
+++ b/test/system/220-environment-variables.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 – 2024 Red Hat, Inc.
+# Copyright © 2023 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,22 +21,36 @@ load 'libs/bats-support/load'
 load 'libs/bats-assert/load'
 load 'libs/helpers'
 
-setup() {
+setup_file() {
   bats_require_minimum_version 1.10.0
   _setup_environment
   cleanup_all
   pushd "$HOME" || return 1
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "arch" >/dev/null 2>/dev/null; then
+    create_distro_container arch latest arch-toolbox-latest
+  fi
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "fedora" >/dev/null 2>/dev/null; then
+    create_default_container
+    create_distro_container fedora 34 fedora-toolbox-34
+    create_distro_container rhel 8.10 rhel-toolbox-8.10
+  fi
+
+  if echo "$TOOLBX_TEST_SYSTEM_TAGS" | grep "ubuntu" >/dev/null 2>/dev/null; then
+    create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
+    create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
+    create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
+  fi
 }
 
-teardown() {
+teardown_file() {
   popd || return 1
   cleanup_all
 }
 
 # bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside the default container" {
-  create_default_container
-
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
     HISTFILESIZE=1001
@@ -59,8 +73,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -84,8 +96,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -109,8 +119,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HISTFILESIZE inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -134,8 +142,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -160,8 +166,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -186,8 +190,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTFILESIZE inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   # shellcheck disable=SC2031
   if [ "$HISTFILESIZE" = "" ]; then
     HISTFILESIZE=1001
@@ -213,8 +215,6 @@ teardown() {
 @test "environment variables: HISTSIZE inside the default container" {
   skip "https://pagure.io/setup/pull-request/48"
 
-  create_default_container
-
   if [ "$HISTSIZE" = "" ]; then
     # shellcheck disable=SC2030
     HISTSIZE=1001
@@ -237,8 +237,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -263,8 +261,6 @@ teardown() {
 # bats test_tags=arch-fedora
 @test "environment variables: HISTSIZE inside Fedora 34" {
   skip "https://pagure.io/setup/pull-request/48"
-
-  create_distro_container fedora 34 fedora-toolbox-34
 
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
@@ -291,8 +287,6 @@ teardown() {
 @test "environment variables: HISTSIZE inside RHEL 8.10" {
   skip "https://pagure.io/setup/pull-request/48"
 
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -316,8 +310,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -341,8 +333,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
     # shellcheck disable=SC2030
@@ -366,8 +356,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HISTSIZE inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   # shellcheck disable=SC2031
   if [ "$HISTSIZE" = "" ]; then
     HISTSIZE=1001
@@ -390,8 +378,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside the default container" {
-  create_default_container
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run bash -c 'echo "$HOSTNAME"'
 
@@ -403,8 +389,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro arch bash -c 'echo "$HOSTNAME"'
 
@@ -416,8 +400,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro fedora --release 34 bash -c 'echo "$HOSTNAME"'
 
@@ -429,8 +411,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: HOSTNAME inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro rhel --release 8.10 bash -c 'echo "$HOSTNAME"'
 
@@ -442,8 +422,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 16.04 bash -c 'echo "$HOSTNAME"'
 
@@ -455,8 +433,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 18.04 bash -c 'echo "$HOSTNAME"'
 
@@ -468,8 +444,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: HOSTNAME inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   # shellcheck disable=SC2016
   run --keep-empty-lines --separate-stderr "$TOOLBX" run --distro ubuntu --release 20.04 bash -c 'echo "$HOSTNAME"'
 
@@ -481,8 +455,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside the default container" {
-  create_default_container
-
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
     export KONSOLE_VERSION=230804
@@ -501,8 +473,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -522,8 +492,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -543,8 +511,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: KONSOLE_VERSION inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -564,8 +530,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -585,8 +549,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -606,8 +568,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: KONSOLE_VERSION inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   # shellcheck disable=SC2031
   if [ "$KONSOLE_VERSION" = "" ]; then
     export KONSOLE_VERSION=230804
@@ -626,8 +586,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside the default container" {
-  create_default_container
-
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
     export XTERM_VERSION="XTerm(385)"
@@ -646,8 +604,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside Arch Linux" {
-  create_distro_container arch latest arch-toolbox-latest
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -667,8 +623,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside Fedora 34" {
-  create_distro_container fedora 34 fedora-toolbox-34
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -688,8 +642,6 @@ teardown() {
 
 # bats test_tags=arch-fedora
 @test "environment variables: XTERM_VERSION inside RHEL 8.10" {
-  create_distro_container rhel 8.10 rhel-toolbox-8.10
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -709,8 +661,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 16.04" {
-  create_distro_container ubuntu 16.04 ubuntu-toolbox-16.04
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -730,8 +680,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 18.04" {
-  create_distro_container ubuntu 18.04 ubuntu-toolbox-18.04
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     # shellcheck disable=SC2030
@@ -751,8 +699,6 @@ teardown() {
 
 # bats test_tags=ubuntu
 @test "environment variables: XTERM_VERSION inside Ubuntu 20.04" {
-  create_distro_container ubuntu 20.04 ubuntu-toolbox-20.04
-
   # shellcheck disable=SC2031
   if [ "$XTERM_VERSION" = "" ]; then
     export XTERM_VERSION="XTerm(385)"


### PR DESCRIPTION
The system tests can be very I/O intensive, because many of them copy
OCI images from the test suite's image cache directory to its local
container/storage store, create containers, and then delete everything
to run the next test with a clean slate.  This makes them slow.

The runtime environment tests, which includes the environment variable
tests, are particularly slow because they don't skip the I/O even when
testing error handling.  This makes them a good target for
optimizations.

The environment variable tests query the values of different environment
variables from different containers without changing their state.
Therefore, a lot of disk I/O can be avoided by creating these containers
only once for all the tests.