### PR TITLE
build: Style fix

### DIFF
--- a/.github/workflows/ubuntu-images.yaml
+++ b/.github/workflows/ubuntu-images.yaml
@@ -36,7 +36,7 @@ jobs:
   build-push-images:
     strategy:
       matrix:
-        release: ['18.04', '20.04', '22.04', '24.04', '25.04', '26.04']
+        release: ['18.04', '20.04', '22.04', '24.04', '25.04', '25.10', '26.04']
       fail-fast: false
 
     runs-on: ubuntu-latest

--- a/images/ubuntu/25.10/Containerfile
+++ b/images/ubuntu/25.10/Containerfile
@@ -1,0 +1,44 @@
+FROM docker.io/library/ubuntu:25.10
+
+LABEL com.github.containers.toolbox="true" \
+      name="ubuntu-toolbox" \
+      version="25.10" \
+      usage="This image is meant to be used with the toolbox command" \
+      summary="Base image for creating Ubuntu Toolbx containers" \
+      maintainer="Ievgen Popovych <jmennius@gmail.com>"
+
+# Remove apt configuration optimized for containers
+# Remove docker-gzip-indexes to help with "command-not-found"
+RUN rm /etc/apt/apt.conf.d/docker-gzip-indexes /etc/apt/apt.conf.d/docker-no-languages
+
+# Restore documentation but do not upgrade all packages
+# Install ubuntu-minimal & ubuntu-standard
+# Install extra packages as well as libnss-myhostname
+COPY extra-packages /
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install unminimize && \
+    sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/bin/unminimize && \
+    yes | /usr/bin/unminimize && \
+    DEBIAN_FRONTEND=noninteractive apt-get -y install \
+        ubuntu-minimal ubuntu-standard \
+        libnss-myhostname \
+        flatpak-xdg-utils \
+        $(cat extra-packages | xargs) && \
+    rm -rd /var/lib/apt/lists/*
+RUN rm /extra-packages
+
+# Enable the use of p11-kit-client.so to access CA certificates from the host
+RUN mkdir --parents /etc/pkcs11/modules
+
+# Fix empty bind-mount to clear selinuxfs (see #337)
+RUN mkdir /usr/share/empty
+
+# Add flatpak-spawn to /usr/bin
+RUN ln -s /usr/libexec/flatpak-xdg-utils/flatpak-spawn /usr/bin/
+
+# Having anything in /home prevents toolbox from symlinking /var/home there,
+# and 'ubuntu' user with UID 1000 will most likely conflict with host user as well
+RUN userdel --remove ubuntu
+
+# Disable APT ESM hook which tries to enable some systemd services on each apt invocation
+RUN rm /etc/apt/apt.conf.d/20apt-esm-hook.conf

--- a/images/ubuntu/25.10/extra-packages
+++ b/images/ubuntu/25.10/extra-packages
@@ -1,0 +1,9 @@
+curl
+git
+gnupg2
+keyutils
+p11-kit-modules
+tree
+unzip
+zip
+zsh

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -116,7 +116,7 @@ dynamic_linker="/run/host$dynamic_linker_canonical_dirname/$dynamic_linker_basen
 go build \
         $tags \
         -trimpath \
-        -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker -Wl,-rpath,/run/host$libc_dir_canonical_dirname -Wl,--export-dynamic -Wl,--unresolved-symbols,ignore-in-object-files' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
+        -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker -Wl,--export-dynamic -Wl,-rpath,/run/host$libc_dir_canonical_dirname -Wl,--unresolved-symbols,ignore-in-object-files' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
         -o "$2/$3"
 
 exit "$?"

--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -116,7 +116,7 @@ dynamic_linker="/run/host$dynamic_linker_canonical_dirname/$dynamic_linker_basen
 go build \
         $tags \
         -trimpath \
-        -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker -Wl,-rpath,/run/host$libc_dir_canonical_dirname -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
+        -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker -Wl,-rpath,/run/host$libc_dir_canonical_dirname -Wl,--export-dynamic -Wl,--unresolved-symbols,ignore-in-object-files' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
         -o "$2/$3"
 
 exit "$?"


### PR DESCRIPTION
Use a comma to pass an argument to an external linker option instead of an equal sign for consistency.  It was originally copied verbatim from the NVIDIA Container Toolkit [1], which itself has this inconsistency.

Fallout from 66280a617ae7eaa29113aeb8e76cbcee6ac04feb

[1] NVIDIA Container Toolkit commit 772cf77dcc2347ce
    https://github.com/NVIDIA/nvidia-container-toolkit/commit/772cf77dcc2347ce
    https://github.com/NVIDIA/nvidia-container-toolkit/pull/333