### PR TITLE
Deprecation message when using 0.0.96 and older Toolbx container + tests

### DIFF
--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -256,7 +256,7 @@ func runCommand(container string,
 	if entryPoint != "toolbox" {
 		var builder strings.Builder
 		fmt.Fprintf(&builder, "container %s is too old and no longer supported\n", container)
-		fmt.Fprintf(&builder, "Recreate it with Toolbx version 0.0.17 or newer.")
+		fmt.Fprintf(&builder, "Recreate it with Toolbx version 0.0.97 or newer.")
 
 		errMsg := builder.String()
 		return errors.New(errMsg)
@@ -528,6 +528,9 @@ func callFlatpakSessionHelper(container podman.Container) error {
 	if !needsFlatpakSessionHelper {
 		return nil
 	}
+
+	fmt.Fprintf(os.Stderr, "Warning: container %s uses deprecated features\n", name)
+	fmt.Fprintf(os.Stderr, "Consider recreating it with Toolbx version 0.0.97 or newer.\n")
 
 	if _, err := utils.CallFlatpakSessionHelper(); err != nil {
 		return err

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -316,6 +316,21 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
+@test "run: Ensure that containers using o.fd.Flatpak.SessionHelper are deprecated" {
+  local container="deprecated"
+
+  create_container_flatpak_session_helper "$container"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$container" true
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "Warning: container $container uses deprecated features"
+  assert_line --index 1 "Consider recreating it with Toolbx version 0.0.97 or newer."
+  assert [ ${#stderr_lines[@]} -eq 2 ]
+}
+
 @test "run: Try the non-existent default container with none other present" {
   local default_container_name
   default_container_name="$(get_system_id)-toolbox-$(get_system_version)"
@@ -860,6 +875,6 @@ teardown() {
   assert [ ${#lines[@]} -eq 0 ]
   lines=("${stderr_lines[@]}")
   assert_line --index 0 "Error: container $container is too old and no longer supported"
-  assert_line --index 1 "Recreate it with Toolbx version 0.0.17 or newer."
+  assert_line --index 1 "Recreate it with Toolbx version 0.0.97 or newer."
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }


### PR DESCRIPTION
Added deprecation message when running a container that was created with Toolbx 0.0.96 and older, as described in #1684 