### PR TITLE
[release-0.0.99.5] test/system: Fix Python resolver to use the right family for IPv4

### DIFF
--- a/test/system/203-network.bats
+++ b/test/system/203-network.bats
@@ -22,9 +22,8 @@ load 'libs/helpers'
 readonly RESOLVER_PYTHON3='\
 import socket; \
 import sys; \
-family = socket.AddressFamily.AF_INET if sys.argv[1] == "A" else 0; \
-family = socket.AddressFamily.AF_INET6 if sys.argv[1] == "AAAA" else 0; \
-addr = socket.getaddrinfo(sys.argv[2], None, family, socket.SocketKind.SOCK_RAW)[0][4][0]; \
+family = {"A": socket.AddressFamily.AF_INET, "AAAA": socket.AddressFamily.AF_INET6}; \
+addr = socket.getaddrinfo(sys.argv[2], None, family[sys.argv[1]], socket.SocketKind.SOCK_RAW)[0][4][0]; \
 print(addr)'
 
 # shellcheck disable=SC2016


### PR DESCRIPTION
The existing code was overwriting the address family from
`socket.AddressFamily.AF_INET` to `0`, when an IPv4 address was requested by
setting `sys.argv[1]` to `A`.

Fallout from 5bac0ba4c8bad16b3863022e81f37e54b2eadf36

https://github.com/containers/toolbox/pull/1598
