### PR TITLE
SECURITY.md: Use GitHub's private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,33 @@
 ## Security and Disclosure Information Policy for the Toolbx Project
 
-The Toolbx Project follows the
-[Security and Disclosure Information Policy](https://github.com/containers/container-libs/blob/main/SECURITY.md)
-for the Containers Projects.
+## Reporting a Vulnerability
+
+If you think you've identified a security issue in the Toolbx project, please
+DO NOT report the issue publicly via the GitHub issue tracker or Mastodon or
+Matrix. Instead, submit a private vulnerability report.
+
+Go to the *Security and quality* tab on
+[GitHub](https://github.com/containers/toolbox/security), and click *Report a
+vulnerability* to open the advisory form. You can find more information about
+the fields available and guidance on filling in the form
+[here](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/fix-reported-vulnerabilities/creating-a-repository-security-advisory)
+and
+[here](https://docs.github.com/en/code-security/tutorials/fix-reported-vulnerabilities/write-security-advisories).
+
+If you want to work on a fix, you can create a temporary private fork. Only
+the maintainers can merge changes from that private fork into the parent
+repository.
+
+Please do **not** create a public issue.
+
+## Security Vulnerability Response
+
+Each report is acknowledged and analyzed by the maintainers as soon as
+possible.
+
+Any vulnerability information shared with the maintainers stays within the
+Toolbx project and will not be disseminated to other projects unless it is
+necessary to get the issue fixed.
+
+As the security issue moves from triage, to an identified fix, to release
+planning, the maintainers will keep the reporter updated.


### PR DESCRIPTION
The text is based on the previous security policy for the Containers projects [1] and GitHub's documentation for privately reporting a security vulnerability [2].

[1] https://github.com/containers/container-libs/blob/main/SECURITY.md

[2] https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/privately-reporting-a-security-vulnerability

https://github.com/containers/toolbox/issues/1763