### PR TITLE
cmd/create: add --volume option to allow mounting host directories

### DIFF
--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -120,10 +120,10 @@ remote registry.
 Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `--image`.
 
-**--volume** HOST-DIR:CONTAINER-DIR[:OPTIONS]
+**--volume**, **-V** HOST-DIR:CONTAINER-DIR[:OPTIONS]
 
-Bind mount a host directory into the container. This option can be specified
-multiple times. It is passed directly to `podman create`.
+Bind mount a host directory into the container. Can be specified multiple
+times. It is passed directly to `podman create`.
 For more details see `podman-create(1)`.
 
 Note: Toolbx internally manages a part of system directories such as
@@ -159,8 +159,8 @@ $ toolbox create --authfile ~/auth.json --image registry.example.com/bar
 ### Create a Toolbx container with custom volumes
 
 ```
-$ toolbox create --volume /nix:/nix:ro \
-  --volume /etc/profile.d/nix.sh:/etc/profile.d/nix.sh:ro
+$ toolbox create --volume /home/user/data:/data \
+  --volume /etc/config:/etc/config:rslave
 ```
 
 ## SEE ALSO

--- a/doc/toolbox-create.1.md
+++ b/doc/toolbox-create.1.md
@@ -120,6 +120,16 @@ remote registry.
 Create a Toolbx container for a different operating system RELEASE than the
 host. Cannot be used with `--image`.
 
+**--volume** HOST-DIR:CONTAINER-DIR[:OPTIONS]
+
+Bind mount a host directory into the container. This option can be specified
+multiple times. It is passed directly to `podman create`.
+For more details see `podman-create(1)`.
+
+Note: Toolbx internally manages a part of system directories such as
+/run, /tmp or /etc. Mounting over them may cause the container to fail or
+the mounted contents to be obscured.
+
 ## EXAMPLES
 
 ### Create the default Toolbx container matching the host OS
