### PR TITLE
cmd/create: keep host supplementary groups with --group-add keep-groups

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -441,8 +441,8 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		"--dns", "none",
 	}
 
-        // Add '--group-add keep-groups' when available, so the container inherits
-        // the host user's supplementary groups (eg. vboxusers).
+	// Add '--group-add keep-groups' when available, so the container inherits
+	// the host user's supplementary groups (eg. vboxusers).
 	createArgs = append(createArgs, keepGroups...)
 	createArgs = append(createArgs, toolbxDelayEntryPointEnv...)
 	createArgs = append(createArgs, toolbxFailEntryPointEnv...)


### PR DESCRIPTION
Toolbx currently fails to create or start containers on hosts where the user has group-only access to device nodes under /dev, for example when VirtualBox creates /dev/vboxusb/* owned by root:vboxusers with 0750 permissions. In this situation a rootless Toolbx container inherits /dev from the host, the /dev/vboxusb directory is visible, but the container process has no group membership for vboxusers. When the OCI runtime walks /dev it eventually tries to open or create device nodes under /dev/vboxusb and fails with an OCI permission denied error, so `toolbox enter` aborts with "failed to start container".

This behaviour is described in #1348, which generalizes the problem to any directory under /dev with 0750 permissions where the user only has access via a supplementary group (eg. dialout, vboxusers, docker). It is also the root cause behind reports like #1297 and the older #247, and matches similar issues seen with rootless Podman and VirtualBox in other projects (distrobox, crun, Debian bug reports).

Rootless Podman already has a mechanism to address this class of problems: passing `--group-add keep-groups` to `podman create` or `podman run` tells Podman to keep the caller's supplementary groups instead of dropping them during container setup. The Podman documentation explicitly recommends this flag for cases where device access is granted only via group membership and notes that otherwise accessing such devices from rootless containers will fail with permission errors.

This patch wires that mechanism into Toolbx by adding `--group-add keep-groups` to the `podman create` invocation used by the `toolbox create` command when running as a non-root user and when the Podman version is >= 3.2.0, which is when the flag became available. The call is gated through the existing podman.CheckVersion helper, so older Podman versions are not affected and keep the previous behaviour.

With this change, the OCI runtime sees the same supplementary groups as the host process, so a user who is a member of vboxusers (or dialout, docker, etc.) can access devices that are only group readable from inside a rootless Toolbx container. On systems with VirtualBox installed this fixes errors of the form:

  crun: creating `/dev/vboxusb/00x/00y`: openat2 `dev/vboxusb`:
  Permission denied: OCI permission denied

when entering a freshly created Toolbx container.

This patch intentionally does not change how /dev is mounted into the container and does not implement the more invasive /dev filtering approach discussed in #1348. It is a minimal, backwards compatible improvement that fixes the common VirtualBox and other group-only device cases by leveraging Podman's existing `--group-add keep-groups` support.

Tests:

 * On Fedora 42 with VirtualBox installed and the user in the vboxusers group, verified that `toolbox create` logs the `podman create` command including `--group-add keep-groups`.
 * Confirmed that `toolbox enter` succeeds for a new container where it previously failed with an OCI permission denied on /dev/vboxusb.
 * Verified that behaviour is unchanged on a system without VirtualBox and that the flag is not added when running as root.

Fixes: #1348
Related: #1297, #247