### PR TITLE
Added a warning when using a non-Toolbx container

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -222,23 +222,50 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		return nil
 	}
 
-	imageFull, err := podman.GetFullyQualifiedImageFromRepoTags(image)
-	if err != nil {
-		var errImage *podman.ImageError
+	imageObj, inspectErr := podman.InspectImage(image)
 
-		if errors.As(err, &errImage) {
-			if errors.Is(err, podman.ErrImageRepoTagsEmpty) {
-				logrus.Debugf("Image %s has empty RepoTags, likely because it is without a name", image)
-				imageFull = image
-			} else if errors.Is(err, podman.ErrImageRepoTagsMissing) {
-				return fmt.Errorf("missing RepoTags for image %s", image)
-			} else {
-				panicMsg := fmt.Sprintf("unexpected %T: %s", err, err)
-				panic(panicMsg)
-			}
-		} else {
-			return err
+	logrus.Debugf("Resolving fully qualified name for image %s from RepoTags", image)
+	var imageFull string
+
+	if utils.ImageReferenceHasDomain(image) {
+		imageFull = image
+	} else {
+		if inspectErr != nil {
+			return fmt.Errorf("failed to inspect image %s", image)
 		}
+
+		var err error
+		imageFull, err = podman.GetFullyQualifiedImageFromRepoTags(image, imageObj)
+		if err != nil {
+			var errImage *podman.ImageError
+
+			if errors.As(err, &errImage) {
+				if errors.Is(err, podman.ErrImageRepoTagsEmpty) {
+					logrus.Debugf("Image %s has empty RepoTags, likely because it is without a name", image)
+					imageFull = image
+				} else if errors.Is(err, podman.ErrImageRepoTagsMissing) {
+					return fmt.Errorf("missing RepoTags for image %s", image)
+				} else {
+					panicMsg := fmt.Sprintf("unexpected %T: %s", err, err)
+					panic(panicMsg)
+				}
+			} else {
+				return err
+			}
+		}
+	}
+
+	logrus.Debugf("Resolved image %s to %s", image, imageFull)
+
+	var imageUnknownLabel []string
+
+	hasWarnings, shouldContinue := checkAndWarnImageCompatibility(imageFull, imageObj, true)
+	if !shouldContinue {
+		return nil
+	}
+
+	if hasWarnings {
+		imageUnknownLabel = []string{"--label", "com.github.containers.toolbx.image-unknown=true"}
 	}
 
 	var toolbxDelayEntryPointEnv []string
@@ -445,6 +472,8 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		"--ipc", "host",
 		"--label", "com.github.containers.toolbox=true",
 	}...)
