### PR TITLE
Attempt to fix CI timeouts

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -116,7 +116,9 @@ function _pull_and_cache_distro_image() {
   local -i ret_val
 
   for ((j = 0; j < num_of_retries; j++)); do
-    error_message="$( (skopeo copy --dest-compress \
+    error_message="$( (skopeo copy \
+                          --command-timeout 10m \
+                          --dest-compress \
                           "docker://${image}" \
                           "dir:${IMAGE_CACHE_DIR}/${image_archive}" >/dev/null) 2>&1)"
     ret_val="$?"
@@ -211,7 +213,9 @@ function _setup_docker_registry() {
   assert_success
 
   # Add fedora-toolbox:34 image to the registry
-  run skopeo copy --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
+  run skopeo copy \
+    --command-timeout 60s \
+    --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
     dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
     docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
   assert_success
@@ -331,7 +335,10 @@ function pull_distro_image() {
   fi
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo copy "dir:${IMAGE_CACHE_DIR}/${image_archive}" "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
+  run skopeo copy \
+      --command-timeout 60s \
+      "dir:${IMAGE_CACHE_DIR}/${image_archive}" \
+      "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
 
   # shellcheck disable=SC2154
   if [ "$status" -ne 0 ]; then
@@ -364,6 +371,7 @@ function pull_default_image_and_copy() {
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
   run skopeo copy \
+      --command-timeout 60s \
       "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image" \
       "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image-copy"
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -205,6 +205,23 @@ function _setup_docker_registry() {
     "${IMAGES[docker-reg]}"
   assert_success
 
+  # Ensure the registry is ready
+  local registry_ready=false
+  local -i retries
+  for ((retries = 0; retries < 30; retries++)); do
+    if timeout 5 openssl s_client \
+         -connect "${DOCKER_REG_URI}" \
+         -CAfile "${DOCKER_REG_CERTS_DIR}/domain.crt" \
+         </dev/null >/dev/null 2>&1; then
+      registry_ready=true
+      break
+    fi
+    sleep 1
+  done
+  if ! $registry_ready; then
+    fail "Docker registry at ${DOCKER_REG_URI} did not reach a ready state"
+  fi
+
   run podman login \
     --authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
     --username user \

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -42,7 +42,7 @@ readonly TOOLBX_TEST_SYSTEM_TAGS="${TOOLBX_TEST_SYSTEM_TAGS:-$TOOLBX_TEST_SYSTEM
 # Images
 declare -Ag IMAGES=([arch]="quay.io/toolbx/arch-toolbox" \
                    [busybox]="quay.io/toolbox_tests/busybox" \
-                   [docker-reg]="quay.io/toolbox_tests/registry" \
+                   [docker-reg]="ghcr.io/distribution/distribution:3" \
                    [fedora]="registry.fedoraproject.org/fedora-toolbox" \
                    [rhel]="registry.access.redhat.com/ubi8/toolbox" \
                    [ubuntu]="quay.io/toolbx/ubuntu-toolbox")


### PR DESCRIPTION
Attempt to fix CI timeouts with suggestions from #1805.

1. Add `--command-timeout` to `skopeo copy` calls so they can't hang forever
2. When setting up the local Docker registry, add a step to wait and ensure it's ready before proceeding

@debarshiray I chose to go with 10m timeout for the one over the network and 60s for the ones happening locally (in case there's some really slow IO). Did also take the `openssl s_client` approach like you suggested too. WDYT?