@@ -144,6 +154,13 @@ $ toolbox create --image bar foo
 
 ```
 $ toolbox create --authfile ~/auth.json --image registry.example.com/bar
+```
+
+### Create a Toolbx container with custom volumes
+
+```
+$ toolbox create --volume /nix:/nix:ro \
+  --volume /etc/profile.d/nix.sh:/etc/profile.d/nix.sh:ro
 ```
 
 ## SEE ALSO

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -54,6 +54,7 @@ var (
 		distro    string
 		image     string
 		release   string
+		volume    []string
 	}
 
 	createToolboxShMounts = []struct {
@@ -103,6 +104,12 @@ func init() {
 		"r",
 		"",
 		"Create a Toolbx container for a different operating system release than the host")
+
+	flags.StringArrayVarP(&createFlags.volume,
+		"volume",
+		"",
+		[]string{},
+		"Bind mount a volume into the Toolbx container")
 
 	createCmd.SetHelpFunc(createHelp)
 
@@ -175,19 +182,19 @@ func create(cmd *cobra.Command, args []string) error {
 		createFlags.distro,
 		createFlags.image,
 		createFlags.release)
-
 	if err != nil {
 		return err
 	}
 
-	if err := createContainer(container, image, release, createFlags.authFile, true); err != nil {
+	if err := createContainer(container, image, release,
+		createFlags.authFile, createFlags.volume, true); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func createContainer(container, image, release, authFile string, showCommandToEnter bool) error {
+func createContainer(container, image, release, authFile string, volumes []string, showCommandToEnter bool) error {
 	if container == "" {
 		panic("container not specified")
 	}
@@ -473,6 +480,10 @@ func createContainer(container, image, release, authFile string, showCommandToEn
 	createArgs = append(createArgs, pcscSocketMount...)
 	createArgs = append(createArgs, runMediaMount...)
 	createArgs = append(createArgs, toolboxShMount...)
+
+	// NOTE: Mandatory volumes must be appended before this line.
+	volumeArgs := createVolumeArgs(volumes)
+	createArgs = append(createArgs, volumeArgs...)
 
 	createArgs = append(createArgs, []string{
 		imageFull,
@@ -989,6 +1000,17 @@ func systemdPathBusEscape(path string) string {
 		}
 	}
 	return string(n)
+}
+
+func createVolumeArgs(volumes []string) []string {
+	if len(volumes) == 0 {
+		return nil
+	}
+	result := make([]string, 0, len(volumes)*2)
+	for _, volume := range volumes {
+		result = append(result, "--volume", volume)
+	}
+	return result
 }
 
 func (err *promptForDownloadError) Error() string {

--- a/src/cmd/create.go
+++ b/src/cmd/create.go
@@ -107,7 +107,7 @@ func init() {
 
 	flags.StringArrayVarP(&createFlags.volume,
 		"volume",
-		"",
+		"V",
 		[]string{},
 		"Bind mount a volume into the Toolbx container")
 

--- a/src/cmd/run.go
+++ b/src/cmd/run.go
@@ -146,7 +146,6 @@ func run(cmd *cobra.Command, args []string) error {
 		runFlags.distro,
 		"",
 		runFlags.release)
-
 	if err != nil {
 		return err
 	}
@@ -171,8 +170,8 @@ func runCommand(container string,
 	image, release string,
 	preserveFDs uint,
 	command []string,
-	emitEscapeSequence, fallbackToBash, pedantic bool) error {
-
+	emitEscapeSequence, fallbackToBash, pedantic bool,
+) error {
 	if !pedantic {
 		if image == "" {
 			panic("image not specified")
@@ -225,7 +224,7 @@ func runCommand(container string,
 				return nil
 			}
 
-			if err := createContainer(container, image, release, "", false); err != nil {
+			if err := createContainer(container, image, release, "", nil, false); err != nil {
 				return err
 			}
 		} else if containersCount == 1 && defaultContainer {
@@ -362,8 +361,8 @@ func runCommand(container string,
 func runCommandWithFallbacks(container string,
 	preserveFDs uint,
 	command, environ []string,
-	emitEscapeSequence, fallbackToBash bool) error {
-
+	emitEscapeSequence, fallbackToBash bool,
+) error {
 	logrus.Debug("Checking if 'podman exec' supports disabling the detach keys")
 
 	var detachKeysSupported bool
@@ -563,8 +562,8 @@ func constructExecArgs(container, preserveFDs string,
 	envOptions []string,
 	fallbackToBash bool,
 	ttyNeeded bool,
-	workDir string) []string {
-
+	workDir string,
+) []string {
 	logLevelString := podman.LogLevel.String()
 
 	execArgs := []string{
@@ -797,7 +796,8 @@ func handleEntryPointLog(ctx context.Context,
 	container string,
 	end bool,
 	line string,
-	collectEntryPointErrorFn collectEntryPointErrorFunc) error {
+	collectEntryPointErrorFn collectEntryPointErrorFunc,
+) error {
 	if end {
 		if cause := context.Cause(ctx); errors.Is(cause, context.Canceled) {
 			return cause
@@ -918,7 +918,7 @@ func saveCDISpecTo(spec *specs.Spec, path string) error {
 		return errors.New("failed to marshal Container Device Interface to JSON")
 	}
 
-	if err := renameio.WriteFile(path, data, 0644); err != nil {
+	if err := renameio.WriteFile(path, data, 0o644); err != nil {
 		logrus.Debugf("Saving Container Device Interface: failed to write file: %s", err)
 		return errors.New("failed to write Container Device Interface to file")
 	}

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1221,3 +1221,47 @@ teardown() {
   assert_success
   assert_output "true"
 }
+
+@test "create: With custom volumes (using --volume)" {
+  pull_default_image
+
+  local container="test-volume"
+  local source1="$BATS_TEST_TMPDIR/source1"
+  local source2="$BATS_TEST_TMPDIR/source2"
+  mkdir -p "$source1"
+  mkdir -p "$source2"
+
+  run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create \
+        --container "$container" \
+        --volume "$source1:/destination1" \
+        --volume "$source2:/destination2:ro,rslave"
+
+  assert_success
+  assert_line --index 0 "Created container: $container"
+  assert_line --index 1 "Enter with: toolbox enter $container"
+  assert [ ${#lines[@]} -eq 2 ]
+  assert [ ${#stderr_lines[@]} -eq 0 ]
+
+  run podman ps --all
+
+  assert_success
+  assert_output --regexp "Created[[:blank:]]+$container"
+
+  run podman inspect \
+        --format '{{index .Config.Labels "com.github.containers.toolbox"}}' \
+        --type container \
+        "$container"
+
+  assert_success
+  assert_output "true"
+
+  run podman inspect \
+        --format '{{.Config.CreateCommand}}' \
+        --type container \
+        "$container"
+
+  assert_success
+  assert_output --partial "--volume $source1:/destination1"
+  assert_output --partial "--volume $source2:/destination2:ro,rslave"
+}
+

--- a/test/system/101-create.bats
+++ b/test/system/101-create.bats
@@ -1234,7 +1234,7 @@ teardown() {
   run --keep-empty-lines --separate-stderr "$TOOLBX" --assumeyes create \
         --container "$container" \
         --volume "$source1:/destination1" \
-        --volume "$source2:/destination2:ro,rslave"
+        --volume "$source2:/destination2:rw,rslave"
 
   assert_success
   assert_line --index 0 "Created container: $container"
@@ -1262,6 +1262,6 @@ teardown() {
 
   assert_success
   assert_output --partial "--volume $source1:/destination1"
-  assert_output --partial "--volume $source2:/destination2:ro,rslave"
+  assert_output --partial "--volume $source2:/destination2:rw,rslave"
 }
 


### PR DESCRIPTION
Allow mounting host directories into Toolbx containers. This option provides
a way to integrate specialized host-side environments (such as Nix or custom developer toolchains) without sacrificing the container's integrity or modifying shell configuration files.
Fixes: #1600

- cmd/create: Add --volume option to 'toolbox create'
- doc/toolbox.create.1.md: Update man page to document the new option and
  provide usage guidance and safety warnings.
- system/101-create.bats: Add a test for create with --volume option