+
+	createArgs = append(createArgs, imageUnknownLabel...)
 
 	createArgs = append(createArgs, devPtsMount...)
 

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -155,6 +155,7 @@ func listOutput(images *podman.Images, containers *podman.Containers) {
 
 	if containers.Len() != 0 {
 		const boldGreenColor = "\033[1;32m"
+		const boldYellowColor = "\033[0;33m"
 		const defaultColor = "\033[0;00m" // identical to resetColor, but same length as boldGreenColor
 		const resetColor = "\033[0m"
 
@@ -191,6 +192,8 @@ func listOutput(images *podman.Images, containers *podman.Containers) {
 				var color string
 				if isRunning {
 					color = boldGreenColor
+				} else if container.IsImageUnknown() {
+					color = boldYellowColor
 				} else {
 					color = defaultColor
 				}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -254,6 +254,24 @@ func runCommand(container string,
 		return fmt.Errorf("failed to inspect container %s", container)
 	}
 
+	if !containerObj.IsToolbx() {
+		logrus.Debugf("Checking image compatibility for non-Toolbx container %s", container)
+		imageName := containerObj.Image()
+		if imageObj, err := podman.InspectImage(imageName); err != nil {
+			logrus.Debugf("Failed to inspect image %s: %s", imageName, err)
+		} else if _, shouldContinue := checkAndWarnImageCompatibility(imageName, imageObj, true); !shouldContinue {
+			return nil
+		}
+	} else if containerObj.IsImageUnknown() {
+		logrus.Debugf("Container %s has image compatibility issues", container)
+		imageName := containerObj.Image()
+		if imageObj, err := podman.InspectImage(imageName); err != nil {
+			logrus.Debugf("Failed to inspect image %s: %s", imageName, err)
+		} else {
+			checkAndWarnImageCompatibility(imageName, imageObj, false)
+		}
+	}
+
 	entryPoint := containerObj.EntryPoint()
 	entryPointPID := containerObj.EntryPointPID()
 	logrus.Debugf("Entry point of container %s is %s (PID=%d)", container, entryPoint, entryPointPID)

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -47,6 +48,34 @@ var (
 
 	errHUP = errors.New("HUP")
 )
+
+func checkAndWarnImageCompatibility(image string, imageObj podman.Image, promptUser bool) (hasWarnings bool, shouldContinue bool) {
+	if imageObj == nil {
+		logrus.Debugf("Failed to check image %s compatibility", image)
+		return false, true
+	}
+
+	warnings := podman.CheckImageCompatibility(imageObj)
+
+	if len(warnings) == 0 {
+		return false, true
+	}
+
+	fmt.Fprintf(os.Stderr, "Image %s has compatibility issues with Toolbx:\n", image)
+	for _, warning := range warnings {
+		fmt.Fprintf(os.Stderr, "  Warning: %s\n", warning)
+	}
+	fmt.Fprintf(os.Stderr, "\nContainers using incompatible images may not work as expected or may fail to start at all.\n")
+
+	if promptUser && !rootFlags.assumeYes {
+		prompt := "Continue anyway? [y/N]:"
+		if !askForConfirmation(prompt) {
+			return true, false
+		}
+	}
+
+	return true, true
+}
 
 // askForConfirmation prints prompt to stdout and waits for response from the
 // user

--- a/src/pkg/podman/container.go
+++ b/src/pkg/podman/container.go
@@ -29,6 +29,7 @@ type Container interface {
 	EntryPointPID() int
 	ID() string
 	Image() string
+	IsImageUnknown() bool
 	IsToolbx() bool
 	Labels() map[string]string
 	Mounts() []string
@@ -84,6 +85,10 @@ func (container *containerInspect) ID() string {
 
 func (container *containerInspect) Image() string {
 	return container.image
+}
+
+func (container *containerInspect) IsImageUnknown() bool {
+	return container.labels["com.github.containers.toolbx.image-unknown"] == "true"
 }
 
 func (container *containerInspect) IsToolbx() bool {
@@ -179,6 +184,10 @@ func (container *containerPS) ID() string {
 
 func (container *containerPS) Image() string {
 	return container.image
+}
+
+func (container *containerPS) IsImageUnknown() bool {
+	return container.labels["com.github.containers.toolbx.image-unknown"] == "true"
 }
 
 func (container *containerPS) IsToolbx() bool {

--- a/src/pkg/podman/image.go
+++ b/src/pkg/podman/image.go
@@ -47,6 +47,8 @@ type imageImages struct {
 
 type imageInspect struct {
 	created      string
+	entrypoint   []string
+	env          []string
 	id           string
 	labels       map[string]string
 	namesHistory []string
@@ -279,7 +281,9 @@ func (image *imageInspect) UnmarshalJSON(data []byte) error {
 		Created interface{}
 		ID      string
 		Config  struct {
-			Labels map[string]string
+			Entrypoint []string
+			Env        []string
+			Labels     map[string]string
 		}
 		NamesHistory []string
 		RepoTags     []string
@@ -296,6 +300,8 @@ func (image *imageInspect) UnmarshalJSON(data []byte) error {
 		image.created = utils.HumanDuration(int64(value))
 	}
 
+	image.entrypoint = raw.Config.Entrypoint
+	image.env = raw.Config.Env
 	image.id = raw.ID
 	image.labels = raw.Config.Labels
 	image.namesHistory = raw.NamesHistory

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/HarryMichal/go-version"
@@ -57,6 +58,34 @@ func CheckVersion(requiredVersion string) bool {
 	requiredVersion = version.Normalize(requiredVersion)
 
 	return version.CompareSimple(currentVersion, requiredVersion) >= 0
+}
+
+func CheckImageCompatibility(imageObj Image) []string {
+	logrus.Debugf("Checking image compatibility with Toolbx")
+
+	var warnings []string
+
+	if !imageObj.IsToolbx() {
+		warnings = append(warnings, "image is not a Toolbx image")
+	}
+
+	imageInspectObj, ok := imageObj.(*imageInspect)
+	if !ok {
+		return warnings
+	}
+
+	for _, envVar := range imageInspectObj.env {
+		if strings.HasPrefix(envVar, "LD_PRELOAD=") {
+			warnings = append(warnings, "image has the LD_PRELOAD environment variable set")
+			break
+		}
+	}
+
+	if len(imageInspectObj.entrypoint) > 0 {
+		warnings = append(warnings, "image has a pre-defined entrypoint")
+	}
+
+	return warnings
 }
 
 // ContainerExists checks using Podman if a container with given ID/name exists.
@@ -183,42 +212,29 @@ func GetVersion() (string, error) {
 	return podmanVersion, nil
 }
 
-func GetFullyQualifiedImageFromRepoTags(image string) (string, error) {
-	logrus.Debugf("Resolving fully qualified name for image %s from RepoTags", image)
+func GetFullyQualifiedImageFromRepoTags(image string, imageObj Image) (string, error) {
+	repoTags := imageObj.RepoTags()
+	if repoTags == nil {
+		return "", &ImageError{image, ErrImageRepoTagsMissing}
+	}
+
+	if len(repoTags) == 0 {
+		return "", &ImageError{image, ErrImageRepoTagsEmpty}
+	}
 
 	var imageFull string
 
-	if utils.ImageReferenceHasDomain(image) {
-		imageFull = image
-	} else {
-		imageObj, err := InspectImage(image)
-		if err != nil {
-			return "", fmt.Errorf("failed to inspect image %s", image)
-		}
-
-		repoTags := imageObj.RepoTags()
-		if repoTags == nil {
-			return "", &ImageError{image, ErrImageRepoTagsMissing}
-		}
-
-		if len(repoTags) == 0 {
-			return "", &ImageError{image, ErrImageRepoTagsEmpty}
-		}
-
-		for _, repoTag := range repoTags {
-			tag := utils.ImageReferenceGetTag(repoTag)
-			if tag != "latest" {
-				imageFull = repoTag
-				break
-			}
-		}
-
-		if imageFull == "" {
-			imageFull = repoTags[0]
+	for _, repoTag := range repoTags {
+		tag := utils.ImageReferenceGetTag(repoTag)
+		if tag != "latest" {
+			imageFull = repoTag
+			break
 		}
 	}
 
-	logrus.Debugf("Resolved image %s to %s", image, imageFull)
+	if imageFull == "" {
+		imageFull = repoTags[0]
+	}
 
 	return imageFull, nil
 }

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1221,3 +1221,293 @@ teardown() {
   assert_success
   assert_output "true"
 }
+
+@test "create: With a non-Toolbx image and prompt for confirmation - Yes" {
+  image="$(build_non_toolbx_image)"
+  containerName="test-container-non-toolbx"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "y"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With a non-Toolbx image and prompt for confirmation - No" {
+  image="$(build_non_toolbx_image)"
+  containerName="test-container-non-toolbx"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "n"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
+@test "create: With a non-Toolbx image and prompt for confirmation - assumeyes" {
+  image="$(build_non_toolbx_image)"
+  containerName="test-container-non-toolbx"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --assumeyes --image "$image" "$containerName"
+
+  assert_success
+  assert_line --index 0 "$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image with LD_PRELOAD set and prompt for confirmation - Yes" {
+  containerName="test-container-ld-preload"
+  image="$(build_image_with_ld_preload)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "y"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image with LD_PRELOAD set and prompt for confirmation - No" {
+  containerName="test-container-ld-preload"
+  image="$(build_image_with_ld_preload)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "n"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
+@test "create: With an image with LD_PRELOAD set and prompt for confirmation - assumeyes" {
+  containerName="test-container-ld-preload"
+  image="$(build_image_with_ld_preload)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image" "$containerName"
+
+  assert_success
+  assert_line --index 0 "$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image with an entrypoint set and prompt for confirmation - Yes" {
+  containerName="test-container-entrypoint"
+  image="$(build_image_with_entrypoint)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "y"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image with an entrypoint set and prompt for confirmation - No" {
+  containerName="test-container-entrypoint"
+  image="$(build_image_with_entrypoint)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "n"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
+@test "create: With an image with an entrypoint set and prompt for confirmation - assumeyes" {
+  containerName="test-container-entrypoint"
+  image="$(build_image_with_entrypoint)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create --image "$image" "$containerName"
+
+  assert_success
+  assert_line --index 0 "$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image having all warnings and prompt for confirmation - Yes" {
+  containerName="test-container-all-warnings"
+  image="$(build_image_with_all_warnings)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "y"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 3 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 4 ""
+  assert_line --index 5 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 6 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}
+
+@test "create: With an image having all warnings and prompt for confirmation - No" {
+  containerName="test-container-all-warnings"
+  image="$(build_image_with_all_warnings)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --image "$image" "$containerName" <<< "n"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 3 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 4 ""
+  assert_line --index 5 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 6 ]
+
+  run podman ps --all
+
+  assert_success
+  assert [ ${#lines[@]} -eq 1 ]
+}
+
+@test "create: With an image having all warnings and prompt for confirmation - assumeyes" {
+  containerName="test-container-all-warnings"
+  image="$(build_image_with_all_warnings)"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create --assumeyes --image "$image" "$containerName"
+
+  assert_success
+  assert_line --index 0 "$(created_container_message "$containerName")"
+  assert_line --index 1 "$(enter_with_message "$containerName")"
+  assert [ ${#lines[@]} -eq 2 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 3 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 4 ""
+  assert_line --index 5 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 6 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$containerName"
+}

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -888,3 +888,108 @@ teardown() {
   assert_line --index 1 "Recreate it with Toolbx version 0.0.97 or newer."
   assert [ ${#stderr_lines[@]} -eq 2 ]
 }
+
+
+@test "run: With a non-Toolbx container (created via podman) and prompt for confirmation - No" {
+  image="$(build_non_toolbx_image)"
+  local container="non-toolbx-container"
+
+  run podman create --name "$container" "$image" true
+
+  assert_success
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$container" true <<< "n"
+
+  assert_success
+  assert_line --index 0 "${MSG_CONFIRMATION_PROMPT}"
+  assert [ ${#lines[@]} -eq 1 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert [ ${#stderr_lines[@]} -eq 4 ]
+}
+
+@test "run: With a non-Toolbx image shows warnings without prompt" {
+  containerName="test-container-non-toolbx"
+  image="$(build_non_toolbx_image)"
+
+  create_image_container "$image" "$containerName"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$containerName" true
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert_line --index 4 "$(failed_start_error_message "$containerName")"
+  assert [ ${#stderr_lines[@]} -eq 5 ]
+}
+
+@test "run: With an image with LD_PRELOAD set shows warnings without prompt" {
+  containerName="test-container-ld-preload"
+  image="$(build_image_with_ld_preload)"
+
+  create_image_container "$image" "$containerName"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$containerName" true
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert_line --index 4 "$(failed_start_error_message "$containerName")"
+  assert [ ${#stderr_lines[@]} -eq 5 ]
+}
+
+@test "run: With an image with an entrypoint set shows warnings without prompt" {
+  containerName="test-container-entrypoint"
+  image="$(build_image_with_entrypoint)"
+
+  create_image_container "$image" "$containerName"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$containerName" true
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 2 ""
+  assert_line --index 3 "$(warning_image_outro)"
+  assert_line --index 4 "$(failed_start_error_message "$containerName")"
+  assert [ ${#stderr_lines[@]} -eq 5 ]
+}
+
+@test "run: With an image having all warnings shows warnings without prompt" {
+  containerName="test-container-all-warnings"
+  image="$(build_image_with_all_warnings)"
+
+  create_image_container "$image" "$containerName"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run --container "$containerName" true
+
+  assert_failure
+  assert [ ${#lines[@]} -eq 0 ]
+
+  lines=("${stderr_lines[@]}")
+  assert_line --index 0 "$(warning_image_intro "$image")"
+  assert_line --index 1 --regexp "^[[:blank:]]*$(warning_non_toolbx_image)$"
+  assert_line --index 2 --regexp "^[[:blank:]]*$(warning_ld_preload_image)$"
+  assert_line --index 3 --regexp "^[[:blank:]]*$(warning_entrypoint_image)$"
+  assert_line --index 4 ""
+  assert_line --index 5 "$(warning_image_outro)"
+  assert_line --index 6 "$(failed_start_error_message "$containerName")"
+  assert [ ${#stderr_lines[@]} -eq 7 ]
+}

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -39,6 +39,47 @@ readonly TOOLBX="${TOOLBX:-$(command -v toolbox)}"
 readonly TOOLBX_TEST_SYSTEM_TAGS_ALL="arch-fedora,commands-options,custom-image,runtime-environment,ubuntu"
 readonly TOOLBX_TEST_SYSTEM_TAGS="${TOOLBX_TEST_SYSTEM_TAGS:-$TOOLBX_TEST_SYSTEM_TAGS_ALL}"
 
+# Common test messages (used across multiple test suites)
+export MSG_CONFIRMATION_PROMPT="Continue anyway? [y/N]: "
+
+# Helper functions for generating common messages
+function created_container_message() {
+  local container_name="$1"
+  echo "Created container: $container_name"
+}
+
+function enter_with_message() {
+  local container_name="$1"
+  echo "Enter with: toolbox enter $container_name"
+}
+
+function failed_start_error_message() {
+  local container_name="$1"
+  echo "Error: failed to start container $container_name"
+}
+
+# Helper functions for generating image warning messages
+function warning_image_intro() {
+  local image="$1"
+  echo "Image $image has compatibility issues with Toolbx:"
+}
+
+function warning_image_outro() {
+  echo "Containers using incompatible images may not work as expected or may fail to start at all."
+}
+
+function warning_non_toolbx_image() {
+  echo "Warning: image is not a Toolbx image"
+}
+
+function warning_ld_preload_image() {
+  echo "Warning: image has the LD_PRELOAD environment variable set"
+}
+
+function warning_entrypoint_image() {
+  echo "Warning: image has a pre-defined entrypoint"
+}
+
 # Images
 declare -Ag IMAGES=([arch]="quay.io/toolbx/arch-toolbox" \
                    [busybox]="quay.io/toolbox_tests/busybox" \
@@ -254,6 +295,55 @@ function build_image_without_name() {
   echo "${lines[0]}"
 }
 
+# Generic helper function to build test images with custom Containerfile content
+#
+# Parameters
+# ==========
+# - image_name - Used as part of the image name
+# - containerfile_content - Complete Containerfile content to build the image
+#
+# The function creates a temporary Containerfile with the provided content,
+# builds the image using Podman, and returns the full image name that was built.
+function _build_test_image_generic() {
+  local image_name="$1"
+  local containerfile_content="$2"
+
+  local image_name_full="localhost/${image_name}:test-$$"
+
+  echo -e "$containerfile_content" > "$BATS_TEST_TMPDIR"/Containerfile
+
+  run podman build --quiet --tag "$image_name_full" "$BATS_TEST_TMPDIR"
+
+  assert_success
+  assert_line --index 0 --regexp "^[a-f0-9]{64}$"
+
+  # shellcheck disable=SC2154
+  assert [ ${#lines[@]} -eq 1 ]
+
+  rm -f "$BATS_TEST_TMPDIR"/Containerfile
+
+  echo "$image_name_full"
+}
+
+
+function build_non_toolbx_image() {
+  _build_test_image_generic "non-toolbx" "FROM scratch\n\nLABEL test=\"non-toolbx\""
+}
+
+
+function build_image_with_ld_preload() {
+  _build_test_image_generic "ld-preload" "FROM scratch\n\nENV LD_PRELOAD=foobar.so\n\nLABEL com.github.containers.toolbox=true"
+}
+
+
+function build_image_with_entrypoint() {
+  _build_test_image_generic "entrypoint" "FROM scratch\n\nENTRYPOINT [\"/bin/sh\", \"-c\", \"echo 'Hello, World!'\"]\n\nLABEL com.github.containers.toolbox=true"
+}
+
+
+function build_image_with_all_warnings() {
+  _build_test_image_generic "all-warnings" "FROM scratch\n\nENV LD_PRELOAD=foobar.so\n\nENTRYPOINT [\"/bin/sh\", \"-c\", \"echo 'Multiple warnings!'\"]\n\nLABEL test=\"all-warnings\""
+}
 
 function check_bats_version() {
     local required_version
@@ -419,6 +509,24 @@ function create_default_container() {
 
   "$TOOLBX" --assumeyes create >/dev/null \
     || fail "Toolbx couldn't create default container"
+}
+
+
+# Creates a container with specific name and image
+#
+# Parameters:
+# ===========
+# - image - name of the image
+# - container_name - name of the container
+function create_image_container() {
+  local image
+  local container_name
+
+  image="$1"
+  container_name="$2"
+
+  "$TOOLBX" --assumeyes create --container "${container_name}" --image "${image}" >/dev/null \
+    || fail "Toolbx couldn't create container '$container_name'"
 }
 
 


### PR DESCRIPTION
As mentioned in https://github.com/containers/toolbox/issues/1622, not all images are guaranteed to work with Toolbx. Therefore, every Toolbx verified image contains specific labels (`com.github.containers.toolbox="true"` or `com.github.debarshiray.toolbox="true"`), which means that the image was previously tested with Toolbx.

In this PR, the detection of usage of non-Toolbx images has been added to the `create`, `run`, and `enter` commands. If such an image is detected, the user is prompted with a message like:

```
$ toolbox create --image foo/bar:123 cont_foo_bar_123
Image 'foo/bar:123' is not a Toolbx image and may not work correctly (see https://containertoolbx.org/doc/). Continue anyway? [y/N]: 
...
```

Continuing may lead to an error while opening the container.