### PR TITLE
pkg/utils: Preserve HOME environment variable when forwarding to host

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -92,6 +92,7 @@ var (
 		"HISTIGNORE",
 		"HISTSIZE",
 		"HISTTIMEFORMAT",
+		"HOME",
 		"KONSOLE_VERSION",
 		"LANG",
 		"SHELL",


### PR DESCRIPTION
Currently, it's impossible to create a Toolbx container with a different home directory from the host while sitting inside a Toolbx container.

Preserving the `HOME` environment variable when forwarding to the host will enable users to create containers with different home directories for increased isolation while sitting inside a Toolbx container, and to isolate the host's `HOME` from the system tests.

This was never supported by the POSIX shell implementation.

https://github.com/containers/toolbox/issues/1044
https://github.com/containers/toolbox/issues/1564