### PR TITLE
test/system: Simplify capturing standard error from command substitution

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -78,7 +78,6 @@ function _setup_containers_storage() {
 # Only use during test suite setup for caching all images to be used throughout
 # tests.
 function _pull_and_cache_distro_image() {
-  local num_of_retries=5
   local timeout=10
   local cached=false
   local distro
@@ -112,10 +111,11 @@ function _pull_and_cache_distro_image() {
   fi
 
   local error_message
-  local -i j
+  local max_retries=5
   local -i ret_val
+  local -i retries
 
-  for ((j = 0; j < num_of_retries; j++)); do
+  for ((retries = 0; retries < max_retries; retries++)); do
     ret_val=0
     error_message="$(skopeo --command-timeout 10m copy \
                        --dest-compress \
@@ -508,10 +508,10 @@ function container_started() {
 
   start_container "$container_name"
 
-  local -i j
-  local num_of_retries=5
+  local max_retries=5
+  local -i retries
 
-  for ((j = 0; j < num_of_retries; j++)); do
+  for ((retries = 0; retries < max_retries; retries++)); do
     run --separate-stderr podman logs "$container_name"
 
     # shellcheck disable=SC2154
@@ -532,7 +532,7 @@ function container_started() {
   done
 
   if [ "$ret_val" -ne 0 ]; then
-    if [ "$j" -eq "$num_of_retries" ]; then
+    if [ "$retries" -eq "$max_retries" ]; then
       fail "Failed to initialize container $container_name"
     fi
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -117,10 +117,10 @@ function _pull_and_cache_distro_image() {
 
   for ((j = 0; j < num_of_retries; j++)); do
     ret_val=0
-    error_message="$( (skopeo --command-timeout 10m copy \
-                         --dest-compress \
-                         "docker://${image}" \
-                         "dir:${IMAGE_CACHE_DIR}/${image_archive}" >/dev/null) 2>&1)" || ret_val="$?"
+    error_message="$(skopeo --command-timeout 10m copy \
+                       --dest-compress \
+                       "docker://${image}" \
+                       "dir:${IMAGE_CACHE_DIR}/${image_archive}" 2>&1 >/dev/null)" || ret_val="$?"
 
     if [ "$ret_val" -eq 0 ]; then
       cached=true

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -111,7 +111,7 @@ function _pull_and_cache_distro_image() {
   fi
 
   local error_message
-  local max_retries=5
+  local -i max_retries=5
   local -i ret_val
   local -i retries
 
@@ -508,7 +508,7 @@ function container_started() {
 
   start_container "$container_name"
 
-  local max_retries=5
+  local -i max_retries=5
   local -i retries
 
   for ((retries = 0; retries < max_retries; retries++)); do


### PR DESCRIPTION
This removes the nested subshell and saves spawning an extra process to achieve the exact same result.

As suggested by Gemini Code Assist.

Fallout from 61e2c970f821221f43ac7831849497236fbd5eb0 and 2e7ba83be2eff0d5e815915e739456dc9fd3224b