### PR TITLE
cmd/initContainer: Detect mount points when creating symbolic links

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -942,12 +942,13 @@ func redirectPath(containerPath, target string, folder bool) error {
 	logrus.Debugf("Preparing to redirect %s to %s", containerPath, target)
 	targetSanitized := sanitizeRedirectionTarget(target)
 
-	err := os.Remove(containerPath)
-	if folder {
-		if err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := os.Remove(containerPath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}
+	}
 
+	if folder {
 		if err := os.MkdirAll(target, 0755); err != nil {
 			return fmt.Errorf("failed to redirect %s to %s: %w", containerPath, target, err)
 		}


### PR DESCRIPTION
An error like this shouldn't happen unless Podman did something
unexpected or was used wrong or something else happened that inserted an
unexpected mount point in the container to surprise the entry point.
eg., removing the `--no-hosts` option from `podman create` will trigger
this.

This change replaces the more generic error message:
```ShellSession
  $ toolbox enter
  Error: failed to redirect /etc/hosts to /run/host/etc/hosts: remove
      /etc/hosts: device or resource busy
```

... to something more precise:
```ShellSession
  $ toolbox enter
  Error: failed to redirect /etc/hosts to /run/host/etc/hosts:
      /etc/hosts is a mount point
```