### PR TITLE
pkg/term, pkg/utils: Stop the test functions if they fail their set-up

### DIFF
--- a/src/pkg/term/term_test.go
+++ b/src/pkg/term/term_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2023 – 2024 Red Hat Inc.
+ * Copyright © 2023 – 2025 Red Hat Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,13 +21,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
 func TestIsTerminalTemporaryFile(t *testing.T) {
 	dir := t.TempDir()
 	file, err := os.CreateTemp(dir, "TestIsTerminalTempFile")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	fileName := file.Name()
 	defer os.Remove(fileName)
 	defer file.Close()
@@ -38,7 +39,7 @@ func TestIsTerminalTemporaryFile(t *testing.T) {
 
 func TestIsTerminalTerminal(t *testing.T) {
 	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 
 	ok := IsTerminal(file)
@@ -47,7 +48,7 @@ func TestIsTerminalTerminal(t *testing.T) {
 
 func TestNewStateFromDifferent(t *testing.T) {
 	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 
 	oldState, err := GetState(file)
@@ -66,7 +67,7 @@ func TestNewStateFromDifferent(t *testing.T) {
 
 func TestNewStateFromNOP(t *testing.T) {
 	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 
 	oldState, err := GetState(file)
@@ -85,7 +86,7 @@ func TestNewStateFromNOP(t *testing.T) {
 
 func TestSetStateDifferent(t *testing.T) {
 	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 
 	oldState, err := GetState(file)
@@ -118,7 +119,7 @@ func TestSetStateDifferent(t *testing.T) {
 
 func TestSetStateNOP(t *testing.T) {
 	file, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer file.Close()
 
 	oldState, err := GetState(file)

--- a/src/pkg/utils/utils_test.go
+++ b/src/pkg/utils/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImageReferenceCanBeID(t *testing.T) {
@@ -370,7 +371,7 @@ func TestPathExistsDoesNotExist(t *testing.T) {
 
 func TestPathExistsExecutable(t *testing.T) {
 	path, err := os.Executable()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	exists := PathExists(path)
 	assert.True(t, exists)
 }


### PR DESCRIPTION
Currently, if for some reason the set-up steps of a test function fails,
like opening `/dev/ptmx`, it continues to run and encounters subsequent
failures:
```
  --- FAIL: TestIsTerminalTerminal (0.00s)
      term_test.go:41:
                  Error Trace: toolbox/src/pkg/term/term_test.go:41
                  Error:       Received unexpected error:
                               open /dev/ptmx: not a directory
                  Test:        TestIsTerminalTerminal
      term_test.go:45:
                  Error Trace: toolbox/src/pkg/term/term_test.go:45
                  Error:       Should be true
                  Test:	       TestIsTerminalTerminal
  FAIL
  FAIL  github.com/containers/toolbox/pkg/term  0.004s
```

The test functions are only meaningful if the set-up succeeds, and
continuing in the case of a failure only leads to noise.  Therefore,
stop executing them if they fail their set-up.

This changes the previous failure to:
```
  --- FAIL: TestIsTerminalTerminal (0.00s)
      term_test.go:42:
                  Error Trace: toolbox/src/pkg/term/term_test.go:42
                  Error:       Received unexpected error:
                               open /dev/ptmx: not a directory
                  Test:        TestIsTerminalTerminal
  FAIL
  FAIL  github.com/containers/toolbox/pkg/term  0.003s
```

Fallout from the following:
  * 3d5499366aa18ad676ae31698f0d1a4f9f1ce35b
  * aca4e9dd2626dcd2e822b311712c27ea5bd0a22a
  * e9e77fb0696f2d6f375798b6752008edf1f4762a