### PR TITLE
Fix resolving /etc/localtime

### DIFF
--- a/toolbox
+++ b/toolbox
@@ -1252,7 +1252,7 @@ init_container()
         fi
 
         if [ -d /run/host/monitor ] 2>&3; then
-            if ! localtime_target=$(readlink /etc/localtime >/dev/null 2>&3) \
+            if ! localtime_target=$(readlink /etc/localtime 2>&3) \
                || [ "$localtime_target" != "/run/host/monitor/localtime" ] 2>&3; then
                 echo "$base_toolbox_command: redirecting /etc/localtime to /run/host/monitor/localtime" >&3
 


### PR DESCRIPTION
Detected by https://www.shellcheck.net/:
```
  Line 1255:
  if ! localtime_target=$(readlink /etc/localtime >/dev/null 2>&3) \
                        ^-- SC2327 (warning): This command substitution
                            will be empty because the command's output
                            gets redirected away.
                                                  ^-- SC2328 (error):
                                                      This redirection
                                                      takes output away
                                                      from the command
                                                      substitution.
```

See:
https://www.shellcheck.net/wiki/SC2327
https://www.shellcheck.net/wiki/SC2328

Fallout from 8db414ddc2d73719c628ca56f345556281e33ebf