### PR TITLE
test/system: Don't use Bats' 'run' to only check if a command succeeded

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -106,8 +106,7 @@ function _pull_and_cache_distro_image() {
   fi
 
   if [ ! -d "${IMAGE_CACHE_DIR}" ]; then
-    run mkdir --parents "${IMAGE_CACHE_DIR}"
-    assert_success
+    mkdir --parents "${IMAGE_CACHE_DIR}"
   fi
 
   local error_message
@@ -153,9 +152,8 @@ function _setup_docker_registry() {
   # Create certificates for HTTPS
   # This is needed so that Podman does not have to be configured to work with
   # HTTP-only registries
-  run mkdir --parents "${DOCKER_REG_CERTS_DIR}"
-  assert_success
-  run openssl req \
+  mkdir --parents "${DOCKER_REG_CERTS_DIR}"
+  openssl req \
     -newkey rsa:4096 \
     -nodes -sha256 \
     -keyout "${DOCKER_REG_CERTS_DIR}"/domain.key \
@@ -164,31 +162,24 @@ function _setup_docker_registry() {
     -days 365 \
     -subj '/' \
     -out "${DOCKER_REG_CERTS_DIR}"/domain.crt
-  assert_success
 
   # Add certificate to Podman's trusted certificates (rootless)
-  run mkdir --parents "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
-  assert_success
-  run cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
-  assert_success
+  mkdir --parents "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
+  cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
 
   # Create a registry user
   # username: user; password: user
-  run mkdir --parents "${DOCKER_REG_AUTH_DIR}"
-  assert_success
-  run htpasswd -Bbc "${DOCKER_REG_AUTH_DIR}"/htpasswd user user
-  assert_success
+  mkdir --parents "${DOCKER_REG_AUTH_DIR}"
+  htpasswd -Bbc "${DOCKER_REG_AUTH_DIR}"/htpasswd user user
 
   # Create separate Podman root
-  run mkdir --parents "${DOCKER_REG_ROOT}"
-  assert_success
+  mkdir --parents "${DOCKER_REG_ROOT}"
 
   # Pull Docker registry image
-  run podman --root "${DOCKER_REG_ROOT}" pull "${IMAGES[docker-reg]}"
-  assert_success
+  podman --root "${DOCKER_REG_ROOT}" pull "${IMAGES[docker-reg]}"
 
   # Create a Docker registry
-  run podman --root "${DOCKER_REG_ROOT}" run \
+  podman --root "${DOCKER_REG_ROOT}" run \
     --detach \
     --env REGISTRY_AUTH=htpasswd \
     --env REGISTRY_AUTH_HTPASSWD_PATH="/auth/htpasswd" \
@@ -202,26 +193,18 @@ function _setup_docker_registry() {
     --volume "${DOCKER_REG_AUTH_DIR}":/auth \
     --volume "${DOCKER_REG_CERTS_DIR}":/certs \
     "${IMAGES[docker-reg]}"
-  assert_success
 
   _wait_for_docker_registry
 
-  run podman login \
-    --authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
-    --username user \
-    --password user \
-    "${DOCKER_REG_URI}"
-  assert_success
+  podman login --authfile "${BATS_SUITE_TMPDIR}/authfile.json" --username user --password user "${DOCKER_REG_URI}"
 
   # Add fedora-toolbox:34 image to the registry
-  run skopeo --command-timeout 60s copy \
-        --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
-        dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
-        docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
-  assert_success
+  skopeo --command-timeout 60s copy \
+    --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
+    dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
+    docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
 
-  run rm "${BATS_SUITE_TMPDIR}/authfile.json"
-  assert_success
+  rm "${BATS_SUITE_TMPDIR}/authfile.json"
 }
 
 

--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -106,7 +106,7 @@ function _pull_and_cache_distro_image() {
   fi
 
   if [ ! -d "${IMAGE_CACHE_DIR}" ]; then
-    run mkdir -p "${IMAGE_CACHE_DIR}"
+    run mkdir --parents "${IMAGE_CACHE_DIR}"
     assert_success
   fi
 
@@ -153,7 +153,7 @@ function _setup_docker_registry() {
   # Create certificates for HTTPS
   # This is needed so that Podman does not have to be configured to work with
   # HTTP-only registries
-  run mkdir -p "${DOCKER_REG_CERTS_DIR}"
+  run mkdir --parents "${DOCKER_REG_CERTS_DIR}"
   assert_success
   run openssl req \
     -newkey rsa:4096 \
@@ -167,20 +167,20 @@ function _setup_docker_registry() {
   assert_success
 
   # Add certificate to Podman's trusted certificates (rootless)
-  run mkdir -p "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
+  run mkdir --parents "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"
   assert_success
   run cp "${DOCKER_REG_CERTS_DIR}"/domain.crt "$HOME"/.config/containers/certs.d/"${DOCKER_REG_URI}"/domain.crt
   assert_success
 
   # Create a registry user
   # username: user; password: user
-  run mkdir -p "${DOCKER_REG_AUTH_DIR}"
+  run mkdir --parents "${DOCKER_REG_AUTH_DIR}"
   assert_success
   run htpasswd -Bbc "${DOCKER_REG_AUTH_DIR}"/htpasswd user user
   assert_success
 
   # Create separate Podman root
-  run mkdir -p "${DOCKER_REG_ROOT}"
+  run mkdir --parents "${DOCKER_REG_ROOT}"
   assert_success
 
   # Pull Docker registry image


### PR DESCRIPTION
Bats' `run` helper is not necessary to merely check if a command
succeeded or not [1].

Bats sets Bash's `set -e` [1,2] to fail and exit immediately if a
pipeline, list of commands or compound command returns with a non-zero
exit code.  Therefore, directly invoking the command without `run` is
enough to stop execution in case of an error.

[1] https://bats-core.readthedocs.io/en/stable/writing-tests.html

[2] https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html