### PR TITLE
Add Upgrade Functionality

### DIFF
--- a/doc/toolbox-upgrade.1.md
+++ b/doc/toolbox-upgrade.1.md
@@ -1,0 +1,61 @@
+
+% toolbox-upgrade 1
+
+## NAME
+toolbox\-upgrade - Upgrade packages in Toolbx containers
+
+## SYNOPSIS
+**toolbox upgrade** [*--all* | *-a*] [*--container* | *-c* *CONTAINER*]
+
+## DESCRIPTION
+Upgrades packages inside one or more Toolbx containers by automatically detecting
+the package manager (dnf, apt, pacman, etc.) and running the appropriate upgrade
+command. The container should have been created using the `toolbox create` command.
+
+This command will:
+1. Detect the available package manager in the container
+2. Run the appropriate update/upgrade commands
+3. Report any errors that occur during the process
+
+## OPTIONS
+**--all, -a**
+Upgrade all Toolbx containers. Cannot be used with *--container*.
+
+**--container, -c** *CONTAINER*
+Upgrade a specific Toolbx container. Cannot be used with *--all*.
+
+## EXAMPLES
+**Upgrade packages in a specific container:**
+```
+$ toolbox upgrade --container fedora-toolbox-38
+```
+
+**Upgrade packages in all containers:**
+```
+$ toolbox upgrade --all
+```
+
+**Typical output:**
+```
+Detected package manager: dnf
+Updating metadata...
+Upgrading packages...
+Complete!
+```
+
+## NOTES
+Supported package managers:
+- dnf (Fedora, RHEL)
+- microdnf (Minimal Fedora/RHEL)
+- yum (Older RHEL/Fedora)
+- apt (Debian, Ubuntu)
+- pacman (Arch Linux)
+- xbps (Void Linux)
+- zypper (openSUSE)
+- apk (Alpine Linux)
+- emerge (Gentoo)
+- slackpkg (Slackware)
+- swupd (Clear Linux)
+
+## SEE ALSO
+`toolbox(1)`, `toolbox-create(1)`, `toolbox-list(1)`

--- a/doc/toolbox.1.md
+++ b/doc/toolbox.1.md
@@ -160,6 +160,10 @@ Remove one or more Toolbx images.
 
 Run a command in an existing Toolbx container.
 
+**toolbox-upgrade(1)**
+
+Upgrade one or more existing Toolbx containers via their Package Manager.
+
 ## FILES ##
 
 **toolbox.conf(5)**

