### PR TITLE
CODE-OF-CONDUCT.md, SECURITY.md: Update URLs

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,3 +1,3 @@
 ## The Toolbx Project Community Code of Conduct
 
-The Toolbx project follows the [Containers Community Code of Conduct](https://github.com/containers/common/blob/main/CODE-OF-CONDUCT.md).
+The Toolbx project follows the [Containers Community Code of Conduct](https://github.com/containers/container-libs/blob/main/CODE-OF-CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,5 @@
 ## Security and Disclosure Information Policy for the Toolbx Project
 
 The Toolbx Project follows the
-[Security and Disclosure Information Policy](https://github.com/containers/common/blob/main/SECURITY.md)
+[Security and Disclosure Information Policy](https://github.com/containers/container-libs/blob/main/SECURITY.md)
 for the Containers Projects.


### PR DESCRIPTION
The github.com/containers/common project, along with two others, was merged into a monorepository at github.com/containers/container-libs on 26th August 2025 [1].

[1] containers/common commit fcc14d28ac1185c3
    https://github.com/containers/common/commit/fcc14d28ac1185c3
    https://github.com/containers/common/pull/2520
    https://blog.podman.io/2025/08/upcoming-migration-of-three-containers-repositories-to-monorepo/

https://github.com/containers/toolbox/issues/1763