### PR TITLE
test/system: use a random port for the local Docker registry

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -31,8 +31,10 @@ readonly ROOTLESS_PODMAN_RUNROOT_DIR="$BATS_SUITE_TMPDIR/runroot"
 readonly DOCKER_REG_ROOT="$BATS_SUITE_TMPDIR/docker-registry-root"
 readonly DOCKER_REG_CERTS_DIR="$BATS_SUITE_TMPDIR/certs"
 readonly DOCKER_REG_AUTH_DIR="$BATS_SUITE_TMPDIR/auth"
-readonly DOCKER_REG_URI="localhost:50000"
 readonly DOCKER_REG_NAME="docker-registry"
+# The contents of the file are set when setting up the local Docker registry.
+readonly DOCKER_REG_URI_FILE="$BATS_SUITE_TMPDIR/docker-reg-uri"
+DOCKER_REG_URI="$(cat "$DOCKER_REG_URI_FILE" 2>/dev/null || true)"
 
 # Podman and Toolbx commands to run
 readonly TOOLBX="${TOOLBX:-$(command -v toolbox)}"
@@ -164,10 +166,6 @@ function _setup_docker_registry() {
     -subj '/' \
     -out "${DOCKER_REG_CERTS_DIR}"/domain.crt
 
-  # Add certificate to Podman's trusted certificates (rootless)
-  mkdir --parents "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
-  cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
-
   # Create a registry user
   # username: user; password: user
   mkdir --parents "${DOCKER_REG_AUTH_DIR}"
@@ -189,11 +187,20 @@ function _setup_docker_registry() {
     --env REGISTRY_HTTP_TLS_KEY=/certs/domain.key \
     --name "${DOCKER_REG_NAME}" \
     --privileged \
-    --publish 50000:5000 \
+    --publish 5000 \
     --rm \
     --volume "${DOCKER_REG_AUTH_DIR}":/auth \
     --volume "${DOCKER_REG_CERTS_DIR}":/certs \
     "${IMAGES[docker-reg]}"
+
+  local docker_reg_port
+  docker_reg_port="$(podman --root "${DOCKER_REG_ROOT}" port "${DOCKER_REG_NAME}" 5000)"
+  DOCKER_REG_URI="localhost:${docker_reg_port##*:}"
+  echo "$DOCKER_REG_URI" > "$DOCKER_REG_URI_FILE"
+
+  # Add certificate to Podman's trusted certificates (rootless)
+  mkdir --parents "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
+  cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
 
   _wait_for_docker_registry
 


### PR DESCRIPTION
> Hard-coding the port to 50000 can cause intermittent failures when the port happens to already be in use, and also prevents running the test suite more than once at the same time.
> 
> Let Podman pick a random available port and persist it to a file so test processes in the same run can find it.

See https://github.com/containers/toolbox/pull/1817#issuecomment-4929359777. I _believe_ this should do the trick @debarshiray 