--- a/src/cmd/upgrade.go
+++ b/src/cmd/upgrade.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright © 2025 Hadi Chokr <hadichokr@icloud.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/containers/toolbox/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	upgradeAll       bool
+	upgradeContainer string
+)
+
+var upgradeCmd = &cobra.Command{
+	Use:               "upgrade",
+	Short:             "Detect package manager and upgrade packages in toolbx containers",
+	RunE:              runUpgrade,
+	ValidArgsFunction: completionContainerNamesFiltered,
+}
+
+func init() {
+	upgradeCmd.Flags().BoolVar(&upgradeAll, "all", false, "Upgrade all Toolbx containers")
+	upgradeCmd.Flags().StringVar(&upgradeContainer, "container", "", "Name of the toolbox container to upgrade")
+
+	// Register container flag completion
+	if err := upgradeCmd.RegisterFlagCompletionFunc("container", completionContainerNames); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to register flag completion function: %v\n", err)
+		os.Exit(1)
+	}
+	upgradeCmd.SetHelpFunc(upgradeHelp)
+	rootCmd.AddCommand(upgradeCmd)
+}
+
+func runUpgrade(cmd *cobra.Command, args []string) error {
+	if !upgradeAll && upgradeContainer == "" {
+		return errors.New("must specify either --all or --container")
+	}
+
+	if upgradeAll && upgradeContainer != "" {
+		return errors.New("cannot specify both --all and --container")
+	}
+
+	if upgradeAll {
+		containers, err := getContainers()
+		if err != nil {
+			return err
+		}
+
+		if len(containers) == 0 {
+			return errors.New("no Toolbx containers found")
+		}
+
+		for _, container := range containers {
+			fmt.Printf("Upgrading container: %s\n", container.Name())
+			if err := execUpgradeInContainer(container.Name()); err != nil {
+				fmt.Fprintf(os.Stderr, "Error upgrading container %s: %v\n", container.Name(), err)
+				// Continue with next container instead of returning
+			}
+		}
+		return nil
+	}
+
+	return execUpgradeInContainer(upgradeContainer)
+}
+
+// execUpgradeInContainer runs detection and upgrade inside the specified container
+func execUpgradeInContainer(container string) error {
+	pkgs := []struct {
+		detect  string
+		upgrade string
+		name    string
+	}{
+		{"command -v dnf", "sudo dnf -y upgrade", "dnf"},
+		{"command -v microdnf", "sudo microdnf upgrade -y", "microdnf"},
+		{"command -v yum", "sudo yum -y upgrade", "yum"},
+		{"command -v apt", "sudo apt update && apt upgrade -y", "apt"},
+		{"command -v pacman", "sudo pacman -Syu --noconfirm", "pacman"},
+		{"command -v xbps-install", "sudo xbps-install -Su -y", "xbps"},
+		{"command -v zypper", "sudo zypper update -y", "zypper"},
+		{"command -v apk", "sudo apk update && apk upgrade", "apk"},
+		{"command -v emerge", "sudo emerge --sync && emerge -uDN @world", "emerge"},
+		{"command -v slackpkg", "sudo slackpkg update && slackpkg upgrade-all", "slackpkg"},
+		{"command -v swupd", "sudo swupd update", "swupd"},
+	}
+
+	for _, pkg := range pkgs {
+		// Use runCommand to check if package manager exists
+		err := runCommand(container,
+				  false,  // defaultContainer
+		    "",     // image
+		    "",     // release
+		    0,      // preserveFDs
+		    []string{"sh", "-c", pkg.detect},
+		    false,  // emitEscapeSequence
+		    false,  // fallbackToBash
+		    true)   // pedantic
+
+		if err == nil {
+			fmt.Printf("Detected package manager: %s\n", pkg.name)
+
+			// Use runCommand to execute the upgrade
+			upgradeErr := runCommand(container,
+						 false,
+			    "",
+			    "",
+			    0,
+			    []string{"sh", "-c", pkg.upgrade},
+			    false,
+			    false,
+			    true)
+
+			return upgradeErr
+		}
+	}
+	return errors.New("no supported package manager found")
+}
+
+func upgradeHelp(cmd *cobra.Command, args []string) {
+	if utils.IsInsideContainer() {
+		if !utils.IsInsideToolboxContainer() {
+			fmt.Fprintf(os.Stderr, "Error: this is not a Toolbx container\n")
+			return
+		}
+
+		if _, err := utils.ForwardToHost(); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			return
+		}
+
+		return
+	}
+
+	if err := showManual("toolbox-upgrade"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		return
+	}
+}

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -362,6 +362,7 @@ func getUsageForCommonCommands() string {
 	builder.WriteString("create    Create a new Toolbx container\n")
 	builder.WriteString("enter     Enter an existing Toolbx container\n")
 	builder.WriteString("list      List all existing Toolbx containers and images\n")
+	builder.WriteString("upgrade   Upgrade an existing Toolbx container via their Package Manager\n")
 
 	usage := builder.String()
 	return usage


### PR DESCRIPTION

## toolbox upgrade: Add package manager detection and upgrade capability

This PR introduces a new `toolbox upgrade` command that:

### Key Features
- Automatically detects the container's package manager (supports 11 package managers)
- Performs full system upgrades using the native package manager
- Works with both individual containers (`--container`) and all containers (`--all`)
- Provides clear output showing detected package manager and upgrade progress

### Supported Package Managers
✔️ dnf/microdnf/yum (RHEL/Fedora)  
✔️ apt (Debian/Ubuntu)  
✔️ pacman (Arch)  
✔️ zypper (openSUSE)  
✔️ apk (Alpine)  
✔️ And 5 others (xbps, emerge, slackpkg, swupd)

### Usage Examples
```sh
# Upgrade specific container
toolbox upgrade --container fedora-toolbox-38

# Upgrade all containers
toolbox upgrade --all
```

### Implementation Details
- Uses existing `runCommand` infrastructure
- Gracefully handles errors during upgrade process
- Includes comprehensive man page documentation
- Follows established toolbox patterns

This provides users with a simple, unified way to keep all their toolbox containers updated regardless of distro.
