### PR TITLE
Migrate the config directory from ~/.config/toolbox to ~/.config/toolbx

### DIFF
--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -8,8 +8,8 @@ root_config="${XDG_CONFIG_HOME:-$HOME/.config}"
 toolbox_config="$root_config/toolbx"
 toolbox_config_old="$root_config/toolbox"
 
-if [[ -d "$toolbox_config_old" && ! -e "$toolbox_config" ]]; then
-    mv "$toolbox_config_old" "$toolbox_config"
+if [ -d "$toolbox_config_old" ] && ! [ -e "$toolbox_config" ]; then
+    mv "$toolbox_config_old" "$toolbox_config" 2>/dev/null
 fi
 
 host_welcome_stub="$toolbox_config/host-welcome-shown"

--- a/profile.d/toolbox.sh
+++ b/profile.d/toolbox.sh
@@ -4,7 +4,14 @@
 [ "${BASH_VERSION:-}" != "" ] || [ "${ZSH_VERSION:-}" != "" ] || return 0
 [ "$PS1" != "" ] || return 0
 
-toolbox_config="${XDG_CONFIG_HOME:-$HOME/.config}/toolbox"
+root_config="${XDG_CONFIG_HOME:-$HOME/.config}"
+toolbox_config="$root_config/toolbx"
+toolbox_config_old="$root_config/toolbox"
+
+if [[ -d "$toolbox_config_old" && ! -e "$toolbox_config" ]]; then
+    mv "$toolbox_config_old" "$toolbox_config"
+fi
+
 host_welcome_stub="$toolbox_config/host-welcome-shown"
 toolbox_welcome_stub="$toolbox_config/toolbox-welcome-shown"
 

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -238,7 +238,7 @@ func migrate(cmd *cobra.Command, args []string) error {
 		return errors.New("failed to get the user config directory")
 	}
 
-	toolboxConfigDir := configDir + "/toolbox"
+	toolboxConfigDir := configDir + "/toolbx"
 	stampPath := toolboxConfigDir + "/podman-system-migrate"
 	logrus.Debugf("Toolbx config directory is %s", toolboxConfigDir)
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -166,9 +166,9 @@ function _setup_docker_registry() {
   assert_success
 
   # Add certificate to Podman's trusted certificates (rootless)
-  run mkdir -p "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
+  run mkdir -p "$XDG_CONFIG_HOME"/containers/certs.d/"${DOCKER_REG_URI}"
   assert_success
-  run cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
+  run cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$XDG_CONFIG_HOME"/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
   assert_success
 
   # Create a registry user
@@ -234,7 +234,7 @@ function _clean_docker_registry() {
   # Remove Docker registry dir
   rm --force --recursive "${DOCKER_REG_ROOT}"
   # Remove dir with created registry certificates
-  rm --force --recursive "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
+  rm --force --recursive "$XDG_CONFIG_HOME"/containers/certs.d/"${DOCKER_REG_URI}"
 }
 
 


### PR DESCRIPTION
This PR applies the patches I wrote and shared in https://github.com/containers/toolbox/pull/1769.

The first commit replaces $HOME/.config with $XDG_CONFIG_HOME in test/system/libs/helpers.bash, as suggested in https://github.com/containers/toolbox/pull/1769#issuecomment-4625634761. This should've been part of that PR, but I forgot to include it and wasn't able to add it before the PR was merged.

The second commit just replaces ~/.config/toolbox with ~/.config/toolbx. Additionally, the migration is done by first checking whether a directory exists at the old location and if there isn't anything at the new location. If both of these conditions evaluate to true, the old directory is moved to the new location.

It should be stated that there were some issues with the migration as discussed in https://github.com/containers/toolbox/pull/1769#issuecomment-4702542279. However, I wasn't able to reproduce the issue any longer and instead the migration worked flawlessly, with containers created on the original build working just fine after updating to a build with this PR applied.