### PR TITLE
toolbox.sh: use new TOOLBOX_DO_NOT_OVERRIDE_PS1

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -48,8 +48,10 @@ fi
 
 if [ -f /run/.containerenv ] \
    && [ -f /run/.toolboxenv ]; then
-    [ "${BASH_VERSION:-}" != "" ] && PS1=$(printf "\[\033[35m\]⬢ \[\033[0m\]%s" "[\u@\h \W]\\$ ")
-    [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢ \033[0m%s" "[%n@%m]%~%# ")
+    if [ "${TOOLBOX_DO_NOT_OVERRIDE_PS1}" = "" ]; then 
+        [ "${BASH_VERSION:-}" != "" ] && PS1=$(printf "\[\033[35m\]⬢ \[\033[0m\]%s" "[\u@\h \W]\\$ ")
+        [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢ \033[0m%s" "[%n@%m]%~%# ")
+    fi
 
     if ! [ -f "$toolbox_welcome_stub" ]; then
         echo ""


### PR DESCRIPTION
This allows users to set `TOOLBOX_DO_NOT_OVERRIDE_PS1` in their shell configuration
to prevent toolbox from overriding `PS1`.

Addresses #1357