### PR TITLE
cmd/initContainer: Use errors.Is() instead of os.IsNotExist()

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -944,7 +944,7 @@ func redirectPath(containerPath, target string, folder bool) error {
 
 	err := os.Remove(containerPath)
 	if folder {
-		if err != nil && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}
 


### PR DESCRIPTION
The `os.IsNotExist()` function [1] predates the introduction of the `errors.Is()` function [2] in Go 1.13 [3].  From Go >= 1.16, the documentation explicitly recommends the use of `errors.Is()` instead of `os.IsNotExist()` [4].

The Go implementation of Toolbx never used any Go older than 1.13 [5], and currently it requires Go >= 1.22 [6].  So, there's no reason not to use the more modern and recommended alternative.

[1] https://pkg.go.dev/os#IsNotExist

[2] https://pkg.go.dev/errors#Is

[3] https://go.dev/blog/go1.13-errors

[4] Go commit b641f0dcf48aa748
    https://github.com/golang/go/commit/b641f0dcf48aa748
    https://github.com/golang/go/issues/41122

[5] Commit d857471aa2f233e5
    https://github.com/containers/toolbox/commit/d857471aa2f233e5
    https://github.com/containers/toolbox/pull/318

[6] Commit eb736926183b1c20
    https://github.com/containers/toolbox/commit/eb736926183b1c20
    https://github.com/containers/toolbox/pull/1662