### PR TITLE
test/system: add --command-timeout to skopeo copy calls

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -116,7 +116,7 @@ function _pull_and_cache_distro_image() {
   local -i ret_val
 
   for ((j = 0; j < num_of_retries; j++)); do
-    error_message="$( (skopeo copy \
+    error_message="$( (skopeo --command-timeout 10m copy \
                          --dest-compress \
                          "docker://${image}" \
                          "dir:${IMAGE_CACHE_DIR}/${image_archive}" >/dev/null) 2>&1)"
@@ -212,7 +212,7 @@ function _setup_docker_registry() {
   assert_success
 
   # Add fedora-toolbox:34 image to the registry
-  run skopeo copy \
+  run skopeo --command-timeout 60s copy \
         --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
         dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
         docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
@@ -333,7 +333,7 @@ function pull_distro_image() {
   fi
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo copy \
+  run skopeo --command-timeout 60s copy \
         "dir:${IMAGE_CACHE_DIR}/${image_archive}" \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
 
@@ -367,7 +367,7 @@ function pull_default_image_and_copy() {
   image="${IMAGES[$distro]}:$version"
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo copy \
+  run skopeo --command-timeout 60s copy \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image" \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image-copy"
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -116,9 +116,10 @@ function _pull_and_cache_distro_image() {
   local -i ret_val
 
   for ((j = 0; j < num_of_retries; j++)); do
-    error_message="$( (skopeo copy --dest-compress \
-                          "docker://${image}" \
-                          "dir:${IMAGE_CACHE_DIR}/${image_archive}" >/dev/null) 2>&1)"
+    error_message="$( (skopeo copy \
+                         --dest-compress \
+                         "docker://${image}" \
+                         "dir:${IMAGE_CACHE_DIR}/${image_archive}" >/dev/null) 2>&1)"
     ret_val="$?"
 
     if [ "$ret_val" -eq 0 ]; then
@@ -211,9 +212,10 @@ function _setup_docker_registry() {
   assert_success
 
   # Add fedora-toolbox:34 image to the registry
-  run skopeo copy --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
-    dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
-    docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
+  run skopeo copy \
+        --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
+        dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
+        docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
   assert_success
 
   run rm "${BATS_SUITE_TMPDIR}/authfile.json"
@@ -331,7 +333,9 @@ function pull_distro_image() {
   fi
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo copy "dir:${IMAGE_CACHE_DIR}/${image_archive}" "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
+  run skopeo copy \
+        "dir:${IMAGE_CACHE_DIR}/${image_archive}" \
+        "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
 
   # shellcheck disable=SC2154
   if [ "$status" -ne 0 ]; then
@@ -364,8 +368,8 @@ function pull_default_image_and_copy() {
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
   run skopeo copy \
-      "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image" \
-      "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image-copy"
+        "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image" \
+        "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image-copy"
 
   if [ "$status" -ne 0 ]; then
     echo "Failed to copy image $image to $image-copy"


### PR DESCRIPTION
For some reason, calls to skopeo copy sometimes hang indefinitely. Avoid
this issue by specifying --command-timeout with reasonable values
(longer for call which must fetch over the network).

https://github.com/containers/toolbox/pull/1811