### PR TITLE
cmd/utils: Add architecture resolution and cross-arch name handling

### DIFF
--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -175,7 +175,8 @@ func create(cmd *cobra.Command, args []string) error {
 		containerArg,
 		createFlags.distro,
 		createFlags.image,
-		createFlags.release)
+		createFlags.release,
+		architecture.HostArchID)
 
 	if err != nil {
 		return err

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/skopeo"
@@ -564,7 +565,7 @@ func getEnterCommand(container string) string {
 }
 
 func getImageSizeFromRegistry(ctx context.Context, imageFull string) (string, error) {
-	image, err := skopeo.Inspect(ctx, imageFull)
+	image, err := skopeo.Inspect(ctx, imageFull, architecture.HostArchID, "")
 	if err != nil {
 		return "", err
 	}

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -486,19 +486,15 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 		logrus.Debugf("%s", arg)
 	}
 
-	s := spinner.New(spinner.CharSets[9], 500*time.Millisecond, spinner.WithWriterFile(os.Stdout))
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel {
-		s.Prefix = fmt.Sprintf("Creating container %s: ", container)
-		s.Start()
-		defer s.Stop()
-	}
+	s := startSpinner(fmt.Sprintf("Creating container %s: ", container))
+	defer stopSpinner(s)
 
 	if err := shell.Run("podman", nil, nil, nil, createArgs...); err != nil {
 		return fmt.Errorf("failed to create container %s", container)
 	}
 
 	// The spinner must be stopped before showing the 'enter' hint below.
-	s.Stop()
+	stopSpinner(s)
 
 	if showCommandToEnter {
 		fmt.Printf("Created container: %s\n", container)
@@ -735,12 +731,8 @@ func pullImage(image, release, authFile string) (bool, error) {
 
 	logrus.Debugf("Pulling image %s", imageFull)
 
-	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel {
-		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond, spinner.WithWriterFile(os.Stdout))
-		s.Prefix = fmt.Sprintf("Pulling %s: ", imageFull)
-		s.Start()
-		defer s.Stop()
-	}
+	s := startSpinner(fmt.Sprintf("Pulling %s: ", imageFull))
+	defer stopSpinner(s)
 
 	if err := podman.Pull(imageFull, authFile); err != nil {
 		var builder strings.Builder
@@ -961,6 +953,22 @@ func showPromptForDownload(imageFull string) bool {
 
 	shouldPullImage = showPromptForDownloadSecond(imageFull, errPromptForDownload)
 	return shouldPullImage
+}
+
+func startSpinner(message string) *spinner.Spinner {
+	if logLevel := logrus.GetLevel(); logLevel < logrus.DebugLevel {
+		s := spinner.New(spinner.CharSets[9], 500*time.Millisecond, spinner.WithWriterFile(os.Stdout))
+		s.Prefix = message
+		s.Start()
+		return s
+	}
+	return nil
+}
+
+func stopSpinner(s *spinner.Spinner) {
+	if s != nil {
+		s.Stop()
+	}
 }
 
 // systemdNeedsEscape checks whether a byte in a potential dbus ObjectPath needs to be escaped

--- a/src/cmd/enter.go
+++ b/src/cmd/enter.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -108,7 +109,8 @@ func enter(cmd *cobra.Command, args []string) error {
 		containerArg,
 		enterFlags.distro,
 		"",
-		enterFlags.release)
+		enterFlags.release,
+		architecture.HostArchID)
 
 	if err != nil {
 		return err

--- a/src/cmd/rootMigrationPath.go
+++ b/src/cmd/rootMigrationPath.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/spf13/cobra"
 )
@@ -56,7 +57,7 @@ func rootRunImpl(cmd *cobra.Command, args []string) error {
 		return &exitError{exitCode, err}
 	}
 
-	container, image, release, err := resolveContainerAndImageNames("", "", "", "", "")
+	container, image, release, err := resolveContainerAndImageNames("", "", "", "", "", architecture.HostArchID)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/nvidia"
 	"github.com/containers/toolbox/pkg/podman"
 	"github.com/containers/toolbox/pkg/shell"
@@ -145,7 +146,8 @@ func run(cmd *cobra.Command, args []string) error {
 		"--container",
 		runFlags.distro,
 		"",
-		runFlags.release)
+		runFlags.release,
+		architecture.HostArchID)
 
 	if err != nil {
 		return err

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -525,9 +525,11 @@ func resolveArchitectureID(arch string, image string) (int, error) {
 	return archID, nil
 }
 
-func resolveContainerAndImageNames(container, containerArg, distroCLI, imageCLI, releaseCLI string) (
+func resolveContainerAndImageNames(container, containerArg, distroCLI, imageCLI, releaseCLI string, archID int) (
 	string, string, string, error,
 ) {
+	containerWasEmpty := container == ""
+
 	container, image, release, err := utils.ResolveContainerAndImageNames(container,
 		distroCLI,
 		imageCLI,
@@ -579,6 +581,17 @@ func resolveContainerAndImageNames(container, containerArg, distroCLI, imageCLI,
 			return "", "", "", err
 		} else {
 			return "", "", "", err
+		}
+	}
+
+	if containerWasEmpty && !architecture.HasContainerNativeArch(archID) {
+		archIDFromTag := architecture.ImageReferenceGetArchFromTag(image)
+
+		if archIDFromTag == architecture.NotSpecified {
+			archName := architecture.GetArchNameOCI(archID)
+			if archName != "" {
+				container = container + "-" + archName
+			}
 		}
 	}
 

--- a/src/cmd/utils.go
+++ b/src/cmd/utils.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/shell"
 	"github.com/containers/toolbox/pkg/utils"
 	"github.com/sirupsen/logrus"
@@ -261,6 +262,18 @@ func discardInputAsync(ctx context.Context) (<-chan int, <-chan error) {
 	return retValCh, errCh
 }
 
+func createErrorConflictingArchSpecs(archCLI, archTag int) error {
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "conflicting architecture specifications\n")
+	fmt.Fprintf(&builder, "--arch=%s but image tag specifies %s\n",
+		architecture.GetArchNameOCI(archCLI),
+		architecture.GetArchNameOCI(archTag))
+	fmt.Fprintf(&builder, "Run '%s --help' for usage.", executableBase)
+
+	errMsg := builder.String()
+	return errors.New(errMsg)
+}
+
 func createErrorContainerNotFound(container string) error {
 	var builder strings.Builder
 	fmt.Fprintf(&builder, "container %s not found\n", container)
@@ -483,6 +496,35 @@ func poll(pollFn pollFunc, eventFD int32, fds ...int32) error {
 	}
 }
 
+func resolveArchitectureID(arch string, image string) (int, error) {
+	archID := architecture.NotSpecified
+	if arch != "" {
+		archIDParsed, err := architecture.ParseArgArchValue(arch)
+		if err != nil {
+			return architecture.NotSpecified, err
+		}
+		archID = archIDParsed
+	}
+
+	if image != "" && utils.IsSupportedDistroImage(image) {
+		archIDFromTag := architecture.ImageReferenceGetArchFromTag(image)
+
+		if archID == architecture.NotSpecified && archIDFromTag != architecture.NotSpecified {
+			logrus.Debug("non-native architecture was detected in the image tag -> cross-architecture approach is going to be used")
+
+			archID = archIDFromTag
+		} else if archID != archIDFromTag && archIDFromTag != architecture.NotSpecified {
+			return architecture.NotSpecified, createErrorConflictingArchSpecs(archID, archIDFromTag)
+		}
+	}
+
+	if archID == architecture.NotSpecified {
+		archID = architecture.HostArchID
+	}
+
+	return archID, nil
+}
+
 func resolveContainerAndImageNames(container, containerArg, distroCLI, imageCLI, releaseCLI string) (
 	string, string, string, error,
 ) {
@@ -541,6 +583,21 @@ func resolveContainerAndImageNames(container, containerArg, distroCLI, imageCLI,
 	}
 
 	return container, image, release, nil
+}
+
+func resolveImageNameWithArchitectureSuffix(image string, archID int) string {
+	if architecture.HasContainerNativeArch(archID) {
+		return image
+	}
+
+	archIDFromTag := architecture.ImageReferenceGetArchFromTag(image)
+	isSupportedDistroImage := utils.IsSupportedDistroImage(image)
+
+	if isSupportedDistroImage && archIDFromTag == architecture.NotSpecified {
+		return image + "-" + architecture.GetArchNameOCI(archID)
+	}
+
+	return image
 }
 
 // showManual tries to open the specified manual page using man on stdout

--- a/src/pkg/architecture/architecture.go
+++ b/src/pkg/architecture/architecture.go
@@ -1,0 +1,165 @@
+/*
+ * Copyright © 2019 – 2026 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package architecture
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/containers/toolbox/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+type Architecture struct {
+	ID         int
+	NameBinfmt string
+	NameOCI    string
+	Aliases    []string
+	ELFMagic   []byte
+	ELFMask    []byte
+
+	BinfmtFlags     string
+	BinfmtName      string
+	BinfmtMagicType string
+	BinfmtOffset    string
+}
+
+type Config struct {
+	ID               int
+	QemuEmulatorPath string
+}
+
+const (
+	NotSpecified = iota
+	Aarch64
+	Ppc64le
+	X86_64
+)
+
+var supportedArchitectures = map[int]Architecture{
+	Aarch64: {
+		ID:         Aarch64,
+		NameBinfmt: "aarch64",
+		NameOCI:    "arm64",
+		Aliases:    []string{"aarch64", "arm64"},
+		ELFMagic:   []byte{0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0xb7, 0x00},
+		ELFMask:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff},
+	},
+	Ppc64le: {
+		ID:         Ppc64le,
+		NameBinfmt: "ppc64le",
+		NameOCI:    "ppc64le",
+		Aliases:    []string{"ppc64le"},
+		ELFMagic:   []byte{0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x15, 0x00},
+		ELFMask:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0x00},
+	},
+	X86_64: {
+		ID:         X86_64,
+		NameBinfmt: "x86_64",
+		NameOCI:    "amd64",
+		Aliases:    []string{"x86_64", "amd64"},
+		ELFMagic:   []byte{0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x3e, 0x00},
+		ELFMask:    []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xfe, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff},
+	},
+}
+
+var (
+	HostArchID             int
+	supportedArgArchValues map[string]int
+)
+
+func init() {
+	supportedArgArchValues = make(map[string]int)
+	for archID, arch := range supportedArchitectures {
+		for _, alias := range arch.Aliases {
+			supportedArgArchValues[alias] = archID
+		}
+	}
+
+	HostArchID, _ = ParseArgArchValue(runtime.GOARCH)
+}
+
+func GetArchConfigDefault() Config {
+	return Config{
+		ID:               HostArchID,
+		QemuEmulatorPath: "",
+	}
+}
+
+func getArchitecture(archID int) (Architecture, bool) {
+	arch, exists := supportedArchitectures[archID]
+	return arch, exists
+}
+
+func getArchNameBinfmt(arch int) string {
+	if arch == NotSpecified {
+		logrus.Warnf("Getting arch name for not specified architecture")
+		return "arch_not_specified"
+	}
+	if archObj, exists := supportedArchitectures[arch]; exists {
+		return archObj.NameBinfmt
+	}
+	return ""
+}
+
+func GetArchNameOCI(arch int) string {
+	if arch == NotSpecified {
+		logrus.Warnf("Getting arch name for not specified architecture")
+		return "arch_not_specified"
+	}
+	if archObj, exists := supportedArchitectures[arch]; exists {
+		return archObj.NameOCI
+	}
+	return ""
+}
+
+func HasContainerNativeArch(archID int) bool {
+	return archID == HostArchID
+}
+
+func ImageReferenceGetArchFromTag(image string) int {
+	tag := utils.ImageReferenceGetTag(image)
+
+	if tag == "" {
+		return NotSpecified
+	}
+
+	i := strings.LastIndexByte(tag, '-')
+	if i == -1 {
+		return NotSpecified
+	}
+
+	archInTag := tag[i+1:]
+
+	for archID, arch := range supportedArchitectures {
+		if arch.NameBinfmt == archInTag || arch.NameOCI == archInTag {
+			return archID
+		}
+	}
+
+	return NotSpecified
+}
+
+func ParseArgArchValue(value string) (int, error) {
+	archID, exists := supportedArgArchValues[value]
+	if !exists {
+		return NotSpecified, fmt.Errorf("architecture '%s' is not supported by Toolbx", value)
+	}
+
+	return archID, nil
+}

--- a/src/pkg/architecture/architecture.go
+++ b/src/pkg/architecture/architecture.go
@@ -17,7 +17,11 @@
 package architecture
 
 import (
+	"debug/elf"
+	"errors"
 	"fmt"
+	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 
@@ -155,6 +159,108 @@ func ImageReferenceGetArchFromTag(image string) int {
 	return NotSpecified
 }
 
+func IsArchSupportedOnCreation(archID int) (string, error) {
+	archName := getArchNameBinfmt(archID)
+	archNameDebug := GetArchNameOCI(archID)
+	logrus.Debugf("Checking QEMU emulation support for architecture %s", archNameDebug)
+
+	qemuBinaryPossibleNames := []string{
+		fmt.Sprintf("qemu-%s-static", archName),
+		fmt.Sprintf("qemu-%s", archName),
+	}
+
+	foundQemuBinaryPath := ""
+	for _, qemuName := range qemuBinaryPossibleNames {
+		qemuBinaryPath, err := exec.LookPath(qemuName)
+
+		if err != nil {
+			if errors.Is(err, exec.ErrNotFound) {
+				continue
+			}
+
+			return "", fmt.Errorf("failed to look up binary '%s': %w", qemuName, err)
+		}
+
+		if isStaticallyLinkedELF(qemuBinaryPath) {
+			foundQemuBinaryPath = qemuBinaryPath
+			break
+		}
+	}
+
+	if foundQemuBinaryPath == "" {
+		err := fmt.Errorf("The host system does not have the required support: No %s statically linked QEMU emulator binary found", archNameDebug)
+		return "", err
+	}
+
+	if !validateBinfmtRegistration(archID, false) {
+		err := fmt.Errorf("The host system does not have the required support: No %s binfmt_misc registration found", archNameDebug)
+		return "", err
+	}
+
+	return foundQemuBinaryPath, nil
+}
+
+func IsArchSupportedOnInitialization(archID int, interpreterPath string) (string, error) {
+	archName := getArchNameBinfmt(archID)
+	archNameDebug := GetArchNameOCI(archID)
+	logrus.Debugf("Checking QEMU emulation support for architecture %s", archNameDebug)
+
+	if isStaticallyLinkedELF(interpreterPath) {
+		if !validateBinfmtRegistration(archID, true) {
+			return "", fmt.Errorf("The host system does not have the required support: No %s binfmt_misc registration found", archNameDebug)
+		}
+		return interpreterPath, nil
+	}
+
+	// Fallback: check standard locations on the host
+	logrus.Debugf("Interpreter at %s not found or not statically linked, checking fallback locations in '/run/host/usr/bin/'", interpreterPath)
+	fmt.Fprintf(os.Stderr, "Warning: QEMU emulator not found at expected path '%s', using fallback at '/run/host/usr/bin/'\n", interpreterPath)
+
+	qemuBinaryPossiblePaths := []string{
+		fmt.Sprintf("/run/host/usr/bin/qemu-%s-static", archName),
+		fmt.Sprintf("/run/host/usr/bin/qemu-%s", archName),
+	}
+
+	for _, qemuPath := range qemuBinaryPossiblePaths {
+		if isStaticallyLinkedELF(qemuPath) {
+			logrus.Debugf("Found valid QEMU binary at %s", qemuPath)
+
+			if !validateBinfmtRegistration(archID, true) {
+				return "", fmt.Errorf("The host system does not have the required support: No %s binfmt_misc registration found", archNameDebug)
+			}
+			return qemuPath, nil
+		}
+	}
+
+	return "", fmt.Errorf("The host system does not have the required support: No %s statically linked QEMU emulator binary found", archNameDebug)
+}
+
+func isStaticallyLinkedELF(filePath string) bool {
+	if !utils.PathExists(filePath) {
+		logrus.Debugf("File '%s' does not exist\n", filePath)
+		return false
+	}
+
+	f, err := elf.Open(filePath)
+	if err != nil {
+		logrus.Debugf("File '%s' is not an ELF file\n", filePath)
+		return false
+	}
+	defer f.Close()
+
+	// Check for PT_INTERP program header
+	for _, prog := range f.Progs {
+		if prog.Type == elf.PT_INTERP {
+			// Dynamically linked
+			logrus.Debugf("File '%s' is dynamically linked\n", filePath)
+			return false
+		}
+	}
+
+	// Statically linked
+	return true
+}
+
 func ParseArgArchValue(value string) (int, error) {
 	archID, exists := supportedArgArchValues[value]
 	if !exists {
@@ -162,4 +268,26 @@ func ParseArgArchValue(value string) (int, error) {
 	}
 
 	return archID, nil
+}
+
+func validateBinfmtRegistration(archID int, withinContainer bool) bool {
+	archName := getArchNameBinfmt(archID)
+	inContainerPathPrefix := ""
+
+	if withinContainer {
+		inContainerPathPrefix = "/run/host"
+	}
+
+	qemuBinfmtPossiblePaths := []string{
+		fmt.Sprintf("%s/proc/sys/fs/binfmt_misc/qemu-%s", inContainerPathPrefix, archName),
+		fmt.Sprintf("%s/proc/sys/fs/binfmt_misc/qemu-%s-static", inContainerPathPrefix, archName),
+	}
+
+	for _, binfmtPath := range qemuBinfmtPossiblePaths {
+		if utils.PathExists(binfmtPath) {
+			logrus.Debugf("Architecture %s is supported", archName)
+			return true
+		}
+	}
+	return false
 }

--- a/src/pkg/architecture/binfmt_misc.go
+++ b/src/pkg/architecture/binfmt_misc.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright © 2019 – 2026 Red Hat Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package architecture
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/toolbox/pkg/shell"
+	"github.com/sirupsen/logrus"
+)
+
+type Registration struct {
+	Name        string
+	MagicType   string
+	Offset      string
+	Magic       []byte
+	Mask        []byte
+	Interpreter string
+	Flags       string
+}
+
+const (
+	defaultMagicType = "M"
+	defaultFlags     = "FC"
+	defaultOffset    = "0"
+	binfmtMiscPath   = "/proc/sys/fs/binfmt_misc"
+)
+
+func (r *Registration) buildRegistrationString() string {
+	return fmt.Sprintf(":%s:%s:%s:%s:%s:%s:%s",
+		r.Name, r.MagicType, r.Offset,
+		bytesToEscapedString(r.Magic),
+		bytesToEscapedString(r.Mask),
+		r.Interpreter, r.Flags)
+}
+
+func (r *Registration) register() error {
+	logrus.Debugf("Registering binfmt_misc for %s", r.Name)
+
+	regString := r.buildRegistrationString()
+	logrus.Debugf("Registration string: %s", regString)
+
+	if err := os.WriteFile(filepath.Join(binfmtMiscPath, "register"), []byte(regString), 0200); err != nil {
+		return fmt.Errorf("failed to register binfmt_misc handler: %w", err)
+	}
+	return nil
+}
+
+func bytesToEscapedString(bytes []byte) string {
+	var result strings.Builder
+	for _, b := range bytes {
+		result.WriteString(fmt.Sprintf("\\x%02x", b))
+	}
+	return result.String()
+}
+
+func getDefaultRegistration(archID int, interpreterPath string) *Registration {
+	arch, exists := getArchitecture(archID)
+	if !exists {
+		return nil
+	}
+
+	var name string
+	flags := defaultFlags
+	magicType := defaultMagicType
+	offset := defaultOffset
+
+	if arch.BinfmtName != "" {
+		name = arch.BinfmtName
+	} else {
+		name = "qemu-" + arch.NameBinfmt
+	}
+
+	if arch.BinfmtFlags != "" {
+		flags = arch.BinfmtFlags
+	}
+
+	if arch.BinfmtMagicType != "" {
+		magicType = arch.BinfmtMagicType
+	}
+
+	if arch.BinfmtOffset != "" {
+		offset = arch.BinfmtOffset
+	}
+
+	interpreter := interpreterPath
+	if !strings.HasPrefix(interpreterPath, "/run/host/") {
+		interpreter = filepath.Join("/run/host", interpreter)
+	}
+
+	return &Registration{
+		Name:        name,
+		MagicType:   magicType,
+		Offset:      offset,
+		Magic:       arch.ELFMagic,
+		Mask:        arch.ELFMask,
+		Interpreter: interpreter,
+		Flags:       flags,
+	}
+}
+
+func MountBinfmtMisc() error {
+	args := []string{
+		"binfmt_misc",
+		"-t",
+		"binfmt_misc",
+		binfmtMiscPath,
+	}
+
+	var stdout bytes.Buffer
+
+	if err := shell.Run("mount", nil, &stdout, nil, args...); err != nil {
+		return fmt.Errorf("failed to mount binfmt_misc: %w", err)
+	}
+
+	logrus.Debugf("Result of mount command: %s", stdout.String())
+
+	return nil
+}
+
+func RegisterBinfmtMisc(archID int, interpreterPath string) error {
+	reg := getDefaultRegistration(archID, interpreterPath)
+	if reg == nil {
+		logrus.Debugf("Unable to register binfmt_misc for architecture '%s'", GetArchNameOCI(archID))
+		return fmt.Errorf("Toolbx does not support architecture '%s'", GetArchNameOCI(archID))
+	}
+
+	if err := reg.register(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/src/pkg/shell/shell.go
+++ b/src/pkg/shell/shell.go
@@ -81,8 +81,49 @@ func RunContextWithExitCode(ctx context.Context,
 	return 0, nil
 }
 
+func RunContextWithExitCode2(ctx context.Context,
+	name string,
+	stdin io.Reader,
+	stdout, stderr io.Writer,
+	arg ...string) (int, error) {
+
+	logLevel := logrus.GetLevel()
+	if stderr == nil && logLevel >= logrus.DebugLevel {
+		stderr = os.Stderr
+	}
+
+	cmd := exec.CommandContext(ctx, name, arg...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Run(); err != nil {
+		exitCode := 1
+
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return 1, ctxErr
+		}
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+			return exitCode, err
+		}
+
+		return exitCode, err
+	}
+
+	return 0, nil
+}
+
 func RunWithExitCode(name string, stdin io.Reader, stdout, stderr io.Writer, arg ...string) (int, error) {
 	ctx := context.Background()
 	exitCode, err := RunContextWithExitCode(ctx, name, stdin, stdout, stderr, arg...)
+	return exitCode, err
+}
+
+func RunWithExitCode2(name string, stdin io.Reader, stdout, stderr io.Writer, arg ...string) (int, error) {
+	ctx := context.Background()
+	exitCode, err := RunContextWithExitCode2(ctx, name, stdin, stdout, stderr, arg...)
 	return exitCode, err
 }

--- a/src/pkg/skopeo/skopeo.go
+++ b/src/pkg/skopeo/skopeo.go
@@ -20,15 +20,70 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 
+	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/shell"
+	"github.com/docker/go-units"
+	"github.com/sirupsen/logrus"
 )
 
 type Layer struct {
 	Size json.Number
 }
+
 type Image struct {
-	LayersData []Layer
+	Architecture string `json:"Architecture"`
+	LayersData   []Layer
+	NameFull     string
+}
+
+func (image *Image) GetSize() (float64, error) {
+	var imageSizeFloat float64
+
+	if image.LayersData == nil {
+		return -1, errors.New("'skopeo inspect' did not have LayersData")
+	}
+
+	for _, layer := range image.LayersData {
+		if layerSize, err := layer.Size.Float64(); err != nil {
+			return -1, err
+		} else {
+			imageSizeFloat += layerSize
+		}
+	}
+
+	return imageSizeFloat, nil
+}
+
+func (image *Image) GetSizeHuman() (string, error) {
+	imageSizeFloat, err := image.GetSize()
+	if err != nil {
+		return "", err
+	}
+
+	imageSizeHuman := units.HumanSize(imageSizeFloat)
+	return imageSizeHuman, nil
+}
+
+func (image *Image) VerifyArchitectureMatch(expectedArchID int) error {
+	expectedArchName := architecture.GetArchNameOCI(expectedArchID)
+	logrus.Debugf("Verifying image %s supports architecture %s", image.NameFull, expectedArchName)
+
+	actualArchID, err := architecture.ParseArgArchValue(image.Architecture)
+	if err != nil {
+		return err
+	}
+
+	if actualArchID != expectedArchID {
+		// Single-arch image mismatch
+		return fmt.Errorf("image %s is a single-architecture image for %s, but %s was requested",
+			image.NameFull, image.Architecture, expectedArchName)
+	}
+
+	logrus.Debugf("Architecture verification passed: %s", expectedArchName)
+	return nil
 }
 
 func Inspect(ctx context.Context, target string) (*Image, error) {

--- a/src/pkg/skopeo/skopeo.go
+++ b/src/pkg/skopeo/skopeo.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/containers/toolbox/pkg/architecture"
 	"github.com/containers/toolbox/pkg/shell"
@@ -86,13 +87,49 @@ func (image *Image) VerifyArchitectureMatch(expectedArchID int) error {
 	return nil
 }
 
-func Inspect(ctx context.Context, target string) (*Image, error) {
+func CopyOverrideArch(source, destination string, archID int, authfile string) error {
+
+	destinationWithTransport := "containers-storage:" + destination
+	sourceWithTransport := "docker://" + source
+	args := []string{"copy", "--override-arch", architecture.GetArchNameOCI(archID)}
+
+	if authfile != "" {
+		args = append(args, []string{"--src-authfile", authfile}...)
+	}
+
+	args = append(args, sourceWithTransport, destinationWithTransport)
+
+	if logrus.GetLevel() < logrus.DebugLevel {
+		if err := shell.Run("skopeo", nil, nil, nil, args...); err != nil {
+			return err
+		}
+	} else {
+		if err := shell.Run("skopeo", nil, os.Stderr, nil, args...); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func Inspect(ctx context.Context, target string, archID int, authfile string) (*Image, error) {
 	var stdout bytes.Buffer
 
 	targetWithTransport := "docker://" + target
-	args := []string{"inspect", "--format", "json", targetWithTransport}
+	args := []string{"inspect", "--format", "json"}
 
-	if err := shell.RunContext(ctx, "skopeo", nil, &stdout, nil, args...); err != nil {
+	if !architecture.HasContainerNativeArch(archID) {
+		archName := architecture.GetArchNameOCI(archID)
+		args = append(args, []string{"--override-arch", archName}...)
+	}
+
+	if authfile != "" {
+		args = append(args, []string{"--authfile", authfile}...)
+	}
+
+	args = append(args, targetWithTransport)
+
+	if _, err := shell.RunContextWithExitCode2(ctx, "skopeo", nil, &stdout, nil, args...); err != nil {
 		return nil, err
 	}
 
@@ -101,6 +138,8 @@ func Inspect(ctx context.Context, target string) (*Image, error) {
 	if err := json.Unmarshal(output, &image); err != nil {
 		return nil, err
 	}
+
+	image.NameFull = target
 
 	return &image, nil
 }

--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -664,6 +664,20 @@ func IsP11KitClientPresent() (bool, error) {
 	return false, err
 }
 
+func IsSupportedDistroImage(image string) bool {
+	basename := ImageReferenceGetBasename(image)
+	if basename == "" {
+		return false
+	}
+
+	for _, distroObj := range supportedDistros {
+		if distroObj.ImageBasename == basename {
+			return true
+		}
+	}
+	return false
+}
+
 func SetUpConfiguration() error {
 	logrus.Debug("Setting up configuration")
 


### PR DESCRIPTION
This is PR 6/10 in a series adding cross-architecture container support
using QEMU and binfmt_misc.

Depends on: #1784 (pkg/skopeo: Extend Image struct and add cross-architecture operations)
Please review #1784 first. The new commits in this PR are:
- cmd/utils: cmd/utils: Add architecture resolution from --arch flag, image tags, and names
- cmd/utils: Update resolveContainerAndImageNames for cross-arch support

## Summary

The --arch flag value and architecture embedded in image tags (e.g., _fedora-toolbox:42-aarch64_) need to be resolved into an architecture ID that the rest of the create/enter/run commands can use. When both sources are present, they must not conflict. The architecture in tag detection applies only to images from distributions that Toolbx explicitly supports (see [1]), to avoid a false architecture approach on custom images where a dash-separated component might not represent an architecture, since there is no standard set regarding preserving architecture in the tag (see detailed explanation at [2]).

Cross-architecture images and containers also need distinct names to coexist with native ones. The naming convention appends the OCI architecture name as a suffix (e.g., image -> _fedora-toolbox:42-arm64_, container -> _fedora-toolbox-43-arm64_). The reasoning behind this convention is described in the Podman discussion at [2].

Add:
- `resolveArchitectureID()` that parses the --arch flag, detects architecture from image tags, and validates consistency if both are set. If none of them is set, it falls back to the host architecture, which represents a native behavior.

- `resolveImageNameWithArchitectureSuffix()` that appends an architecture suffix to supported distro image names when the target differs from the host

- Updated `resolveContainerAndImageNames()` with an archID parameter, auto-suffixing container names for non-native architectures

[1] https://containertoolbx.org/distros/
[2] https://github.com/containers/podman/discussions/27780#discussioncomment-16662213