### PR TITLE
pkg/utils: Update fallback release to 42 for non-fedora hosts

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -63,7 +63,7 @@ const (
 	containerNamePrefixFallback = "fedora-toolbox"
 	distroFallback              = "fedora"
 	idTruncLength               = 12
-	releaseFallback             = "40"
+	releaseFallback             = "42"
 )
 
 const (


### PR DESCRIPTION
Fedora 40 reached End of Life on 13th May 2025:
https://docs.fedoraproject.org/en-US/releases/eol/