### PR TITLE
test/system: Require Bats >= 1.10.0 for all tests

### DIFF
--- a/test/system/001-version.bats
+++ b/test/system/001-version.bats
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers.bash'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
 }
 
 @test "version: Check version using option --version" {

--- a/test/system/103-container.bats
+++ b/test/system/103-container.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2024 Red Hat, Inc.
+# Copyright © 2021 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
 }
 

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
   pushd "$HOME" || return 1
 }

--- a/test/system/105-enter.bats
+++ b/test/system/105-enter.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2024 Red Hat, Inc.
+# Copyright © 2021 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
 }
 

--- a/test/system/106-rm.bats
+++ b/test/system/106-rm.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2024 Red Hat, Inc.
+# Copyright © 2021 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
 }
 

--- a/test/system/107-rmi.bats
+++ b/test/system/107-rmi.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2021 – 2024 Red Hat, Inc.
+# Copyright © 2021 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
 }
 

--- a/test/system/108-completion.bats
+++ b/test/system/108-completion.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2023 – 2024 Red Hat, Inc.
+# Copyright © 2023 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
 }
 
 @test "completion: Smoke test with 'bash'" {

--- a/test/system/501-create.bats
+++ b/test/system/501-create.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2024 Red Hat, Inc.
+# Copyright © 2024 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
   pushd "$HOME" || return 1
 }

--- a/test/system/504-run.bats
+++ b/test/system/504-run.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2024 Red Hat, Inc.
+# Copyright © 2024 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
   pushd "$HOME" || return 1
 }

--- a/test/system/505-enter.bats
+++ b/test/system/505-enter.bats
@@ -1,6 +1,6 @@
 # shellcheck shell=bats
 #
-# Copyright © 2024 Red Hat, Inc.
+# Copyright © 2024 – 2025 Red Hat, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ load 'libs/bats-assert/load'
 load 'libs/helpers'
 
 setup() {
-  bats_require_minimum_version 1.8.0
+  bats_require_minimum_version 1.10.0
   cleanup_all
   pushd "$HOME" || return 1
 }

--- a/test/system/setup_suite.bash
+++ b/test/system/setup_suite.bash
@@ -24,7 +24,7 @@ else
 fi
 
 setup_suite() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   echo "# test suite: Set up" >&3
 
   if $missing_dependencies; then
@@ -72,7 +72,7 @@ setup_suite() {
 }
 
 teardown_suite() {
-  bats_require_minimum_version 1.7.0
+  bats_require_minimum_version 1.10.0
   echo "# test suite: Tear down" >&3
 
   if $missing_dependencies; then


### PR DESCRIPTION
Commit 87eaeea6f0c2b245 already added a dependency on Bats >= 1.10.0, and it's used on all the operating systems where the tests are run by the CI.  Therefore, there's no easy and practical way to ensure that a subset of the tests keep working with Bats < 1.10.0.