### PR TITLE
cmd/initContainer: Use configuration file for 'p11-kit server' socket

### DIFF
--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -610,10 +610,11 @@ func configurePKCS11(targetUser *user.User) error {
 	}
 
 	var builder strings.Builder
-	builder.WriteString("# Written by Toolbx\n")
-	builder.WriteString("# https://containertoolbx.org/\n")
-	builder.WriteString("\n")
-	builder.WriteString("module: p11-kit-client.so\n")
+	fmt.Fprintf(&builder, "# Written by Toolbx\n")
+	fmt.Fprintf(&builder, "# https://containertoolbx.org/\n")
+	fmt.Fprintf(&builder, "\n")
+	fmt.Fprintf(&builder, "module: p11-kit-client.so\n")
+	fmt.Fprintf(&builder, "server-address: unix:path=%s\n", serverSocket)
 
 	pkcs11ConfigString := builder.String()
 	pkcs11ConfigBytes := []byte(pkcs11ConfigString)


### PR DESCRIPTION
When a Toolbx container is set up to use the `p11-kit-client.so` PKCS #&NoBreak;11 module instead of the usual `p11-kit-trust.so` module, the location of the local file system socket used by the `p11-kit server` running on the host must be specified inside the container.  So far, this was being done through the `P11_KIT_SERVER_ADDRESS` environment variable [1].

Unfortunately, the environment variable has a tendency to go missing within child sessions started by `sshd(8)`, `su(1)`, `sudo(8)`, etc..

It's now possible to specify the location of the socket using a configuration file in the `/etc/pkcs11/modules` directory [2,3].  This is better because configuration files inherently persist across sessions, and won't go missing like the environment variable.

The `P11_KIT_SERVER_ADDRESS` environment variable will continue to be supported for older p11-kit versions.

[1] https://p11-glue.github.io/p11-glue/p11-kit/manual/p11-kit.html

[2] https://p11-glue.github.io/p11-glue/p11-kit/manual/pkcs11-conf.html

[3] https://github.com/p11-glue/p11-kit/pull/707
    https://github.com/p11-glue/p11-kit/issues/706

https://github.com/containers/toolbox/issues/626
https://github.com/containers/toolbox/issues/1661
https://github.com/containers/toolbox/issues/1674