### PR TITLE
ubuntu: Add NOPASSWD sudoers rule for 25.10 and 26.04

### DIFF
--- a/images/ubuntu/25.10/Containerfile
+++ b/images/ubuntu/25.10/Containerfile
@@ -27,6 +27,9 @@ RUN apt-get update && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages
 
+# Allow passwordless sudo for the sudo group
+RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/90-toolbx-nopasswd
+
 # Enable the use of p11-kit-client.so to access CA certificates from the host
 RUN mkdir --parents /etc/pkcs11/modules
 

--- a/images/ubuntu/26.04/Containerfile
+++ b/images/ubuntu/26.04/Containerfile
@@ -27,6 +27,9 @@ RUN apt-get update && \
     rm -rd /var/lib/apt/lists/*
 RUN rm /extra-packages
 
+# Allow passwordless sudo for the sudo group
+RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/90-toolbx-nopasswd
+
 # Enable the use of p11-kit-client.so to access CA certificates from the host
 RUN mkdir --parents /etc/pkcs11/modules
 


### PR DESCRIPTION
Ubuntu 25.10 switched from traditional C sudo to sudo-rs (Rust-based sudo). ~Unlike C sudo, sudo-rs does not use PAM for authentication and therefore does not honor the nullok option in /etc/pam.d/common-auth.~ 
Edit: this analysis is wrong, check comment by foriequal0 below. 

Toolbox creates users with an empty password (useradd --password "") and relies on PAM's nullok to accept blank authentication. With sudo-rs, this no longer works and the user gets prompted for a password.

Fix this by adding an explicit NOPASSWD sudoers drop-in for the sudo group, matching the approach already used in the Arch Containerfile. This works regardless of the sudo implementation.

Assisted by: Claude Opus 4.6 <noreply@anthropic.com>

Fixes https://github.com/containers/toolbox/issues/1807