### PR TITLE
WIP: Refresh Podman user namespace mappings on Rawhide

### DIFF
--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -39,6 +39,11 @@
       - udisks2
     use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
+- name: Force Podman to refresh user namespace mappings
+  become: true
+  command: podman system migrate
+  ignore_errors: true
+
 - name: Ensure that 'p11-kit server' is absent
   become: yes
   package:


### PR DESCRIPTION
Some CI jobs on Fedora Rawhide failed with rootless Podman builds due to stale or missing UID/GID mappings, even after installing shadow-utils-subid-devel:

    Error: cannot find mappings for user zuul-worker in /etc/subuid

Force a refresh of Podman’s user namespace mappings with `podman system migrate`, which re-reads /etc/subuid and /etc/subgid and applies default ranges when available.

Once the Rawhide base image includes proper mappings by default, this workaround can be removed.