### PR TITLE
test/system: Remove stale cache directory left between pull attempts

### DIFF
--- a/test/system/libs/helpers.bash
+++ b/test/system/libs/helpers.bash
@@ -126,6 +126,7 @@ function _pull_and_cache_distro_image() {
       break
     fi
 
+    rm --force --recursive "${IMAGE_CACHE_DIR:?}/${image_archive}"
     sleep "$timeout"
   done
 


### PR DESCRIPTION
When setting up caching for images, if an iteration of the retry loop to download images to the cache fails, it leaves behind a stale cache which will cause the next attempt to also fail with:
```
  not ok 1 setup_suite
  # (from function `_pull_and_cache_distro_image' in file
       test/system/libs/helpers.bash, line 139,
  #  from function `setup_suite' in test file
       test/system/setup_suite.bash, line 59)
  #   `_pull_and_cache_distro_image ubuntu 20.04' failed
  # Failed to cache image quay.io/toolbx/ubuntu-toolbox:20.04 to
      /tmp/bats-run-3FdzJ3/suite/image-cache/ubuntu-toolbox-20.04
  # time="2026-07-28T22:40:16Z" level=fatal msg="initializing
      destination
      dir:/tmp/bats-run-3FdzJ3/suite/image-cache/ubuntu-toolbox-20.04:
      not a containers image directory, don't want to overwrite
      important data"
```

This is because `skopeo(1)` will refuse to write to the directory saying it's not a valid containers image directory.  Specifically, this is the `ErrNotContainerImageDir` error from the `go.podman.io/image/v5/directory` package [1].

Add a clean-up step to remove the directory before the next attempt to avoid the issue.

Shell parameter expansion [2] is used to ensure that `rm(1)` doesn't recursively delete everything in the host operating system's root directory [3] due to future programmer errors.

[1] https://pkg.go.dev/go.podman.io/image/v5/directory

[2] https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

[3] https://www.shellcheck.net/wiki/SC2115

https://github.com/containers/toolbox/pull/1822