### PR TITLE
refactor(build): use existing -I and -r flags from cmd/link

### DIFF
--- a/src/go-build-wrapper
+++ b/src/go-build-wrapper
@@ -116,7 +116,7 @@ dynamic_linker="/run/host$dynamic_linker_canonical_dirname/$dynamic_linker_basen
 go build \
         $tags \
         -trimpath \
-        -ldflags "-extldflags '-Wl,-dynamic-linker,$dynamic_linker,--export-dynamic,-rpath,/run/host$libc_dir_canonical_dirname,--unresolved-symbols,ignore-in-object-files,-z,lazy' -linkmode external -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
+        -ldflags "-extldflags '-Wl,--export-dynamic,--unresolved-symbols,ignore-in-object-files,-z,lazy' -I $dynamic_linker -linkmode external -r /run/host$libc_dir_canonical_dirname -X github.com/containers/toolbox/pkg/version.currentVersion=$4" \
         -o "$2/$3"
 
 exit "$?"


### PR DESCRIPTION
Make cmd/link pass these flags to the compiler driver instead of doing it manually.

Here you go. Naturally this will change after the other pull request is merged. RPATH is set correctly from what I can tell.