### PR TITLE
cmd/create: stop bind-mounting the host /dev , fixing VirtualBox issues

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -459,7 +459,6 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		"--userns", usernsArg,
 		"--user", "root:root",
 		"--volume", "/:/run/host:rslave",
-		"--volume", "/dev:/dev:rslave",
 		"--volume", dbusSystemSocketMountArg,
 		"--volume", homeDirMountArg,
 		"--volume", toolboxPathMountArg,

--- a/src/cmd/initContainer.go
+++ b/src/cmd/initContainer.go
@@ -73,6 +73,26 @@ var (
 		{"/var/log/journal", "/run/host/var/log/journal", ""},
 		{"/var/mnt", "/run/host/var/mnt", "rslave"},
 	}
+
+	initContainerIgnoredHostDevices = map[string]struct{}{
+		"console": {},
+		"core":    {},
+		"fd":      {},
+		"full":    {},
+		"kmsg":    {},
+		"mqueue":  {},
+		"null":    {},
+		"ptmx":    {},
+		"pts":     {},
+		"random":  {},
+		"shm":     {},
+		"stderr":  {},
+		"stdin":   {},
+		"stdout":  {},
+		"tty":     {},
+		"urandom": {},
+		"zero":    {},
+	}
 )
 
 var initContainerCmd = &cobra.Command{
@@ -262,6 +282,8 @@ func initContainer(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	}
+
+	projectHostDevices()
 
 	if utils.PathExists("/sys/fs/selinux") {
 		if err := mountBind("/sys/fs/selinux", "/usr/share/empty", ""); err != nil {
@@ -1018,20 +1040,22 @@ func mountBind(containerPath, source, flags string) error {
 		if err := os.MkdirAll(containerPath, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", containerPath, err)
 		}
-	} else if fileMode.IsRegular() || fileMode&os.ModeSocket != 0 {
-		logrus.Debugf("Creating regular file %s", containerPath)
-
+	} else {
 		containerPathDir := filepath.Dir(containerPath)
 		if err := os.MkdirAll(containerPathDir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", containerPathDir, err)
 		}
 
-		containerPathFile, err := os.Create(containerPath)
-		if err != nil && !os.IsExist(err) {
-			return fmt.Errorf("failed to create regular file %s: %w", containerPath, err)
-		}
+		if !utils.PathExists(containerPath) {
+			logrus.Debugf("Creating file mount point %s", containerPath)
 
-		defer containerPathFile.Close()
+			containerPathFile, err := os.Create(containerPath)
+			if err != nil {
+				return fmt.Errorf("failed to create file mount point %s: %w", containerPath, err)
+			}
+
+			defer containerPathFile.Close()
+		}
 	}
 
 	logrus.Debugf("Binding %s to %s", containerPath, source)
@@ -1051,6 +1075,50 @@ func mountBind(containerPath, source, flags string) error {
 	}
 
 	return nil
+}
+
+func projectHostDevices() {
+	const hostDevices = "/run/host/dev"
+	const logPrefix = "Projecting host devices into the container"
+
+	logrus.Debugf("%s", logPrefix)
+
+	entries, err := os.ReadDir(hostDevices)
+	if err != nil {
+		logrus.Debugf("%s: failed to read %s: %s", logPrefix, hostDevices, err)
+		logrus.Debugf("%s: skipping", logPrefix)
+		return
+	}
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if _, ignored := initContainerIgnoredHostDevices[name]; ignored {
+			logrus.Debugf("%s: skipping runtime-managed path /dev/%s", logPrefix, name)
+			continue
+		}
+
+		source := filepath.Join(hostDevices, name)
+		fileInfo, err := os.Lstat(source)
+		if err != nil {
+			logrus.Debugf("%s: failed to lstat %s: %s", logPrefix, source, err)
+			continue
+		}
+
+		if fileInfo.Mode()&os.ModeSymlink != 0 {
+			logrus.Debugf("%s: skipping symbolic link %s", logPrefix, source)
+			continue
+		}
+
+		flags := ""
+		if fileInfo.IsDir() {
+			flags = "rslave"
+		}
+
+		containerPath := filepath.Join("/dev", name)
+		if err := mountBind(containerPath, source, flags); err != nil {
+			logrus.Debugf("%s: failed to bind %s to %s: %s", logPrefix, containerPath, source, err)
+		}
+	}
 }
 
 // redirectPath serves for creating symbolic links for crucial system

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -60,6 +60,26 @@ teardown() {
   assert_output "true"
 }
 
+@test "create: The host /dev is not bind-mounted into the container" {
+  local default_container
+  default_container="$(get_system_id)-toolbox-$(get_system_version)"
+
+  pull_default_image
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" create
+
+  assert_success
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run podman inspect \
+        --format '{{range .Mounts}}{{println .Destination}}{{end}}' \
+        --type container \
+        "$default_container"
+
+  assert_success
+  refute_line "/dev"
+}
+
 @test "create: Smoke test with SHELL unset" {
   local default_container
   default_container="$(get_system_id)-toolbox-$(get_system_version)"


### PR DESCRIPTION
Toolbx currently bind-mounts the host `/dev` wholesale into the container.

That breaks container startup on hosts where the user has group-only access to device
subtrees under `/dev`, for example VirtualBox's `/dev/vboxusb/*` owned by
`root:vboxusers` with `0750` permissions. In that situation the OCI runtime ends up
walking the host `/dev` during container startup and fails before the Toolbx container
can be entered.

Instead of trying to preserve host supplementary groups inside the container, this
change takes a different approach:

- stop bind-mounting the host `/dev` into the container during `toolbox create`
- let the container runtime provide the container's own `/dev`
- during `init-container`, project host devices from `/run/host/dev` into `/dev`
  on a best-effort basis
- skip runtime-managed pseudo devices such as `null`, `zero`, `urandom`, `tty`,
  `ptmx`, `pts`, `shm`, `stdin`, `stdout`, and `stderr`

This keeps the startup path away from the problematic host `/dev` bind mount while
preserving the existing Toolbx user model inside the container, including the current
`wheel`/`sudo` behaviour.

## Why this approach

The previous `keep-groups` direction fixes the startup failure, but it also changes
the container's user/group semantics and breaks existing expectations around
`wheel` and `sudo`.

This patch is intentionally narrower:

- it fixes the default goal of "Toolbx should still start on hosts with problematic
  `/dev` subtrees"
- it does not rely on inheriting host supplementary groups into the container
- it leaves the current Toolbx user setup unchanged

This is a startup fix, not a full host-device-access policy.

## Behavioural impact

With this change:

- Toolbx no longer bind-mounts the host `/dev` wholesale
- containers can be created and started on hosts where `/dev/vboxusb` exists and
  the user is in `vboxusers`
- `wheel` membership and `sudo` inside the container continue to work

This does **not** automatically grant usable access to VirtualBox USB device nodes
inside the container as an unprivileged user. The goal here is to prevent Toolbx from
failing to start in the first place.

## Tests

Manual checks on a host with:

- `/dev/vboxusb` present
- `/dev/vboxusb/*` owned by `root:vboxusers` with `0750`
- user in `vboxusers`

Verified that:

- `toolbox create` succeeds with this branch where the old `/dev` bind mount path
  was the problematic part
- the resulting container has no global `/dev` bind mount (`podman inspect` only
  shows `/dev/pts`)
- `groups` inside the container still shows the expected `wheel` membership
- `sudo id` inside the container still works
- Stuff like `/dev/urandom` still exists and is readable inside the container

Also added a system test that checks the host `/dev` is no longer bind-mounted
into the container.

## Related

Fixes: #1348
Related: #1297, #247
Superseeds: https://github.com/containers/toolbox/pull/1732
