### PR TITLE
Revert "playbooks/dependencies-fedora: Unbreak missing subordinate IDs"

### DIFF
--- a/playbooks/dependencies-fedora.yaml
+++ b/playbooks/dependencies-fedora.yaml
@@ -39,22 +39,6 @@
       - udisks2
     use: "{{ 'dnf' if zuul.attempts > 1 else 'auto' }}"
 
-- name: Ensure subordinate ID ranges exist for zuul-worker
-  become: true
-  lineinfile:
-    create: true
-    path: "{{ item.file }}"
-    regexp: "^zuul-worker:"
-    line: "zuul-worker:524288:65536"
-  with_items:
-    - { file: /etc/subgid }
-    - { file: /etc/subuid }
-
-- name: Force Podman to refresh user namespace mappings
-  become: true
-  command: podman system migrate
-  ignore_errors: true
-
 - name: Ensure that 'p11-kit server' is absent
   become: yes
   package:


### PR DESCRIPTION
The `useradd(8)` change in Fedora 42 onwards [1,2] that necessitated this
workaround has since been dropped [3].  The update was unpushed from
Fedora 42 and the change was reverted in Fedora 43 onwards [4].
Therefore, there's no need for this workaround.

This reverts commit a61b85cf8fb8aa476a6755518c1974e6ebcf019d.

[1] Fedora shadow-utils commit e1cfa31731cd68aa
    https://src.fedoraproject.org/rpms/shadow-utils/c/e1cfa31731cd68aa
    https://bugzilla.redhat.com/show_bug.cgi?id=2334168

[2] Fedora shadow-utils commit 4929903292e027ca
    https://src.fedoraproject.org/rpms/shadow-utils/c/4929903292e027ca
    https://bugzilla.redhat.com/show_bug.cgi?id=2334169

[3] https://bugzilla.redhat.com/show_bug.cgi?id=2382662

[4] Fedora shadow-utils commit b75f74d3f1b086fd
    https://src.fedoraproject.org/rpms/shadow-utils/c/b75f74d3f1b086fd