### PR TITLE
cmd, pkg/podman: Turn Image into an interface

### DIFF
--- a/src/cmd/completion.go
+++ b/src/cmd/completion.go
@@ -150,12 +150,10 @@ func completionImageNames(cmd *cobra.Command, _ []string, _ string) ([]string, c
 	if images, err := podman.GetImages(true); err != nil {
 		logrus.Debugf("Getting all images failed: %s", err)
 	} else {
-		for _, image := range images {
-			if len(image.Names) != 1 {
-				panic("cannot complete unflattened Image")
-			}
-
-			imageNames = append(imageNames, image.Names[0])
+		for images.Next() {
+			image := images.Get()
+			name := image.Name()
+			imageNames = append(imageNames, name)
 		}
 	}
 
@@ -170,15 +168,12 @@ func completionImageNamesFiltered(_ *cobra.Command, args []string, _ string) ([]
 	if images, err := podman.GetImages(true); err != nil {
 		logrus.Debugf("Getting all images failed: %s", err)
 	} else {
-		for _, image := range images {
+		for images.Next() {
+			image := images.Get()
+			name := image.Name()
 			skip := false
-
-			if len(image.Names) != 1 {
-				panic("cannot complete unflattened Image")
-			}
-
 			for _, arg := range args {
-				if arg == image.Names[0] {
+				if arg == name {
 					skip = true
 					break
 				}
@@ -188,7 +183,7 @@ func completionImageNamesFiltered(_ *cobra.Command, args []string, _ string) ([]
 				continue
 			}
 
-			imageNames = append(imageNames, image.Names[0])
+			imageNames = append(imageNames, name)
 		}
 	}
 

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -140,10 +140,8 @@ func listOutput(images []podman.Image, containers *podman.Containers) {
 				panic("cannot list unflattened Image")
 			}
 
-			fmt.Fprintf(writer, "%s\t%s\t%s\n",
-				utils.ShortID(image.ID),
-				image.Names[0],
-				image.Created)
+			shortID := utils.ShortID(image.ID)
+			fmt.Fprintf(writer, "%s\t%s\t%s\n", shortID, image.Names[0], image.Created)
 		}
 
 		writer.Flush()
@@ -199,11 +197,15 @@ func listOutput(images []podman.Image, containers *podman.Containers) {
 			}
 
 			created := container.Created()
-			id := container.ID()
 			image := container.Image()
 			name := container.Name()
+
+			id := container.ID()
+			shortID := utils.ShortID(id)
+
 			status := container.Status()
-			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s", utils.ShortID(id), name, created, status, image)
+
+			fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s", shortID, name, created, status, image)
 
 			if term.IsTerminal(os.Stdout) {
 				fmt.Fprintf(writer, "%s", resetColor)

--- a/src/cmd/list.go
+++ b/src/cmd/list.go
@@ -81,7 +81,7 @@ func list(cmd *cobra.Command, args []string) error {
 		lsImages = false
 	}
 
-	var images []podman.Image
+	var images *podman.Images
 	var containers *podman.Containers
 	var err error
 
@@ -130,24 +130,26 @@ func listHelp(cmd *cobra.Command, args []string) {
 	}
 }
 
-func listOutput(images []podman.Image, containers *podman.Containers) {
-	if len(images) != 0 {
+func listOutput(images *podman.Images, containers *podman.Containers) {
+	if images.Len() != 0 {
 		writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintf(writer, "%s\t%s\t%s\n", "IMAGE ID", "IMAGE NAME", "CREATED")
 
-		for _, image := range images {
-			if len(image.Names) != 1 {
-				panic("cannot list unflattened Image")
-			}
+		for images.Next() {
+			image := images.Get()
+			created := image.Created()
+			name := image.Name()
 
-			shortID := utils.ShortID(image.ID)
-			fmt.Fprintf(writer, "%s\t%s\t%s\n", shortID, image.Names[0], image.Created)
+			id := image.ID()
+			shortID := utils.ShortID(id)
+
+			fmt.Fprintf(writer, "%s\t%s\t%s\n", shortID, name, created)
 		}
 
 		writer.Flush()
 	}
 
-	if len(images) != 0 && containers.Len() != 0 {
+	if images.Len() != 0 && containers.Len() != 0 {
 		fmt.Println()
 	}
 

--- a/src/cmd/rmi.go
+++ b/src/cmd/rmi.go
@@ -76,8 +76,9 @@ func rmi(cmd *cobra.Command, args []string) error {
 			return errors.New("failed to get images")
 		}
 
-		for _, image := range toolboxImages {
-			imageID := image.ID
+		for toolboxImages.Next() {
+			image := toolboxImages.Get()
+			imageID := image.ID()
 			if err := podman.RemoveImage(imageID, rmiFlags.forceDelete); err != nil {
 				fmt.Fprintf(os.Stderr, "Error: %s\n", err)
 				continue

--- a/src/meson.build
+++ b/src/meson.build
@@ -23,6 +23,8 @@ sources = files(
   'pkg/nvidia/nvidia.go',
   'pkg/podman/container.go',
   'pkg/podman/errors.go',
+  'pkg/podman/image.go',
+  'pkg/podman/imageImages_test.go',
   'pkg/podman/podman.go',
   'pkg/podman/containerInspect_test.go',
   'pkg/shell/shell.go',

--- a/src/pkg/podman/image.go
+++ b/src/pkg/podman/image.go
@@ -43,6 +43,8 @@ type imageImages struct {
 	names   []string
 }
 
+type imageSlice []imageImages
+
 func (images *Images) Get() Image {
 	if images == nil {
 		panic("called Images.Get() on a nil Images")
@@ -187,4 +189,18 @@ func (image *imageImages) UnmarshalJSON(data []byte) error {
 	image.labels = raw.Labels
 	image.names = raw.Names
 	return nil
+}
+
+func (images imageSlice) Len() int {
+	return len(images)
+}
+
+func (images imageSlice) Less(i, j int) bool {
+	nameI := images[i].Name()
+	nameJ := images[j].Name()
+	return nameI < nameJ
+}
+
+func (images imageSlice) Swap(i, j int) {
+	images[i], images[j] = images[j], images[i]
 }

--- a/src/pkg/podman/image.go
+++ b/src/pkg/podman/image.go
@@ -1,0 +1,190 @@
+/*
+ * Copyright © 2025 – 2026 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podman
+
+import (
+	"encoding/json"
+
+	"github.com/containers/toolbox/pkg/utils"
+)
+
+type Image interface {
+	Created() string
+	ID() string
+	IsToolbx() bool
+	Labels() map[string]string
+	Name() string
+	Names() []string
+}
+
+type Images struct {
+	data []imageImages
+	i    int
+}
+
+type imageImages struct {
+	created string
+	id      string
+	labels  map[string]string
+	names   []string
+}
+
+func (images *Images) Get() Image {
+	if images == nil {
+		panic("called Images.Get() on a nil Images")
+	}
+
+	if images.i < 1 {
+		panic("called Images.Get() without calling Images.Next()")
+	}
+
+	image := &images.data[images.i-1]
+	return image
+}
+
+func (images *Images) Len() int {
+	if images == nil {
+		return 0
+	}
+
+	return len(images.data)
+}
+
+func (images *Images) Next() bool {
+	if images == nil {
+		return false
+	}
+
+	available := images.i < len(images.data)
+	if available {
+		images.i++
+	}
+
+	return available
+}
+
+func (images *Images) Reset() {
+	if images == nil {
+		return
+	}
+
+	images.i = 0
+}
+
+func (image *imageImages) Created() string {
+	return image.created
+}
+
+func (image *imageImages) flattenNames(fillNameWithID bool) []imageImages {
+	var ret []imageImages
+
+	names := image.Names()
+	namesCount := len(names)
+	if namesCount == 0 {
+		flattenedImage := *image
+
+		if fillNameWithID {
+			id := image.ID()
+			shortID := utils.ShortID(id)
+			flattenedImage.names = []string{shortID}
+		} else {
+			flattenedImage.names = []string{"<none>"}
+		}
+
+		ret = []imageImages{flattenedImage}
+		return ret
+	}
+
+	ret = make([]imageImages, 0, namesCount)
+
+	for _, name := range names {
+		flattenedImage := *image
+		flattenedImage.names = []string{name}
+		ret = append(ret, flattenedImage)
+	}
+
+	return ret
+}
+
+func (image *imageImages) ID() string {
+	return image.id
+}
+
+func (image *imageImages) IsToolbx() bool {
+	return isToolbx(image.labels)
+}
+
+func (image *imageImages) Labels() map[string]string {
+	if image.labels == nil {
+		return nil
+	}
+
+	labelsCount := len(image.labels)
+	ret := make(map[string]string, labelsCount)
+	for label, value := range image.labels {
+		ret[label] = value
+	}
+
+	return ret
+}
+
+func (image *imageImages) Name() string {
+	if len(image.names) != 1 {
+		panic("cannot get name from unflattened Image")
+	}
+
+	return image.names[0]
+}
+
+func (image *imageImages) Names() []string {
+	if image.names == nil {
+		return nil
+	}
+
+	namesCount := len(image.names)
+	ret := make([]string, namesCount)
+	copy(ret, image.names)
+	return ret
+}
+
+func (image *imageImages) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Created interface{}
+		ID      string
+		Labels  map[string]string
+		Names   []string
+	}
+
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// Until Podman 2.0.x the field 'Created' held a human-readable string in
+	// format "5 minutes ago". Since Podman 2.1 the field holds an integer with
+	// Unix time. Go interprets numbers in JSON as float64.
+	switch value := raw.Created.(type) {
+	case string:
+		image.created = value
+	case float64:
+		image.created = utils.HumanDuration(int64(value))
+	}
+
+	image.id = raw.ID
+	image.labels = raw.Labels
+	image.names = raw.Names
+	return nil
+}

--- a/src/pkg/podman/imageImages_test.go
+++ b/src/pkg/podman/imageImages_test.go
@@ -1,0 +1,1026 @@
+/*
+ * Copyright © 2025 – 2026 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podman
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestImageImages(t *testing.T) {
+	type expect struct {
+		id       string
+		isToolbx bool
+		labels   map[string]string
+		names    []string
+	}
+
+	testCases := []struct {
+		name        string
+		data        string
+		expects     []expect
+		imagesCount int
+	}{
+		{
+			name: "podman 1.1.2, fedora-toolbox:29",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"id\": \"4a6adf1f2a96adf5ea0c02b61f9fa574306f77fc522f39c2ce6bb164daead882\"," +
+				"    \"names\": [" +
+				"      \"registry.fedoraproject.org/f29/fedora-toolbox:29\"" +
+				"    ]," +
+				"    \"created\": \"2019-11-06T11:36:10.586442Z\"," +
+				"    \"size\": 437590766" +
+				"  }," +
+				"  {" +
+				"    \"id\": \"8c5e0075ddaf4651b73e71dcf420bab922209f246e1165f306f223112a3061a4\"," +
+				"    \"names\": [" +
+				"      \"localhost/fedora-toolbox-user:29\"" +
+				"    ]," +
+				"    \"created\": \"2025-10-06T09:10:26.394950134Z\"," +
+				"    \"size\": 437967580" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "4a6adf1f2a96adf5ea0c02b61f9fa574306f77fc522f39c2ce6bb164daead882",
+					isToolbx: false,
+					labels:   nil,
+					names: []string{
+						"registry.fedoraproject.org/f29/fedora-toolbox:29",
+					},
+				},
+				{
+					id:       "8c5e0075ddaf4651b73e71dcf420bab922209f246e1165f306f223112a3061a4",
+					isToolbx: false,
+					labels:   nil,
+					names: []string{
+						"localhost/fedora-toolbox-user:29",
+					},
+				},
+			},
+			imagesCount: 2,
+		},
+		{
+			name: "podman 1.8.0, fedora-toolbox:30",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"id\": \"c49513deb6160607504d2c9abf9523e81c02f69ea479fd07572a7a32b50beab8\"," +
+				"    \"names\": [" +
+				"      \"registry.fedoraproject.org/f30/fedora-toolbox:30\"" +
+				"    ]," +
+				"    \"created\": \"2020-03-03T10:32:20.503064Z\"," +
+				"    \"size\": 404259600," +
+				"    \"readonly\": false," +
+				"    \"history\": []" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "c49513deb6160607504d2c9abf9523e81c02f69ea479fd07572a7a32b50beab8",
+					isToolbx: false,
+					labels:   nil,
+					names: []string{
+						"registry.fedoraproject.org/f30/fedora-toolbox:30",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 2.2.1, fedora-toolbox:32",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"6b2cbce8102fc0c0424b619ad199216c025efc374457dc7a61bb89d393e7eab6\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"Size\": 371369047," +
+				"    \"Labels\": {" +
+				"      \"architecture\": \"x86_64\"," +
+				"      \"authoritative-source-url\": \"registry.fedoraproject.org\"," +
+				"      \"build-date\": \"2021-04-25T12:01:08.917265\"," +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"com.github.debarshiray.toolbox\": \"true\"," +
+				"      \"com.redhat.component\": \"fedora-toolbox\"," +
+				"      \"distribution-scope\": \"public\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"release\": \"14\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"32\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:32\"" +
+				"    ]," +
+				"    \"Created\": 1619352159," +
+				"    \"CreatedAt\": \"2021-04-25T12:02:39Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "6b2cbce8102fc0c0424b619ad199216c025efc374457dc7a61bb89d393e7eab6",
+					isToolbx: true,
+					labels: map[string]string{
+						"architecture":                   "x86_64",
+						"authoritative-source-url":       "registry.fedoraproject.org",
+						"build-date":                     "2021-04-25T12:01:08.917265",
+						"com.github.containers.toolbox":  "true",
+						"com.github.debarshiray.toolbox": "true",
+						"com.redhat.component":           "fedora-toolbox",
+						"distribution-scope":             "public",
+						"license":                        "MIT",
+						"name":                           "fedora-toolbox",
+						"release":                        "14",
+						"vendor":                         "Fedora Project",
+						"version":                        "32",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:32",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 3.4.7, fedora-toolbox:35",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"862705390e8b1678bbac66beb30547e0ef59abd65b18e23ea533f059ba069227\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 495703728," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 495703728," +
+				"    \"Labels\": {" +
+				"      \"architecture\": \"x86_64\"," +
+				"      \"authoritative-source-url\": \"registry.fedoraproject.org\"," +
+				"      \"build-date\": \"2022-11-09T13:15:18.185125\"," +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"com.github.debarshiray.toolbox\": \"true\"," +
+				"      \"com.redhat.component\": \"fedora-toolbox\"," +
+				"      \"distribution-scope\": \"public\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"release\": \"18\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"35\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:35\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:35\"" +
+				"    ]," +
+				"    \"Created\": 1667999803," +
+				"    \"CreatedAt\": \"2022-11-09T13:16:43Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "862705390e8b1678bbac66beb30547e0ef59abd65b18e23ea533f059ba069227",
+					isToolbx: true,
+					labels: map[string]string{
+						"architecture":                   "x86_64",
+						"authoritative-source-url":       "registry.fedoraproject.org",
+						"build-date":                     "2022-11-09T13:15:18.185125",
+						"com.github.containers.toolbox":  "true",
+						"com.github.debarshiray.toolbox": "true",
+						"com.redhat.component":           "fedora-toolbox",
+						"distribution-scope":             "public",
+						"license":                        "MIT",
+						"name":                           "fedora-toolbox",
+						"release":                        "18",
+						"vendor":                         "Fedora Project",
+						"version":                        "35",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:35",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 4.9.4, fedora-toolbox:38",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"e8c6a36c07b778f0efcf7adb0c317ea2405afed5a3547fe8272c54b2495955ce\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 1748730844," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 1748730844," +
+				"    \"Labels\": {" +
+				"      \"architecture\": \"x86_64\"," +
+				"      \"authoritative-source-url\": \"registry.fedoraproject.org\"," +
+				"      \"build-date\": \"2024-02-01T19:07:19.783946\"," +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"com.redhat.component\": \"fedora-toolbox\"," +
+				"      \"distribution-scope\": \"public\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"release\": \"20\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"38\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:38\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:38\"" +
+				"    ]," +
+				"    \"Created\": 1706814575," +
+				"    \"CreatedAt\": \"2024-02-01T19:09:35Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "e8c6a36c07b778f0efcf7adb0c317ea2405afed5a3547fe8272c54b2495955ce",
+					isToolbx: true,
+					labels: map[string]string{
+						"architecture":                  "x86_64",
+						"authoritative-source-url":      "registry.fedoraproject.org",
+						"build-date":                    "2024-02-01T19:07:19.783946",
+						"com.github.containers.toolbox": "true",
+						"com.redhat.component":          "fedora-toolbox",
+						"distribution-scope":            "public",
+						"license":                       "MIT",
+						"name":                          "fedora-toolbox",
+						"release":                       "20",
+						"vendor":                        "Fedora Project",
+						"version":                       "38",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:38",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 4.9.4, fedora-toolbox:38 locally built",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"5abdeba6b7f0b1443294df0e64db58f6f7a3064d901e4c9cef488c95976d5b46\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 1118076168," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 1118076168," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"com.redhat.component\": \"fedora-toolbox\"," +
+				"      \"io.buildah.version\": \"1.33.7\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"38\"" +
+				"    }," +
+				"    \"Containers\": 0," +
+				"    \"Names\": [" +
+				"      \"localhost/fedora-toolbox:38\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"localhost/fedora-toolbox:38\"" +
+				"    ]," +
+				"    \"Created\": 1775683847," +
+				"    \"CreatedAt\": \"2026-04-08T21:30:47Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"3eda970c1318e5ea564134338746c04d86ae9817c3a0defdc138b8ccdf787285\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 186903609," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 186903609," +
+				"    \"Labels\": {" +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"38\"" +
+				"    }," +
+				"    \"Containers\": 0," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora:38\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora:38\"" +
+				"    ]," +
+				"    \"Created\": 1706165366," +
+				"    \"CreatedAt\": \"2024-01-25T06:49:26Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "5abdeba6b7f0b1443294df0e64db58f6f7a3064d901e4c9cef488c95976d5b46",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox": "true",
+						"com.redhat.component":          "fedora-toolbox",
+						"io.buildah.version":            "1.33.7",
+						"license":                       "MIT",
+						"name":                          "fedora-toolbox",
+						"vendor":                        "Fedora Project",
+						"version":                       "38",
+					},
+					names: []string{
+						"localhost/fedora-toolbox:38",
+					},
+				},
+				{
+					id:       "3eda970c1318e5ea564134338746c04d86ae9817c3a0defdc138b8ccdf787285",
+					isToolbx: false,
+					labels: map[string]string{
+						"license": "MIT",
+						"name":    "fedora",
+						"vendor":  "Fedora Project",
+						"version": "38",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora:38",
+					},
+				},
+			},
+			imagesCount: 2,
+		},
+		{
+			name: "podman 4.9.4, fedora-toolbox:38 locally built without a name",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"77b838402716b59256e007a09f66a45b3bbeda584d6996dc451916d71ad7c865\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 1118078214," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 1118078214," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"com.redhat.component\": \"fedora-toolbox\"," +
+				"      \"io.buildah.version\": \"1.33.7\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"38\"" +
+				"    }," +
+				"    \"Containers\": 0," +
+				"    \"Dangling\": true," +
+				"    \"History\": [" +
+				"      \"docker.io/library/0200639f72f073877d2db4a7f43d38ce51a4ef5c5add7fdae62e39da37cf605a-tmp:latest\"" +
+				"    ]," +
+				"    \"Created\": 1775683847," +
+				"    \"CreatedAt\": \"2026-04-08T21:30:47Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"3eda970c1318e5ea564134338746c04d86ae9817c3a0defdc138b8ccdf787285\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 186903609," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 186903609," +
+				"    \"Labels\": {" +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"38\"" +
+				"    }," +
+				"    \"Containers\": 0," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora:38\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora:38\"" +
+				"    ]," +
+				"    \"Created\": 1706165366," +
+				"    \"CreatedAt\": \"2024-01-25T06:49:26Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "77b838402716b59256e007a09f66a45b3bbeda584d6996dc451916d71ad7c865",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox": "true",
+						"com.redhat.component":          "fedora-toolbox",
+						"io.buildah.version":            "1.33.7",
+						"license":                       "MIT",
+						"name":                          "fedora-toolbox",
+						"vendor":                        "Fedora Project",
+						"version":                       "38",
+					},
+					names: nil,
+				},
+				{
+					id:       "3eda970c1318e5ea564134338746c04d86ae9817c3a0defdc138b8ccdf787285",
+					isToolbx: false,
+					labels: map[string]string{
+						"license": "MIT",
+						"name":    "fedora",
+						"vendor":  "Fedora Project",
+						"version": "38",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora:38",
+					},
+				},
+			},
+			imagesCount: 2,
+		},
+		{
+			name: "podman 4.9.4, fedora-toolbox:39",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"20a55d9dc10ebf8483727242074d0c50086a82c987b408ec4fc281ea23d7558b\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2105060434," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2105060434," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"39\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:39\"" +
+				"    ]," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:39\"" +
+				"    ]," +
+				"    \"Created\": 1732607485," +
+				"    \"CreatedAt\": \"2024-11-26T07:51:25Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "20a55d9dc10ebf8483727242074d0c50086a82c987b408ec4fc281ea23d7558b",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox": "true",
+						"license":                       "MIT",
+						"name":                          "fedora",
+						"vendor":                        "Fedora Project",
+						"version":                       "39",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:39",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 5.4.2, fedora-toolbox:40",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 5.4.2, fedora-toolbox:40 with its name removed",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"Dangling\": true," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: nil,
+				},
+			},
+			imagesCount: 1,
+		},
+		{
+			name: "podman 5.4.2, fedora-toolbox:40 and its copy with different registries",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"," +
+				"      \"localhost/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"localhost/fedora-toolbox:40\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"," +
+				"      \"localhost/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"localhost/fedora-toolbox:40\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"localhost/fedora-toolbox:40",
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"localhost/fedora-toolbox:40",
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+			},
+			imagesCount: 2,
+		},
+		{
+			name: "podman 5.4.2, fedora-toolbox:40 and its copy with different tags",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-test\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-test\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-test\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-test\"," +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:40-test",
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:40-test",
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+			},
+			imagesCount: 2,
+		},
+		{
+			name: "podman 5.4.2, fedora-toolbox:40, fedora-toolbox:40-aarch64, postgres:latest",
+			data: "" +
+				"[" +
+				"  {" +
+				"    \"Id\": \"194f5f2a900a5775ecff2129be107adc7c1ce98b89ac00ca0bed141310b7e6cd\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 463150524," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 463150524," +
+				"    \"Labels\": null," +
+				"    \"Containers\": 0," +
+				"    \"History\": [" +
+				"      \"docker.io/library/postgres:latest\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"docker.io/library/postgres:latest\"" +
+				"    ]," +
+				"    \"Created\": 1758824555," +
+				"    \"CreatedAt\": \"2025-09-25T18:22:35Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 2204748042," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 2204748042," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 1," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }," +
+				"  {" +
+				"    \"Id\": \"49008798958db0411330d8b6a996c03bdab1d1b10d139e7df2b75ed3298f84a7\"," +
+				"    \"ParentId\": \"\"," +
+				"    \"RepoTags\": null," +
+				"    \"Size\": 1253521285," +
+				"    \"SharedSize\": 0," +
+				"    \"VirtualSize\": 1253521285," +
+				"    \"Labels\": {" +
+				"      \"com.github.containers.toolbox\": \"true\"," +
+				"      \"io.buildah.version\": \"1.39.2\"," +
+				"      \"license\": \"MIT\"," +
+				"      \"name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.license\": \"MIT\"," +
+				"      \"org.opencontainers.image.name\": \"fedora-toolbox\"," +
+				"      \"org.opencontainers.image.url\": \"https://fedoraproject.org/\"," +
+				"      \"org.opencontainers.image.vendor\": \"Fedora Project\"," +
+				"      \"org.opencontainers.image.version\": \"40\"," +
+				"      \"vendor\": \"Fedora Project\"," +
+				"      \"version\": \"40\"" +
+				"    }," +
+				"    \"Containers\": 0," +
+				"    \"History\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-aarch64\"" +
+				"    ]," +
+				"    \"Names\": [" +
+				"      \"registry.fedoraproject.org/fedora-toolbox:40-aarch64\"" +
+				"    ]," +
+				"    \"Created\": 1747122540," +
+				"    \"CreatedAt\": \"2025-05-13T07:49:00Z\"" +
+				"  }" +
+				"]",
+			expects: []expect{
+				{
+					id:       "194f5f2a900a5775ecff2129be107adc7c1ce98b89ac00ca0bed141310b7e6cd",
+					isToolbx: false,
+					labels:   nil,
+					names: []string{
+						"docker.io/library/postgres:latest",
+					},
+				},
+				{
+					id:       "5c5b2e637806fccb644effa4affc4a5d08dc7e6140586ecb8c601c8739e12628",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:40",
+					},
+				},
+				{
+					id:       "49008798958db0411330d8b6a996c03bdab1d1b10d139e7df2b75ed3298f84a7",
+					isToolbx: true,
+					labels: map[string]string{
+						"com.github.containers.toolbox":    "true",
+						"io.buildah.version":               "1.39.2",
+						"license":                          "MIT",
+						"name":                             "fedora-toolbox",
+						"org.opencontainers.image.license": "MIT",
+						"org.opencontainers.image.name":    "fedora-toolbox",
+						"org.opencontainers.image.url":     "https://fedoraproject.org/",
+						"org.opencontainers.image.vendor":  "Fedora Project",
+						"org.opencontainers.image.version": "40",
+						"vendor":                           "Fedora Project",
+						"version":                          "40",
+					},
+					names: []string{
+						"registry.fedoraproject.org/fedora-toolbox:40-aarch64",
+					},
+				},
+			},
+			imagesCount: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data := []byte(tc.data)
+			var images []imageImages
+			err := json.Unmarshal(data, &images)
+			assert.NoError(t, err)
+			assert.Len(t, images, tc.imagesCount)
+
+			for i, expect := range tc.expects {
+				image := images[i]
+				assert.Equal(t, expect.id, image.ID())
+				assert.Equal(t, expect.isToolbx, image.IsToolbx())
+
+				labels := image.Labels()
+				if labels != nil {
+					labels["foo"] = "bar"
+				}
+
+				assert.Equal(t, expect.labels, image.Labels())
+
+				names := image.Names()
+				namesCount := len(names)
+				if namesCount != 0 {
+					names[0] = "foo/bar"
+				}
+
+				assert.Equal(t, expect.names, image.Names())
+
+				switch namesCount {
+				case 0:
+					assert.Panics(t, func() { _ = image.Name() })
+				case 1:
+					assert.Equal(t, expect.names[0], image.Name())
+				default:
+					assert.Panics(t, func() { _ = image.Name() })
+
+					flattenedImages := image.flattenNames(false)
+					for j, flattenedImage := range flattenedImages {
+						assert.Equal(t, expect.names[j], flattenedImage.Name())
+					}
+
+				}
+			}
+		})
+	}
+}

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -33,8 +33,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type imageSlice []imageImages
-
 var (
 	podmanVersion string
 )
@@ -46,20 +44,6 @@ var (
 
 	LogLevel = logrus.ErrorLevel
 )
-
-func (images imageSlice) Len() int {
-	return len(images)
-}
-
-func (images imageSlice) Less(i, j int) bool {
-	nameI := images[i].Name()
-	nameJ := images[j].Name()
-	return nameI < nameJ
-}
-
-func (images imageSlice) Swap(i, j int) {
-	images[i], images[j] = images[j], images[i]
-}
 
 // CheckVersion compares provided version with the version of Podman.
 //

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -57,7 +57,8 @@ var (
 func (image *Image) flattenNames(fillNameWithID bool) []Image {
 	var ret []Image
 
-	if len(image.Names) == 0 {
+	namesCount := len(image.Names)
+	if namesCount == 0 {
 		flattenedImage := *image
 
 		if fillNameWithID {
@@ -71,7 +72,7 @@ func (image *Image) flattenNames(fillNameWithID bool) []Image {
 		return ret
 	}
 
-	ret = make([]Image, 0, len(image.Names))
+	ret = make([]Image, 0, namesCount)
 
 	for _, name := range image.Names {
 		flattenedImage := *image

--- a/src/pkg/podman/podman.go
+++ b/src/pkg/podman/podman.go
@@ -33,14 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Image struct {
-	Created string
-	ID      string
-	Labels  map[string]string
-	Names   []string
-}
-
-type imageSlice []Image
+type imageSlice []imageImages
 
 var (
 	podmanVersion string
@@ -54,77 +47,14 @@ var (
 	LogLevel = logrus.ErrorLevel
 )
 
-func (image *Image) flattenNames(fillNameWithID bool) []Image {
-	var ret []Image
-
-	namesCount := len(image.Names)
-	if namesCount == 0 {
-		flattenedImage := *image
-
-		if fillNameWithID {
-			shortID := utils.ShortID(image.ID)
-			flattenedImage.Names = []string{shortID}
-		} else {
-			flattenedImage.Names = []string{"<none>"}
-		}
-
-		ret = []Image{flattenedImage}
-		return ret
-	}
-
-	ret = make([]Image, 0, namesCount)
-
-	for _, name := range image.Names {
-		flattenedImage := *image
-		flattenedImage.Names = []string{name}
-		ret = append(ret, flattenedImage)
-	}
-
-	return ret
-}
-
-func (image *Image) UnmarshalJSON(data []byte) error {
-	var raw struct {
-		Created interface{}
-		ID      string
-		Labels  map[string]string
-		Names   []string
-	}
-
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return err
-	}
-
-	// Until Podman 2.0.x the field 'Created' held a human-readable string in
-	// format "5 minutes ago". Since Podman 2.1 the field holds an integer with
-	// Unix time. Go interprets numbers in JSON as float64.
-	switch value := raw.Created.(type) {
-	case string:
-		image.Created = value
-	case float64:
-		image.Created = utils.HumanDuration(int64(value))
-	}
-
-	image.ID = raw.ID
-	image.Labels = raw.Labels
-	image.Names = raw.Names
-	return nil
-}
-
 func (images imageSlice) Len() int {
 	return len(images)
 }
 
 func (images imageSlice) Less(i, j int) bool {
-	if len(images[i].Names) != 1 {
-		panic("cannot sort unflattened imageSlice")
-	}
-
-	if len(images[j].Names) != 1 {
-		panic("cannot sort unflattened imageSlice")
-	}
-
-	return images[i].Names[0] < images[j].Names[0]
+	nameI := images[i].Name()
+	nameJ := images[j].Name()
+	return nameI < nameJ
 }
 
 func (images imageSlice) Swap(i, j int) {
@@ -203,7 +133,7 @@ func GetContainers() (*Containers, error) {
 // Returned value is a slice of Images.
 //
 // If a problem happens during execution, first argument is nil and second argument holds the error message.
-func GetImages(fillNameWithID bool) ([]Image, error) {
+func GetImages(fillNameWithID bool) (*Images, error) {
 	var stdout bytes.Buffer
 
 	logLevelString := LogLevel.String()
@@ -213,28 +143,29 @@ func GetImages(fillNameWithID bool) ([]Image, error) {
 	}
 
 	output := stdout.Bytes()
-	var images []Image
+	var images []imageImages
 	if err := json.Unmarshal(output, &images); err != nil {
 		return nil, err
 	}
 
 	processedIDs := make(map[string]struct{})
-	var toolbxImages []Image
+	var toolbxImages []imageImages
 
 	for _, image := range images {
-		if _, ok := processedIDs[image.ID]; ok {
+		id := image.ID()
+		if _, ok := processedIDs[id]; ok {
 			continue
 		}
 
-		processedIDs[image.ID] = struct{}{}
-		if isToolbx(image.Labels) {
+		processedIDs[id] = struct{}{}
+		if image.IsToolbx() {
 			flattenedImages := image.flattenNames(fillNameWithID)
 			toolbxImages = append(toolbxImages, flattenedImages...)
 		}
 	}
 
 	sort.Sort(imageSlice(toolbxImages))
-	return toolbxImages, nil
+	return &Images{toolbxImages, 0}, nil
 }
 
 // GetVersion returns version of Podman in a string


### PR DESCRIPTION
A subsequent commit will switch to unmarshalling the JSON returned from
`podman inspect --format json --type image` directly inside
`podman.InspectImage()` to confine the details within the `podman` package
and make it easier to write unit tests for it.  eg., it requires
tracking changes to the JSON output across different Podman versions.

Unfortunately, the JSON from `podman inspect --format json --type image`
and `podman images --format json` are considerably different and it will
be awkward to use the same implementation of the `json.Unmarshaler`
interface [1] for both.  One option is to have two different concrete
types separately implement `json.Unmarshaler` to handle the differences in
the JSON, and then hiding these concrete types behind an `Image` interface
that provides access to the values parsed from the JSON.

[1] https://pkg.go.dev/encoding/json#Unmarshaler

https://github.com/containers/toolbox/pull/1724