### PR TITLE
Create /run/.toolbxenv file

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -43,7 +43,7 @@ be accessed by the container at /run/host. The container has access to the
 host's Kerberos credentials cache if it's configured to use KCM caches.
 
 A Toolbx container can be identified by the `com.github.containers.toolbox`
-label or the `/run/.toolboxenv` file.
+label or the `/run/.toolbxenv` file.
 
 The entry point of a Toolbx container is the `toolbox init-container` command
 which plays a role in setting up the container, along with the options passed

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -47,7 +47,7 @@ if [ -f /run/ostree-booted ] \
 fi
 
 if [ -f /run/.containerenv ] \
-   && [ -f /run/.toolboxenv ]; then
+   && [ -f /run/.toolbxenv ]; then
     [ "${BASH_VERSION:-}" != "" ] && PS1=$(printf "\[\033[35m\]⬢ \[\033[0m\]%s" "[\u@\h \W]\\$ ")
     [ "${ZSH_VERSION:-}" != "" ] && PS1=$(printf "\033[35m⬢ \033[0m%s" "[%n@%m]%~%# ")
 

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -163,7 +163,7 @@ func initContainer(cmd *cobra.Command, args []string) error {
 
 	utils.EnsureXdgRuntimeDirIsSet(initContainerFlags.uid)
 
-	logrus.Debug("Creating /run/.toolboxenv")
+	logrus.Debug("Creating legacy /run/.toolboxenv")
 
 	toolboxEnvFile, err := os.Create("/run/.toolboxenv")
 	if err != nil {
@@ -171,6 +171,15 @@ func initContainer(cmd *cobra.Command, args []string) error {
 	}
 
 	defer toolboxEnvFile.Close()
+
+	logrus.Debug("Creating /run/.toolbxenv")
+
+	toolbxEnvFile, err := os.Create("/run/.toolbxenv")
+	if err != nil {
+		return errors.New("failed to create /run/.toolbxenv")
+	}
+
+	defer toolbxEnvFile.Close()
 
 	if toolbxDelayEntryPoint, ok := getDelayEntryPoint(); ok {
 		delayString := toolbxDelayEntryPoint.String()

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -765,7 +765,7 @@ func IsInsideContainer() bool {
 }
 
 func IsInsideToolboxContainer() bool {
-	return PathExists("/run/.toolboxenv")
+	return PathExists("/run/.toolbxenv") || PathExists("/run/.toolboxenv")
 }
 
 // ResolveContainerAndImageNames takes care of standardizing names of containers and images.

--- a/test/system/104-run.bats
+++ b/test/system/104-run.bats
@@ -220,10 +220,20 @@ teardown() {
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
-@test "run: Ensure that /run/.toolboxenv exists" {
+@test "run: Ensure that legacy /run/.toolboxenv exists" {
   create_default_container
 
   run --keep-empty-lines --separate-stderr "$TOOLBX" run test -f /run/.toolboxenv
+
+  assert_success
+  assert [ ${#lines[@]} -eq 0 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+}
+
+@test "run: Ensure that /run/.toolbxenv exists" {
+  create_default_container
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" run test -f /run/.toolbxenv
 
   assert_success
   assert [ ${#lines[@]} -eq 0 ]


### PR DESCRIPTION
It's difficult to explain to people integrating with toolbx why you have to look at `/run/.toolboxenv` to see if you're in a toolbx :)

Create this, but leave `/run/.toolboxenv` around as a legacy file as well.  Updates any references to the short name.