### PR TITLE
fix(cmd): ensure rm and rmi exit with errors on failure

### DIFF
--- a/src/cmd/rm.go
+++ b/src/cmd/rm.go
@@ -89,22 +89,31 @@ func rm(cmd *cobra.Command, args []string) error {
 			return errors.New(errMsg)
 		}
 
+		var attemptFailed bool
+
 		for _, container := range args {
 			containerObj, err := podman.InspectContainer(container)
 			if err != nil {
+				attemptFailed = true
 				fmt.Fprintf(os.Stderr, "Error: failed to inspect container %s\n", container)
 				continue
 			}
 
 			if !containerObj.IsToolbx() {
+				attemptFailed = true
 				fmt.Fprintf(os.Stderr, "Error: %s is not a Toolbx container\n", container)
 				continue
 			}
 
 			if err := podman.RemoveContainer(container, rmFlags.forceDelete); err != nil {
+				attemptFailed = true
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 				continue
 			}
+		}
+
+		if attemptFailed {
+			return errors.New("failed to remove one or more containers")
 		}
 	}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -89,16 +89,24 @@ func rmi(cmd *cobra.Command, args []string) error {
 			return errors.New(errMsg)
 		}
 
+		var attemptFailed bool
+
 		for _, image := range args {
 			if _, err := podman.IsToolboxImage(image); err != nil {
+				attemptFailed = true
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 				continue
 			}
 
 			if err := podman.RemoveImage(image, rmiFlags.forceDelete); err != nil {
+				attemptFailed = true
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 				continue
 			}
+		}
+
+		if attemptFailed {
+			return errors.New("failed to remove one or more images")
 		}
 	}
 


### PR DESCRIPTION
This PR ensures that `toolbox rm` and `toolbox rmi` exit with a non-zero status code if any error occurs during the removal process.

Previously, these commands would print an error message but continue execution and exit with 0, which could be misleading for scripts and automation.