### PR TITLE
Include run in list of common commands

### DIFF
--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -387,6 +387,7 @@ func getUsageForCommonCommands() string {
 	var builder strings.Builder
 	builder.WriteString("create    Create a new Toolbx container\n")
 	builder.WriteString("enter     Enter an existing Toolbx container\n")
+	builder.WriteString("run       Run a command in an existing Toolbx container\n")
 	builder.WriteString("list      List all existing Toolbx containers and images\n")
 
 	usage := builder.String()

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -42,7 +42,8 @@ teardown_file() {
   assert_line --index 0 "Error: missing command"
   assert_line --index 2 "create    Create a new Toolbx container"
   assert_line --index 3 "enter     Enter an existing Toolbx container"
-  assert_line --index 4 "list      List all existing Toolbx containers and images"
+  assert_line --index 4 "run       Run a command in an existing Toolbx container"
+  assert_line --index 5 "list      List all existing Toolbx containers and images"
   assert_line --index 6 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 7 ]
 }
@@ -74,8 +75,9 @@ teardown_file() {
   assert_line --index 2 "Common commands are:"
   assert_line --index 3 "create    Create a new Toolbx container"
   assert_line --index 4 "enter     Enter an existing Toolbx container"
-  assert_line --index 5 "list      List all existing Toolbx containers and images"
-  assert_line --index 7 "Go to https://containertoolbx.org/ for further information."
+  assert_line --index 5 "run       Run a command in an existing Toolbx container"
+  assert_line --index 6 "list      List all existing Toolbx containers and images"
+  assert_line --index 8 "Go to https://containertoolbx.org/ for further information."
   assert [ ${#lines[@]} -eq 8 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
@@ -107,8 +109,9 @@ teardown_file() {
   assert_line --index 2 "Common commands are:"
   assert_line --index 3 "create    Create a new Toolbx container"
   assert_line --index 4 "enter     Enter an existing Toolbx container"
-  assert_line --index 5 "list      List all existing Toolbx containers and images"
-  assert_line --index 7 "Go to https://containertoolbx.org/ for further information."
+  assert_line --index 5 "run       Run a command in an existing Toolbx container"
+  assert_line --index 6 "list      List all existing Toolbx containers and images"
+  assert_line --index 8 "Go to https://containertoolbx.org/ for further information."
   assert [ ${#lines[@]} -eq 8 ]
 
   # shellcheck disable=SC2154

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -45,7 +45,7 @@ teardown_file() {
   assert_line --index 4 "run       Run a command in an existing Toolbx container"
   assert_line --index 5 "list      List all existing Toolbx containers and images"
   assert_line --index 6 "Run 'toolbox --help' for usage."
-  assert [ ${#stderr_lines[@]} -eq 7 ]
+  assert [ ${#stderr_lines[@]} -eq 8 ]
 }
 
 @test "help: Command 'help'" {
@@ -78,7 +78,7 @@ teardown_file() {
   assert_line --index 5 "run       Run a command in an existing Toolbx container"
   assert_line --index 6 "list      List all existing Toolbx containers and images"
   assert_line --index 8 "Go to https://containertoolbx.org/ for further information."
-  assert [ ${#lines[@]} -eq 8 ]
+  assert [ ${#lines[@]} -eq 9 ]
   assert [ ${#stderr_lines[@]} -eq 0 ]
 }
 
@@ -112,7 +112,7 @@ teardown_file() {
   assert_line --index 5 "run       Run a command in an existing Toolbx container"
   assert_line --index 6 "list      List all existing Toolbx containers and images"
   assert_line --index 8 "Go to https://containertoolbx.org/ for further information."
-  assert [ ${#lines[@]} -eq 8 ]
+  assert [ ${#lines[@]} -eq 9 ]
 
   # shellcheck disable=SC2154
   assert [ ${#stderr_lines[@]} -eq 0 ]

--- a/test/system/002-help.bats
+++ b/test/system/002-help.bats
@@ -44,7 +44,7 @@ teardown_file() {
   assert_line --index 3 "enter     Enter an existing Toolbx container"
   assert_line --index 4 "run       Run a command in an existing Toolbx container"
   assert_line --index 5 "list      List all existing Toolbx containers and images"
-  assert_line --index 6 "Run 'toolbox --help' for usage."
+  assert_line --index 7 "Run 'toolbox --help' for usage."
   assert [ ${#stderr_lines[@]} -eq 8 ]
 }
 


### PR DESCRIPTION
The idea was to make `toolbox run` a little more discoverable when running just `toolbox`; for a while I was under the assumption that toolbox only supported create, enter, and list (knowing about run earlier would have solved the major reason I reached for distrobox)

I know the help document covers all available commands, but it was busy enough that I glazed over the commands section at the end.

### Tradeoffs & Concerns
I am a little hesitant to include too many things in commonCommands at the risk of users glazing over the output (like myself). A short list of three commands covering most people's workflow might be a sweet spot and moving discoverability of `toolbox run` et al. somewhere else might be more prudent; perhaps just mentioning a full list of commands can be found elsewhere would be enough.