### PR TITLE
pkg/utils: Update fallback release to 44 for non-fedora hosts

### DIFF
--- a/src/pkg/utils/utils.go
+++ b/src/pkg/utils/utils.go
@@ -65,7 +65,7 @@ const (
 	containerNamePrefixFallback = "fedora-toolbox"
 	distroFallback              = "fedora"
 	idTruncLength               = 12
-	releaseFallback             = "42"
+	releaseFallback             = "44"
 )
 
 const (


### PR DESCRIPTION
Fedora 42 reached End of Life on 27th May 2026:
https://docs.fedoraproject.org/en-US/releases/eol/

https://github.com/containers/toolbox/issues/1819