### PR TITLE
cmd: fallback to parsing `getent passwd` output when $SHELL is not set

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -404,9 +404,9 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 
 	logLevelString := podman.LogLevel.String()
 
-	userShell := os.Getenv("SHELL")
-	if userShell == "" {
-		return errors.New("failed to get the current user's login shell")
+	userShell, err := getCurrentUserShell()
+	if err != nil {
+		return err
 	}
 
 	entryPoint := []string{

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -114,9 +114,9 @@ func enter(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	userShell := os.Getenv("SHELL")
-	if userShell == "" {
-		return errors.New("failed to get the current user's login shell")
+	userShell, err := getCurrentUserShell()
+	if err != nil {
+		return err
 	}
 
 	command := []string{userShell, "-l"}

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -61,9 +61,9 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	userShell := os.Getenv("SHELL")
-	if userShell == "" {
-		return errors.New("failed to get the current user's login shell")
+	userShell, err := getCurrentUserShell()
+	if err != nil {
+		return err
 	}
 
 	command := []string{userShell, "-l"}

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -381,6 +382,44 @@ func getCurrentUserHomeDir() string {
 	logrus.Debug("Using user.Current() instead")
 
 	return currentUser.HomeDir
+}
+
+func getCurrentUserShell() (string, error) {
+	if currentUser == nil {
+		panic("current user unknown")
+	}
+
+	if userShell := os.Getenv("SHELL"); userShell != "" {
+		return userShell, nil
+	}
+
+	logrus.Debug("Getting the current user's login shell: failed to read SHELL")
+	logrus.Debug("Using 'getent passwd' instead")
+
+	var stderr strings.Builder
+	var stdout strings.Builder
+
+	if err := shell.Run("getent", nil, &stdout, &stderr, "passwd", currentUser.Uid); err != nil {
+		errString := stderr.String()
+		logrus.Debugf("Getting the current user's login shell failed: %s", errString)
+		return "", fmt.Errorf("failed to get the current user's login shell: %w", err)
+	}
+
+	output := stdout.String()
+	passwdLine := strings.TrimSpace(output)
+	if len(passwdLine) == 0 {
+		return "", errors.New("failed to get the current user's login shell: no getent(1) output")
+	}
+
+	passwdLineParts := strings.Split(passwdLine, ":")
+	passwdLinePartsCount := len(passwdLineParts)
+	if passwdLinePartsCount != 7 {
+		logrus.Debugf("Getting the current user's login shell: failed to parse getent(1) output: %s",
+			passwdLine)
+		return "", errors.New("failed to get the current user's login shell: invalid getent(1) output")
+	}
+
+	return passwdLineParts[passwdLinePartsCount-1], nil
 }
 
 func getUsageForCommonCommands() string {

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -60,6 +60,35 @@ teardown() {
   assert_output "true"
 }
 
+@test "create: Smoke test with SHELL unset" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  pull_default_image
+  unset SHELL
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create
+
+  assert_success
+  assert_line --index 0 "Created container: $default_container"
+  assert_line --index 1 "Enter with: toolbox enter"
+  assert [ ${#lines[@]} -eq 2 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$default_container"
+
+  run podman inspect \
+        --format '{{index .Config.Labels "com.github.containers.toolbox"}}' \
+        --type container \
+        "$default_container"
+
+  assert_success
+  assert_output "true"
+}
+
 @test "create: With a custom name (using option --container)" {
   pull_default_image
 


### PR DESCRIPTION
As suggested in #1615, this PR just adds a fallback if $SHELL is not set for whatever reason.

Not very comfortable with Go, but hopefully the code is alright. Happy to make any changes anyway. And let me know if you want some tests added, I just wasn't sure entirely where to add that.