### PR TITLE
Get the config directory from $XDG_CONFIG_HOME if it is set

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -4,7 +4,7 @@
 [ "${BASH_VERSION:-}" != "" ] || [ "${ZSH_VERSION:-}" != "" ] || return 0
 [ "$PS1" != "" ] || return 0
 
-toolbox_config="$HOME/.config/toolbox"
+toolbox_config="${XDG_CONFIG_HOME:-$HOME/.config}/toolbox"
 host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 


### PR DESCRIPTION
Closes #1766

If the $XDG_CONFIG_HOME environment variable is set, we should use it instead of always falling back to $HOME/.config