### PR TITLE
test/system: Try to prevent local 'skopeo copy' from timing out

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -199,7 +199,7 @@ function _setup_docker_registry() {
   podman login --authfile "${BATS_SUITE_TMPDIR}/authfile.json" --username user --password user "${DOCKER_REG_URI}"
 
   # Add fedora-toolbox:34 image to the registry
-  skopeo --command-timeout 60s copy \
+  skopeo --command-timeout 120s copy \
     --dest-authfile "${BATS_SUITE_TMPDIR}/authfile.json" \
     dir:"${IMAGE_CACHE_DIR}"/fedora-toolbox-34 \
     docker://"${DOCKER_REG_URI}"/fedora-toolbox:34
@@ -371,7 +371,7 @@ function pull_distro_image() {
   fi
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo --command-timeout 60s copy \
+  run skopeo --command-timeout 120s copy \
         "dir:${IMAGE_CACHE_DIR}/${image_archive}" \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]${image}"
 
@@ -405,7 +405,7 @@ function pull_default_image_and_copy() {
   image="${IMAGES[$distro]}:$version"
 
   # https://github.com/containers/skopeo/issues/547 for the options for containers-storage
-  run skopeo --command-timeout 60s copy \
+  run skopeo --command-timeout 120s copy \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image" \
         "containers-storage:[overlay@$TOOLBX_ROOTLESS_STORAGE_PATH+$TOOLBX_ROOTLESS_STORAGE_PATH]$image-copy"
 


### PR DESCRIPTION
The 60 second timeouts might not be quite enough for local `skopeo copy` because they sometimes fail with:
```
  not ok 187 run: Smoke test with 'exit 2'
  # tags: commands-options
  # (from function `assert_success' in file
       test/system/libs/bats-assert/src/assert.bash, line 114,
  #  from function `pull_distro_image' in file
       test/system/libs/helpers.bash, line 391,
  #  from function `pull_default_image' in file
       test/system/libs/helpers.bash, line 402,
  #  from function `create_default_container' in file
       test/system/libs/helpers.bash, line 470,
  #  in test file test/system/104-run.bats, line 806)
  #   `create_default_container' failed
  # ~ /home/zuul-worker/src/github.com/containers/toolbox
  # Failed to load image registry.fedoraproject.org/fedora-toolbox:45
      from cache
      /var/tmp/bats-run-yokdp3/suite/image-cache/fedora-toolbox-45
  #
  # -- command failed --
  # status : 1
  # output (3 lines):
  #   Getting image source signatures
  #   Copying blob sha256:8e0fe36f464ab46d2ce4ea3a1f2779c3921598ebf824e7
  #   time="2026-07-28T00:08:31Z" level=fatal msg="copying config:
        context deadline exceeded"
  # --
  #
```

So, double the timeouts to 120 seconds.

https://github.com/containers/toolbox/pull/1822